### PR TITLE
feat(components): add gs-date-range-changed event to date range selector

### DIFF
--- a/components/index.html
+++ b/components/index.html
@@ -44,6 +44,15 @@
                         });
                     });
                 });
+                document.querySelector('gs-date-range-selector').addEventListener('gs-date-range-changed', (event) => {
+                    const sequencesElements = document.querySelectorAll('gs-prevalence-over-time');
+                    sequencesElements.forEach((el) => {
+                        ['numerator', 'denominator'].forEach((attr) => {
+                            const old = JSON.parse(el.getAttribute(attr));
+                            el.setAttribute(attr, JSON.stringify({ ...old, ...event.detail }));
+                        });
+                    });
+                });
             });
         </script>
     </body>

--- a/components/src/components/dateRangeSelector/date-range-selector.stories.ts
+++ b/components/src/components/dateRangeSelector/date-range-selector.stories.ts
@@ -1,12 +1,20 @@
 import { html } from 'lit';
 import { Meta, StoryObj } from '@storybook/web-components';
 import './date-range-selector';
-import { expect, userEvent, within } from '@storybook/test';
+import { expect, fn, userEvent, within } from '@storybook/test';
+import { withActions } from '@storybook/addon-actions/decorator';
+import { toYYYYMMDD } from './date-range-selector';
 
 const meta: Meta = {
     title: 'Input/Date Range Selector',
     component: 'gs-date-range-selector',
-    parameters: { fetchMock: {} },
+    parameters: {
+        fetchMock: {},
+        actions: {
+            handles: ['gs-date-range-changed'],
+        },
+    },
+    decorators: [withActions],
 };
 
 export default meta;
@@ -39,17 +47,37 @@ export const DateRangeSelectorWithSelectedRange: StoryObj = {
     ...DateRangeSelectorStory,
     play: async ({ canvasElement, step }) => {
         const canvas = within(canvasElement);
-        const dateFrom = canvas.getByPlaceholderText('Date from');
-        const dateTo = canvas.getByPlaceholderText('Date to');
+        const dateFrom = () => canvas.getByPlaceholderText('Date from');
+        const dateTo = () => canvas.getByPlaceholderText('Date to');
+
+        const listenerMock = fn();
+        await step('Setup event listener mock', async () => {
+            canvasElement.addEventListener('gs-date-range-changed', listenerMock);
+        });
 
         const someDateInThePast = '2021-10-01';
         await step(`Set custom date from: ${someDateInThePast}`, async () => {
-            await userEvent.clear(dateFrom);
-            await userEvent.type(dateFrom, `${someDateInThePast}{enter}`);
+            await userEvent.clear(dateFrom());
+            await userEvent.type(dateFrom(), `${someDateInThePast}`);
 
-            await expect(dateFrom).toHaveValue(someDateInThePast);
-            // TODO(#80): Reenable this line when hitting enter works on the input.
-            // await expect(canvas.getByRole('combobox')).toHaveValue('custom');
+            await userEvent.click(dateTo());
+
+            await expect(dateFrom()).toHaveValue(someDateInThePast);
+            await expect(canvas.getByRole('combobox')).toHaveValue('custom');
+        });
+
+        await step('Expect correct event in thrown', async () => {
+            await expect(listenerMock).toHaveBeenCalled();
+
+            const firstCall = listenerMock.mock.calls[0][0];
+            const detail = firstCall.detail;
+
+            const dateFrom = detail.dateFrom;
+            await expect(dateFrom).toEqual(someDateInThePast);
+
+            const dateTo = detail.dateTo;
+            const expectedDateTo = new Date();
+            await expect(dateTo).toEqual(toYYYYMMDD(expectedDateTo));
         });
 
         await step('Select last 3 months', async () => {
@@ -63,8 +91,10 @@ export const DateRangeSelectorWithSelectedRange: StoryObj = {
             threeMonthAgo.setMonth(threeMonthAgo.getMonth() - 3);
             const threeMonthAgoString = threeMonthAgo.toISOString().split('T')[0];
 
-            await expect(dateFrom).toHaveValue(threeMonthAgoString);
-            await expect(dateTo).toHaveValue(todayString);
+            await expect(dateFrom()).toHaveValue(threeMonthAgoString);
+            await expect(dateTo()).toHaveValue(todayString);
+
+            await expect(listenerMock).toHaveBeenCalledTimes(2);
         });
     },
 };


### PR DESCRIPTION
Resolves #81, resolves #80

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This adds a event and a submit button to the date range selector. The event contains the dateFrom and dateTo of the selector.


### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![image](https://github.com/GenSpectrum/dashboards/assets/122305307/d3dbfae0-7b46-476e-bd0a-fa2741d2b5c6)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] The implemented feature is covered by an appropriate test.
