### PR TITLE
refactor(components): remove mutation cache

### DIFF
--- a/components/src/operator/FetchSubstitutionsOrDeletionsOperator.ts
+++ b/components/src/operator/FetchSubstitutionsOrDeletionsOperator.ts
@@ -2,7 +2,7 @@ import { type Dataset } from './Dataset';
 import { type Operator } from './Operator';
 import { fetchSubstitutionsOrDeletions } from '../lapisApi/lapisApi';
 import { type LapisFilter, type SequenceType, type SubstitutionOrDeletionEntry } from '../types';
-import { MutationCache, Substitution } from '../utils/mutations';
+import { Deletion, Substitution } from '../utils/mutations';
 
 export class FetchSubstitutionsOrDeletionsOperator implements Operator<SubstitutionOrDeletionEntry> {
     constructor(
@@ -14,13 +14,24 @@ export class FetchSubstitutionsOrDeletionsOperator implements Operator<Substitut
     async evaluate(lapis: string, signal?: AbortSignal): Promise<Dataset<SubstitutionOrDeletionEntry>> {
         const mutations = await this.fetchMutations(lapis, signal);
 
-        const instance = MutationCache.getInstance();
-        const content: SubstitutionOrDeletionEntry[] = mutations.map(({ mutation, count, proportion }) => {
-            const parsed = instance.getSubstitutionOrDeletion(mutation);
-            return parsed instanceof Substitution
-                ? { type: 'substitution', mutation: parsed, count, proportion }
-                : { type: 'deletion', mutation: parsed, count, proportion };
-        });
+        const content: SubstitutionOrDeletionEntry[] = mutations.map(
+            ({ count, proportion, mutationFrom, mutationTo, position, sequenceName }) => {
+                if (mutationTo === '-') {
+                    return {
+                        type: 'deletion',
+                        mutation: new Deletion(sequenceName ?? undefined, mutationFrom, position),
+                        count,
+                        proportion,
+                    };
+                }
+                return {
+                    type: 'substitution',
+                    mutation: new Substitution(sequenceName ?? undefined, mutationFrom, mutationTo, position),
+                    count,
+                    proportion,
+                };
+            },
+        );
 
         return { content };
     }

--- a/components/src/preact/mutationComparison/__mockData__/nucleotideMutationsOtherVariant.json
+++ b/components/src/preact/mutationComparison/__mockData__/nucleotideMutationsOtherVariant.json
@@ -289,7 +289,7 @@
             "sequenceName": null,
             "mutationFrom": "G",
             "mutationTo": "-",
-            "position": 19
+            "position": 199
         }
     ]
 }

--- a/components/src/preact/mutationComparison/__mockData__/nucleotideMutationsSomeVariant.json
+++ b/components/src/preact/mutationComparison/__mockData__/nucleotideMutationsSomeVariant.json
@@ -298,7 +298,7 @@
             "sequenceName": null,
             "mutationFrom": "G",
             "mutationTo": "-",
-            "position": 19
+            "position": 199
         }
     ]
 }

--- a/components/src/preact/mutations/__mockData__/nucleotideMutations.json
+++ b/components/src/preact/mutations/__mockData__/nucleotideMutations.json
@@ -397,7 +397,7 @@
             "sequenceName": null,
             "mutationFrom": "A",
             "mutationTo": "-",
-            "position": 2202
+            "position": 22029
         },
         {
             "mutation": "G22030-",
@@ -406,7 +406,7 @@
             "sequenceName": null,
             "mutationFrom": "G",
             "mutationTo": "-",
-            "position": 2203
+            "position": 22030
         },
         {
             "mutation": "G160A",
@@ -424,7 +424,7 @@
             "sequenceName": null,
             "mutationFrom": "T",
             "mutationTo": "-",
-            "position": 2203
+            "position": 22031
         },
         {
             "mutation": "T22032-",
@@ -433,7 +433,7 @@
             "sequenceName": null,
             "mutationFrom": "T",
             "mutationTo": "-",
-            "position": 2203
+            "position": 22032
         },
         {
             "mutation": "T20372C",
@@ -451,7 +451,7 @@
             "sequenceName": null,
             "mutationFrom": "C",
             "mutationTo": "-",
-            "position": 2203
+            "position": 22033
         },
         {
             "mutation": "G11048T",
@@ -469,7 +469,7 @@
             "sequenceName": null,
             "mutationFrom": "A",
             "mutationTo": "-",
-            "position": 2203
+            "position": 22034
         },
         {
             "mutation": "T17033C",
@@ -487,7 +487,7 @@
             "sequenceName": null,
             "mutationFrom": "G",
             "mutationTo": "-",
-            "position": 2824
+            "position": 28248
         },
         {
             "mutation": "G21839T",
@@ -505,7 +505,7 @@
             "sequenceName": null,
             "mutationFrom": "A",
             "mutationTo": "-",
-            "position": 2824
+            "position": 28249
         },
         {
             "mutation": "T28250-",
@@ -514,7 +514,7 @@
             "sequenceName": null,
             "mutationFrom": "T",
             "mutationTo": "-",
-            "position": 2825
+            "position": 28250
         },
         {
             "mutation": "C27864A",
@@ -532,7 +532,7 @@
             "sequenceName": null,
             "mutationFrom": "T",
             "mutationTo": "-",
-            "position": 2825
+            "position": 28251
         },
         {
             "mutation": "T28252-",
@@ -541,7 +541,7 @@
             "sequenceName": null,
             "mutationFrom": "T",
             "mutationTo": "-",
-            "position": 2825
+            "position": 28252
         },
         {
             "mutation": "C28253-",
@@ -550,7 +550,7 @@
             "sequenceName": null,
             "mutationFrom": "C",
             "mutationTo": "-",
-            "position": 2825
+            "position": 28253
         },
         {
             "mutation": "A28271-",

--- a/components/src/utils/mutations.spec.ts
+++ b/components/src/utils/mutations.spec.ts
@@ -1,22 +1,22 @@
-import { expect, describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { Deletion, Insertion, MutationCache, Substitution } from './mutations';
+import { Deletion, Insertion, Substitution } from './mutations';
 
-describe('MutationCache.getMutation', () => {
-    const cache = MutationCache.getInstance();
-
-    it('should parse substitution', () => {
-        expect(cache.getMutation('A1T')).deep.equal(new Substitution(undefined, 'A', 'T', 1));
-        expect(cache.getMutation('seg1:A1T')).deep.equal(new Substitution('seg1', 'A', 'T', 1));
+describe('Substitution', () => {
+    it('should be parsed from string', () => {
+        expect(Substitution.parse('A1T')).deep.equal(new Substitution(undefined, 'A', 'T', 1));
+        expect(Substitution.parse('seg1:A1T')).deep.equal(new Substitution('seg1', 'A', 'T', 1));
     });
-
-    it('should parse deletion', () => {
-        expect(cache.getMutation('A1-')).deep.equal(new Deletion(undefined, 'A', 1));
-        expect(cache.getMutation('seg1:A1-')).deep.equal(new Deletion('seg1', 'A', 1));
+});
+describe('Deletion', () => {
+    it('should be parsed from string', () => {
+        expect(Deletion.parse('A1-')).deep.equal(new Deletion(undefined, 'A', 1));
+        expect(Deletion.parse('seg1:A1-')).deep.equal(new Deletion('seg1', 'A', 1));
     });
-
-    it('should parse insertion', () => {
-        expect(cache.getMutation('ins_1:A')).deep.equal(new Insertion(undefined, 1, 'A'));
-        expect(cache.getMutation('ins_seg1:1:A')).deep.equal(new Insertion('seg1', 1, 'A'));
+});
+describe('Insertion', () => {
+    it('should be parsed from string', () => {
+        expect(Insertion.parse('ins_1:A')).deep.equal(new Insertion(undefined, 1, 'A'));
+        expect(Insertion.parse('ins_seg1:1:A')).deep.equal(new Insertion('seg1', 1, 'A'));
     });
 });

--- a/components/src/utils/mutations.ts
+++ b/components/src/utils/mutations.ts
@@ -1,57 +1,5 @@
 import { type SequenceType } from '../types';
 
-export class MutationCache {
-    private substitutionCache = new Map<string, Substitution>();
-    private deletionCache = new Map<string, Deletion>();
-    private insertionCache = new Map<string, Insertion>();
-
-    private constructor() {}
-
-    getMutation(mutationStr: string) {
-        if (mutationStr.startsWith('ins_')) {
-            return this.getInsertion(mutationStr);
-        }
-        if (mutationStr.endsWith('-')) {
-            return this.getDeletion(mutationStr);
-        }
-        return this.getSubstitution(mutationStr);
-    }
-
-    getSubstitution(mutationStr: string) {
-        const key = mutationStr.toUpperCase();
-        if (!this.substitutionCache.has(key)) {
-            this.substitutionCache.set(key, Substitution.parse(mutationStr));
-        }
-        return this.substitutionCache.get(key)!;
-    }
-
-    getDeletion(mutationStr: string) {
-        const key = mutationStr.toUpperCase();
-        if (!this.deletionCache.has(key)) {
-            this.deletionCache.set(key, Deletion.parse(mutationStr));
-        }
-        return this.deletionCache.get(key)!;
-    }
-
-    getSubstitutionOrDeletion(mutationStr: string) {
-        return mutationStr.endsWith('-') ? this.getDeletion(mutationStr) : this.getSubstitution(mutationStr);
-    }
-
-    getInsertion(mutationStr: string): Insertion {
-        const key = mutationStr.toUpperCase();
-        if (!this.insertionCache.has(key)) {
-            this.insertionCache.set(key, Insertion.parse(mutationStr));
-        }
-        return this.insertionCache.get(key)!;
-    }
-
-    private static instance = new MutationCache();
-
-    static getInstance(): MutationCache {
-        return this.instance;
-    }
-}
-
 export interface Mutation {
     readonly segment: string | undefined;
     readonly position: number;
@@ -125,9 +73,9 @@ export class Insertion implements Mutation {
     constructor(
         readonly segment: string | undefined,
         readonly position: number,
-        readonly value: string,
+        readonly insertedSymbols: string,
     ) {
-        this.code = `ins_${this.segment ? `${this.segment}:` : ''}${this.position}:${this.value}`;
+        this.code = `ins_${this.segment ? `${this.segment}:` : ''}${this.position}:${this.insertedSymbols}`;
     }
 
     toString() {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #123

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Removes the mutation cache and uses the parsed mutations directly from LAPIS.

Also fixes wrongly assigned position to mock data.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] The implemented feature is covered by an appropriate test.
