### PR TITLE
fix(components): move flaky date range test to playwright

### DIFF
--- a/components/src/preact/dateRangeSelector/date-range-selector.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.tsx
@@ -4,6 +4,7 @@ import 'flatpickr/dist/flatpickr.min.css';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { Select } from '../components/select';
 import type { ScaleType } from '../shared/charts/getYAxisScale';
+import { toYYYYMMDD } from './dateConversion';
 
 export type CustomSelectOption = { label: string; dateFrom: string; dateTo: string };
 
@@ -223,13 +224,4 @@ const getDatesForSelectorValue = (
         default:
             return { dateFrom: today, dateTo: today };
     }
-};
-
-export const toYYYYMMDD = (date?: Date) => {
-    if (!date) {
-        return undefined;
-    }
-
-    const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: '2-digit', day: '2-digit' };
-    return date.toLocaleDateString('en-CA', options);
 };

--- a/components/src/preact/dateRangeSelector/dateConversion.ts
+++ b/components/src/preact/dateRangeSelector/dateConversion.ts
@@ -1,0 +1,8 @@
+export const toYYYYMMDD = (date?: Date) => {
+    if (!date) {
+        return undefined;
+    }
+
+    const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: '2-digit', day: '2-digit' };
+    return date.toLocaleDateString('en-CA', options);
+};

--- a/components/src/web-components/input/date-range-selector-component.stories.ts
+++ b/components/src/web-components/input/date-range-selector-component.stories.ts
@@ -1,12 +1,12 @@
 import { LAPIS_URL } from '../../constants';
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { withActions } from '@storybook/addon-actions/decorator';
 import { html } from 'lit';
-import { DateRangeSelectorProps, toYYYYMMDD } from '../../preact/dateRangeSelector/date-range-selector';
+import { DateRangeSelectorProps } from '../../preact/dateRangeSelector/date-range-selector';
 import './date-range-selector-component';
 import '../app';
 import { withinShadowRoot } from '../withinShadowRoot.story';
-import { expect, fn, userEvent, waitFor } from '@storybook/test';
+import { expect, waitFor } from '@storybook/test';
+import { toYYYYMMDD } from '../../preact/dateRangeSelector/dateConversion';
 
 const meta: Meta<DateRangeSelectorProps> = {
     title: 'Input/DateRangeSelector',
@@ -17,7 +17,6 @@ const meta: Meta<DateRangeSelectorProps> = {
         },
         fetchMock: {},
     },
-    decorators: [withActions],
 };
 
 export default meta;
@@ -47,61 +46,5 @@ export const DateRangeSelectorStory: StoryObj<DateRangeSelectorProps> = {
     args: {
         customSelectOptions: [{ label: 'CustomDateRange', dateFrom: '2021-01-01', dateTo: '2021-12-31' }],
         earliestDate: '1970-01-01',
-    },
-};
-
-export const DateRangeSelectorWithSelectedRange: StoryObj<DateRangeSelectorProps> = {
-    ...DateRangeSelectorStory,
-    play: async ({ canvasElement, step }) => {
-        const canvas = await withinShadowRoot(canvasElement, 'gs-date-range-selector');
-        const dateFrom = canvas.getByPlaceholderText('Date from');
-        const dateTo = canvas.getByPlaceholderText('Date to');
-
-        const listenerMock = fn();
-        await step('Setup event listener mock', async () => {
-            canvasElement.addEventListener('gs-date-range-changed', listenerMock);
-        });
-
-        const someDateInThePast = '2021-10-01';
-        await step(`Set custom date from: ${someDateInThePast}`, async () => {
-            await userEvent.type(dateFrom, '{backspace>10/}');
-            await userEvent.type(dateFrom, `${someDateInThePast}`);
-            await userEvent.click(dateTo);
-            await waitFor(() => {
-                expect(dateFrom).toHaveValue(someDateInThePast);
-                expect(canvas.getByRole('combobox')).toHaveValue('custom');
-            });
-        });
-
-        await step('Expect correct event in thrown', async () => {
-            await expect(listenerMock).toHaveBeenCalled();
-
-            const firstCall = listenerMock.mock.calls[0][0];
-            const detail = firstCall.detail;
-
-            const dateFrom = detail.dateFrom;
-            await expect(dateFrom).toEqual(someDateInThePast);
-
-            const dateTo = detail.dateTo;
-            const expectedDateTo = new Date();
-            await expect(dateTo).toEqual(toYYYYMMDD(expectedDateTo));
-        });
-
-        await step('Select last 3 months', async () => {
-            await userEvent.selectOptions(canvas.getByRole('combobox'), 'last3Months');
-
-            await expect(canvas.getByRole('combobox')).toHaveValue('last3Months');
-
-            const today = new Date();
-            const todayString = today.toISOString().split('T')[0];
-            const threeMonthAgo = today;
-            threeMonthAgo.setMonth(threeMonthAgo.getMonth() - 3);
-            const threeMonthAgoString = threeMonthAgo.toISOString().split('T')[0];
-
-            await expect(dateFrom).toHaveValue(threeMonthAgoString);
-            await expect(dateTo).toHaveValue(todayString);
-
-            await expect(listenerMock).toHaveBeenCalledTimes(2);
-        });
     },
 };


### PR DESCRIPTION
### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The play function of storybook does not support pressing enter on the input form. This required to do for testing. Thus, we moved the test to playwright, where this is possible.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] The implemented feature is covered by an appropriate test.
