### PR TITLE
feat(components): indicate error on wrong mutation filter input #156

### DIFF
--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -29,6 +29,7 @@ export const MutationFilter: FunctionComponent<MutationFilterProps> = () => {
         aminoAcidInsertions: [],
     });
     const [inputValue, setInputValue] = useState('');
+    const [isError, setIsError] = useState(false);
     const formRef = useRef<HTMLFormElement>(null);
 
     const handleSubmit = (event: Event) => {
@@ -37,6 +38,7 @@ export const MutationFilter: FunctionComponent<MutationFilterProps> = () => {
         const parsedMutation = parseAndValidateMutation(inputValue, referenceGenome);
 
         if (parsedMutation === null) {
+            setIsError(true);
             return;
         }
 
@@ -76,6 +78,7 @@ export const MutationFilter: FunctionComponent<MutationFilterProps> = () => {
 
     const handleInputChange = (event: Event) => {
         setInputValue((event.target as HTMLInputElement).value);
+        setIsError(false);
     };
 
     return (
@@ -87,7 +90,7 @@ export const MutationFilter: FunctionComponent<MutationFilterProps> = () => {
             />
 
             <form className='mt-2 w-full' onSubmit={handleSubmit} ref={formRef}>
-                <label className='input input-bordered flex items-center gap-2'>
+                <label className={`input flex items-center gap-2 ${isError ? 'input-error' : 'input-bordered'}`}>
                     <input
                         className='grow min-w-0'
                         type='text'


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #156

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Adds an error boundary on the mutation filter input, when the user enters an invalid mutation and hits enter. The indicator vanishes on typing.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/9355553c-4df2-4307-b078-7b0d56990bd2)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
