### PR TITLE
build(components): fix workflow steps after release created

### DIFF
--- a/.github/workflows/release-components.yml
+++ b/.github/workflows/release-components.yml
@@ -22,23 +22,23 @@ jobs:
           target-branch: main
 
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.components--release_created }}
 
       - uses: actions/cache@v4
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.components--release_created }}
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('components/**/package-lock.json') }}
 
       - name: Build
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.components--release_created }}
         run:
           npm ci
           npm run build
         working-directory: components
 
       - name: Publish
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.components--release_created }}
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Apparently, `release_created` is only set when creating a release for the root of the repo. Instead, it seems that we can use `components--release_created`.
https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#path-outputs

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
