### PR TITLE
docs(components): annotate components that fire events

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -8,8 +8,12 @@
     "module": "dist/genspectrum-components.js",
     "types": "dist/genspectrum-components.d.ts",
     "exports": {
-        ".": "./dist/dashboard-components.js",
-        "./custom-elements.json": "./custom-elements.json",
+        ".": {
+            "import": "./dist/dashboard-components.js",
+            "require": "./dist/dashboard-components.js",
+            "types": "./dist/genspectrum-components.d.ts"
+        },
+        "./custom-elements.json": "./custom-,elements.json",
         "./package.json": "./package.json",
         "./style.css": "./dist/style.css"
     },

--- a/components/src/preact/dateRangeSelector/date-range-selector.stories.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.stories.tsx
@@ -1,3 +1,4 @@
+import { withActions } from '@storybook/addon-actions/decorator';
 import { type Meta, type StoryObj } from '@storybook/preact';
 
 import { DateRangeSelector, type DateRangeSelectorProps } from './date-range-selector';
@@ -8,12 +9,16 @@ const meta: Meta<DateRangeSelectorProps> = {
     title: 'Input/DateRangeSelector',
     component: DateRangeSelector,
     parameters: {
+        actions: {
+            handles: ['gs-date-range-changed'],
+        },
         fetchMock: {},
     },
     args: {
         customSelectOptions: [{ label: 'CustomDateRange', dateFrom: '2021-01-01', dateTo: '2021-12-31' }],
         earliestDate: '1970-01-01',
     },
+    decorators: [withActions],
 };
 
 export default meta;

--- a/components/src/preact/locationFilter/location-filter.stories.tsx
+++ b/components/src/preact/locationFilter/location-filter.stories.tsx
@@ -1,3 +1,4 @@
+import { withActions } from '@storybook/addon-actions/decorator';
 import { type Meta, type StoryObj } from '@storybook/preact';
 
 import data from './__mockData__/aggregated.json';
@@ -27,12 +28,13 @@ const meta: Meta<typeof LocationFilter> = {
             ],
         },
         actions: {
-            handles: ['gs-location-changed .div', 'mouseover'],
+            handles: ['gs-location-changed'],
         },
     },
     args: {
         fields: ['region', 'country', 'division', 'location'],
     },
+    decorators: [withActions],
 };
 
 export default meta;

--- a/components/src/preact/textInput/text-input.stories.tsx
+++ b/components/src/preact/textInput/text-input.stories.tsx
@@ -1,3 +1,4 @@
+import { withActions } from '@storybook/addon-actions/decorator';
 import { type Meta, type StoryObj } from '@storybook/preact';
 
 import data from './__mockData__/aggregated_hosts.json';
@@ -9,6 +10,9 @@ const meta: Meta<TextInputProps> = {
     title: 'Input/TextInput',
     component: TextInput,
     parameters: {
+        actions: {
+            handles: ['gs-text-input-changed'],
+        },
         fetchMock: {
             mocks: [
                 {
@@ -27,6 +31,7 @@ const meta: Meta<TextInputProps> = {
             ],
         },
     },
+    decorators: [withActions],
 };
 
 export default meta;

--- a/components/src/web-components/input/date-range-selector-component.stories.ts
+++ b/components/src/web-components/input/date-range-selector-component.stories.ts
@@ -1,3 +1,4 @@
+import { withActions } from '@storybook/addon-actions/decorator';
 import { expect, waitFor } from '@storybook/test';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
@@ -18,6 +19,7 @@ const meta: Meta<DateRangeSelectorProps> = {
         },
         fetchMock: {},
     },
+    decorators: [withActions],
 };
 
 export default meta;

--- a/components/src/web-components/input/date-range-selector-component.tsx
+++ b/components/src/web-components/input/date-range-selector-component.tsx
@@ -3,6 +3,9 @@ import { customElement, property } from 'lit/decorators.js';
 import { type CustomSelectOption, DateRangeSelector } from '../../preact/dateRangeSelector/date-range-selector';
 import { PreactLitAdapter } from '../PreactLitAdapter';
 
+/**
+ * @fires {CustomEvent<{ dateFrom: string; dateTo: string; }>} gs-date-range-changed - When the date range has changed
+ */
 @customElement('gs-date-range-selector')
 export class DateRangeSelectorComponent extends PreactLitAdapter {
     @property({ type: Array })
@@ -19,5 +22,12 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
 declare global {
     interface HTMLElementTagNameMap {
         'gs-date-range-selector': DateRangeSelectorComponent;
+    }
+
+    interface HTMLElementEventMap {
+        'gs-date-range-changed': CustomEvent<{
+            dateFrom: string;
+            dateTo: string;
+        }>;
     }
 }

--- a/components/src/web-components/input/location-filter-component.stories.ts
+++ b/components/src/web-components/input/location-filter-component.stories.ts
@@ -1,3 +1,4 @@
+import { withActions } from '@storybook/addon-actions/decorator';
 import { expect, fn, userEvent, waitFor } from '@storybook/test';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
@@ -16,6 +17,8 @@ const meta: Meta = {
             handles: ['gs-location-changed'],
         },
     },
+    decorators: [withActions],
+    tags: ['autodocs'],
 };
 
 export default meta;

--- a/components/src/web-components/input/location-filter-component.tsx
+++ b/components/src/web-components/input/location-filter-component.tsx
@@ -3,6 +3,9 @@ import { customElement, property } from 'lit/decorators.js';
 import { LocationFilter } from '../../preact/locationFilter/location-filter';
 import { PreactLitAdapter } from '../PreactLitAdapter';
 
+/**
+ * @fires {CustomEvent<Record<string, string>>} gs-location-changed - When the location has changed
+ */
 @customElement('gs-location-filter')
 export class LocationFilterComponent extends PreactLitAdapter {
     @property()
@@ -19,5 +22,9 @@ export class LocationFilterComponent extends PreactLitAdapter {
 declare global {
     interface HTMLElementTagNameMap {
         'gs-location-filter': LocationFilterComponent;
+    }
+
+    interface HTMLElementEventMap {
+        'gs-location-changed': CustomEvent<Record<string, string>>;
     }
 }

--- a/components/src/web-components/input/text-input-component.stories.ts
+++ b/components/src/web-components/input/text-input-component.stories.ts
@@ -1,3 +1,4 @@
+import { withActions } from '@storybook/addon-actions/decorator';
 import { expect, fn, userEvent, waitFor } from '@storybook/test';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
@@ -33,6 +34,7 @@ const meta: Meta = {
             ],
         },
     },
+    decorators: [withActions],
 };
 
 export default meta;

--- a/components/src/web-components/input/text-input-component.tsx
+++ b/components/src/web-components/input/text-input-component.tsx
@@ -3,6 +3,9 @@ import { customElement, property } from 'lit/decorators.js';
 import { TextInput } from '../../preact/textInput/text-input';
 import { PreactLitAdapter } from '../PreactLitAdapter';
 
+/**
+ * @fires {CustomEvent<Record<string, string>>} gs-text-input-changed - When the text input has changed
+ */
 @customElement('gs-text-input')
 export class TextInputComponent extends PreactLitAdapter {
     @property()
@@ -19,5 +22,9 @@ export class TextInputComponent extends PreactLitAdapter {
 declare global {
     interface HTMLElementTagNameMap {
         'gs-text-input': TextInputComponent;
+    }
+
+    interface HTMLElementEventMap {
+        'gs-text-input-changed': CustomEvent<Record<string, string>>;
     }
 }

--- a/examples/React/src/App.tsx
+++ b/examples/React/src/App.tsx
@@ -13,8 +13,11 @@ function App() {
     })
 
     useEffect(() => {
-        const handleLocationChange = (event: Event) => setLocation((event as CustomEvent).detail);
-        const handleDateRangeChange = (event: Event) => setDateRange((event as CustomEvent).detail);
+        const handleLocationChange = (event: CustomEvent) => setLocation(event.detail);
+        const handleDateRangeChange = (event: CustomEvent<{
+            dateFrom: string;
+            dateTo: string
+        }>) => setDateRange(event.detail);
 
         const locationFilter = document.querySelector('gs-location-filter');
         if (locationFilter) {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
related to #129

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Provide JSDoc annotations and `HTMLElementEventMap` entries for the events that our input elements fire.
(and fix Storybook such that the "Actions" tab shows the events again)

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/GenSpectrum/dashboards/assets/92720311/90ae58e8-964b-4659-a22d-72c6fbfab082)

With the help of the `HTMLElementEventMap`, typescript can infer the type of the event in the React app:
![grafik](https://github.com/GenSpectrum/dashboards/assets/92720311/02516dee-fd0a-485a-8123-72167efc3b0f)



### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] The implemented feature is covered by an appropriate test.~~
