### PR TITLE
check/test date granularity

### DIFF
--- a/components/src/operator/FillMissingOperator.ts
+++ b/components/src/operator/FillMissingOperator.ts
@@ -1,16 +1,16 @@
 import { Operator } from './Operator';
 import { Dataset } from './Dataset';
 
-export class FillMissingOperator<S, K extends keyof S> implements Operator<S> {
+export class FillMissingOperator<Data, KeyToFill extends keyof Data> implements Operator<Data> {
     constructor(
-        private child: Operator<S>,
-        private keyField: K,
-        private getMinMaxFn: (values: Iterable<S[K]>) => [S[K], S[K]] | null,
-        private getAllRequiredKeysFn: (min: S[K], max: S[K]) => S[K][],
-        private defaultValueFn: (key: S[K]) => S,
+        private child: Operator<Data>,
+        private keyField: KeyToFill,
+        private getMinMaxFn: (values: Iterable<Data[KeyToFill]>) => [Data[KeyToFill], Data[KeyToFill]] | null,
+        private getAllRequiredKeysFn: (min: Data[KeyToFill], max: Data[KeyToFill]) => Data[KeyToFill][],
+        private defaultValueFn: (key: Data[KeyToFill]) => Data,
     ) {}
 
-    async evaluate(lapis: string, signal?: AbortSignal): Promise<Dataset<S>> {
+    async evaluate(lapis: string, signal?: AbortSignal): Promise<Dataset<Data>> {
         const childEvaluated = await this.child.evaluate(lapis, signal);
         const existingKeys = new Set(childEvaluated.content.map((row) => row[this.keyField]));
         const minMax = this.getMinMaxFn(existingKeys);

--- a/components/src/operator/GroupByAndSumOperator.ts
+++ b/components/src/operator/GroupByAndSumOperator.ts
@@ -2,17 +2,17 @@ import { GroupByOperator } from './GroupByOperator';
 import { Operator } from './Operator';
 import { NumberFields } from '../utils/type-utils';
 
-type Result<T, K extends keyof T, C extends keyof T> = {
-    [P in K | C]: P extends K ? T[K] : number;
+type Result<Data, KeyToGroupBy extends keyof Data, KeyToSumBy extends keyof Data> = {
+    [P in KeyToGroupBy | KeyToSumBy]: P extends KeyToGroupBy ? Data[KeyToGroupBy] : number;
 };
 
-export class GroupByAndSumOperator<T, K extends keyof T, C extends NumberFields<T>> extends GroupByOperator<
-    T,
-    Result<T, K, C>,
-    K
-> {
-    constructor(child: Operator<T>, groupByField: K, sumField: C) {
-        super(child, groupByField, (values: T[]) => {
+export class GroupByAndSumOperator<
+    Data,
+    KeyToGroupBy extends keyof Data,
+    KeySoSumBy extends NumberFields<Data>,
+> extends GroupByOperator<Data, Result<Data, KeyToGroupBy, KeySoSumBy>, KeyToGroupBy> {
+    constructor(child: Operator<Data>, groupByField: KeyToGroupBy, sumField: KeySoSumBy) {
+        super(child, groupByField, (values: Data[]) => {
             let n = 0;
             for (const value of values) {
                 n += value[sumField] as number;
@@ -20,7 +20,7 @@ export class GroupByAndSumOperator<T, K extends keyof T, C extends NumberFields<
             return {
                 [groupByField]: values[0][groupByField],
                 [sumField]: n,
-            } as Result<T, K, C>;
+            } as Result<Data, KeyToGroupBy, KeySoSumBy>;
         });
     }
 }

--- a/components/src/operator/SlidingOperator.spec.ts
+++ b/components/src/operator/SlidingOperator.spec.ts
@@ -3,31 +3,49 @@ import { SlidingOperator } from './SlidingOperator';
 import { expectEqualAfterSorting } from '../utils/test-utils';
 import { describe, it } from 'vitest';
 
+const mockOperator = new MockOperator([
+    { id: 1, value: 1 },
+    { id: 2, value: 2 },
+    { id: 3, value: 3 },
+    { id: 4, value: 4 },
+    { id: 5, value: 5 },
+]);
 describe('SlidingOperator', () => {
     it('should slide the values', async () => {
-        const child = new MockOperator([
-            { id: 1, value: 1 },
-            { id: 2, value: 2 },
-            { id: 3, value: 3 },
-            { id: 4, value: 4 },
-            { id: 5, value: 5 },
-        ]);
-        const query = new SlidingOperator(child, 3, (values) => {
-            let sum = 0;
-            for (const { value } of values) {
-                sum += value;
-            }
-            return { id: values[1].id, sum };
-        });
-        const result = await query.evaluate('lapis');
-        await expectEqualAfterSorting(
+        const underTest = getSlidingOperatorWithWindowSize(3);
+
+        const result = await underTest.evaluate('lapis');
+
+        expectEqualAfterSorting(
             result.content,
             [
                 { id: 2, sum: 6 },
                 { id: 3, sum: 9 },
                 { id: 4, sum: 12 },
             ],
-            (a, b) => a.id - b.id,
+            sortById,
         );
     });
+
+    it('should return single value when window size is greater than number of entries', async () => {
+        const underTest = getSlidingOperatorWithWindowSize(999);
+
+        const result = await underTest.evaluate('lapis');
+
+        expectEqualAfterSorting(result.content, [{ id: 2, sum: 15 }], sortById);
+    });
+
+    function getSlidingOperatorWithWindowSize(windowSize: number) {
+        return new SlidingOperator(mockOperator, windowSize, (values) => {
+            let sum = 0;
+            for (const { value } of values) {
+                sum += value;
+            }
+            return { id: values[1].id, sum };
+        });
+    }
+
+    function sortById(a: { id: number }, b: { id: number }) {
+        return a.id - b.id;
+    }
 });

--- a/components/src/operator/SlidingOperator.ts
+++ b/components/src/operator/SlidingOperator.ts
@@ -1,21 +1,21 @@
 import { Operator } from './Operator';
-import { Dataset } from './Dataset';
 
-export class SlidingOperator<T, S> implements Operator<S> {
+export class SlidingOperator<Data, AggregationResult> implements Operator<AggregationResult> {
     constructor(
-        private child: Operator<T>,
+        private child: Operator<Data>,
         private windowSize: number,
-        private aggregate: (values: T[]) => S,
+        private aggregate: (values: Data[]) => AggregationResult,
     ) {
         if (windowSize < 1) {
             throw new Error('Window size must be at least 1');
         }
     }
 
-    async evaluate(lapis: string, signal?: AbortSignal): Promise<Dataset<S>> {
+    async evaluate(lapis: string, signal?: AbortSignal) {
         const childEvaluated = await this.child.evaluate(lapis, signal);
-        const content = new Array<S>();
-        for (let i = 0; i < childEvaluated.content.length - this.windowSize + 1; i++) {
+        const content = new Array<AggregationResult>();
+        const numberOfWindows = Math.max(childEvaluated.content.length - this.windowSize, 0) + 1;
+        for (let i = 0; i < numberOfWindows; i++) {
             content.push(this.aggregate(childEvaluated.content.slice(i, i + this.windowSize)));
         }
         return { content };

--- a/components/src/query/queryPrevalenceOverTime.ts
+++ b/components/src/query/queryPrevalenceOverTime.ts
@@ -4,7 +4,6 @@ import { MapOperator } from '../operator/MapOperator';
 import { GroupByAndSumOperator } from '../operator/GroupByAndSumOperator';
 import { FillMissingOperator } from '../operator/FillMissingOperator';
 import { SortOperator } from '../operator/SortOperator';
-import { Operator } from '../operator/Operator';
 import { SlidingOperator } from '../operator/SlidingOperator';
 import { DivisionOperator } from '../operator/DivisionOperator';
 import { compareTemporal, generateAllInRange, getMinMaxTemporal, Temporal, TemporalCache } from '../utils/temporal';
@@ -66,11 +65,8 @@ function fetchAndPrepare(filter: LapisFilter, granularity: TemporalGranularity, 
         (key) => ({ dateRange: key, count: 0 }),
     );
     const sortData = new SortOperator(fillData, dateRangeCompare);
-    let smoothData: Operator<{ dateRange: Temporal | null; count: number }> = sortData;
-    if (smoothingWindow >= 1) {
-        smoothData = new SlidingOperator(sortData, smoothingWindow, averageSmoothing);
-    }
-    return smoothData;
+
+    return smoothingWindow >= 1 ? new SlidingOperator(sortData, smoothingWindow, averageSmoothing) : sortData;
 }
 
 function mapDateToGranularityRange(d: { date: string | null; count: number }, granularity: TemporalGranularity) {

--- a/components/src/utils/temporal.spec.ts
+++ b/components/src/utils/temporal.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
     generateAllDaysInRange,
     generateAllMonthsInRange,
@@ -7,13 +7,13 @@ import {
     Year,
     YearMonth,
     YearMonthDay,
+    YearWeek,
 } from './temporal';
 
-// TODO The tests don't work: error: "TypeError: dayjs is not a function"
+const cache = TemporalCache.getInstance();
 
 describe('generateAllDaysInRange', () => {
     it('should return all days in range', () => {
-        const cache = TemporalCache.getInstance();
         expect(
             generateAllDaysInRange(YearMonthDay.parse('2020-01-01', cache), YearMonthDay.parse('2020-01-04', cache)),
         ).deep.equal([
@@ -27,7 +27,6 @@ describe('generateAllDaysInRange', () => {
 
 describe('generateAllMonthsInRange', () => {
     it('should return all months in range', () => {
-        const cache = TemporalCache.getInstance();
         expect(
             generateAllMonthsInRange(YearMonth.parse('2020-01', cache), YearMonth.parse('2020-04', cache)),
         ).deep.equal([
@@ -41,12 +40,57 @@ describe('generateAllMonthsInRange', () => {
 
 describe('generateAllYearsInRange', () => {
     it('should return all years in range', () => {
-        const cache = TemporalCache.getInstance();
         expect(generateAllYearsInRange(Year.parse('2020-01', cache), Year.parse('2023', cache))).deep.equal([
             Year.parse('2020', cache),
             Year.parse('2021', cache),
             Year.parse('2022', cache),
             Year.parse('2023', cache),
         ]);
+    });
+});
+
+describe('YearMonthDay', () => {
+    it('should parse from string', () => {
+        const underTest = YearMonthDay.parse('2020-01-01', cache);
+
+        expect(underTest.yearNumber).equal(2020);
+        expect(underTest.monthNumber).equal(1);
+        expect(underTest.dayNumber).equal(1);
+        // seems to be a bug in dayjs: https://github.com/iamkun/dayjs/issues/2620
+        expect(underTest.week.text).equal('2019-01');
+        expect(underTest.text).equal('2020-01-01');
+    });
+});
+
+describe('YearWeek', () => {
+    it('should parse from string', () => {
+        const underTest = YearWeek.parse('2020-02', cache);
+
+        expect(underTest.isoYearNumber).equal(2020);
+        expect(underTest.isoWeekNumber).equal(2);
+        expect(underTest.firstDay.text).equal('2020-01-06');
+        expect(underTest.text).equal('2020-02');
+    });
+});
+
+describe('YearMonth', () => {
+    it('should parse from string', () => {
+        const underTest = YearMonth.parse('2020-01', cache);
+
+        expect(underTest.yearNumber).equal(2020);
+        expect(underTest.monthNumber).equal(1);
+        expect(underTest.text).equal('2020-01');
+        expect(underTest.firstDay.text).equal('2020-01-01');
+    });
+});
+
+describe('Year', () => {
+    it('should parse from string', () => {
+        const underTest = Year.parse('2020', cache);
+
+        expect(underTest.year).equal(2020);
+        expect(underTest.text).equal('2020');
+        expect(underTest.firstDay.text).equal('2020-01-01');
+        expect(underTest.firstMonth.text).equal('2020-01');
     });
 });


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #26

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The actual issue described in the ticket, that the month range doesn't go far enough seems to be due to the smoothing window. I didn't observe any issues with that when reducing the smoothing window.

What I did though: 
* I added a couple of tests
* I fixed a bug in the sliding operator
* better naming for generic types.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] The implemented feature is covered by an appropriate test.
