### PR TITLE
refactor(components): use mutations directly in table instead of string representation 

### DIFF
--- a/components/src/preact/components/csv-download-button.tsx
+++ b/components/src/preact/components/csv-download-button.tsx
@@ -1,9 +1,15 @@
 import { type FunctionComponent } from 'preact';
 
+type ToStringable = {
+    toString: () => string;
+};
+
+type DataValue = string | number | boolean | null | ToStringable;
+
 export interface CsvDownloadButtonProps {
     label?: string;
     filename?: string;
-    getData: () => Record<string, string | number | boolean | null>[];
+    getData: () => Record<string, DataValue>[];
     className?: string;
 }
 
@@ -32,7 +38,7 @@ export const CsvDownloadButton: FunctionComponent<CsvDownloadButtonProps> = ({
         return header + rows;
     };
 
-    const getDataKeys = (data: Record<string, string | number | boolean | null>[]) => {
+    const getDataKeys = (data: Record<string, DataValue>[]) => {
         const keysSet = data
             .map((row) => Object.keys(row))
             .reduce((accumulatedKeys, keys) => {

--- a/components/src/preact/mutationComparison/getMutationComparisonTableData.spec.ts
+++ b/components/src/preact/mutationComparison/getMutationComparisonTableData.spec.ts
@@ -51,12 +51,12 @@ describe('getPrevalenceOverTimeTableData', () => {
 
         expect(result).toEqual([
             {
-                mutation: 'A123T',
+                mutation: new Substitution(undefined, 'A', 'T', 123),
                 'Test 1 prevalence': 0.123,
                 'Test 2 prevalence': 0.345,
             },
             {
-                mutation: 'G234A',
+                mutation: new Substitution(undefined, 'G', 'A', 234),
                 'Test 1 prevalence': 0.567,
                 'Test 2 prevalence': 0.789,
             },
@@ -106,17 +106,17 @@ describe('getPrevalenceOverTimeTableData', () => {
 
         expect(result).toEqual([
             {
-                mutation: 'A200T',
+                mutation: new Substitution(undefined, 'A', 'T', 200),
                 'Test 1 prevalence': inRange,
                 'Test 2 prevalence': belowRange,
             },
             {
-                mutation: 'A300T',
+                mutation: new Substitution(undefined, 'A', 'T', 300),
                 'Test 1 prevalence': inRange,
                 'Test 2 prevalence': inRange,
             },
             {
-                mutation: 'A400T',
+                mutation: new Substitution(undefined, 'A', 'T', 400),
                 'Test 1 prevalence': inRange,
                 'Test 2 prevalence': aboveRange,
             },

--- a/components/src/preact/mutationComparison/mutation-comparison-table.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison-table.tsx
@@ -3,6 +3,7 @@ import { type FunctionComponent } from 'preact';
 import { getMutationComparisonTableData } from './getMutationComparisonTableData';
 import { type MutationData } from './queryMutationData';
 import { type Dataset } from '../../operator/Dataset';
+import { type Deletion, type Substitution } from '../../utils/mutations';
 import { type ProportionInterval } from '../components/proportion-selector';
 import { Table } from '../components/table';
 import { sortSubstitutionsAndDeletions } from '../shared/sort/sortSubstitutionsAndDeletions';
@@ -14,30 +15,27 @@ export interface MutationsTableProps {
 }
 
 export const MutationComparisonTable: FunctionComponent<MutationsTableProps> = ({ data, proportionInterval }) => {
-    const getHeaders = () => {
-        return [
-            {
-                name: 'Mutation',
-                sort: {
-                    compare: (a: string, b: string) => {
-                        return sortSubstitutionsAndDeletions(a, b);
-                    },
-                },
+    const headers = [
+        {
+            name: 'Mutation',
+            sort: {
+                compare: sortSubstitutionsAndDeletions,
             },
-            {
-                name: 'Prevalence',
-                columns: data.content.map((mutationData) => {
-                    return {
-                        name: mutationData.displayName,
-                        sort: true,
-                        formatter: (cell: number) => formatProportion(cell),
-                    };
-                }),
-            },
-        ];
-    };
+            formatter: (cell: Substitution | Deletion) => cell.toString(),
+        },
+        {
+            name: 'Prevalence',
+            columns: data.content.map((mutationData) => {
+                return {
+                    name: mutationData.displayName,
+                    sort: true,
+                    formatter: (cell: number) => formatProportion(cell),
+                };
+            }),
+        },
+    ];
 
     const tableData = getMutationComparisonTableData(data, proportionInterval).map((row) => Object.values(row));
 
-    return <Table data={tableData} columns={getHeaders()} pagination={true} />;
+    return <Table data={tableData} columns={headers} pagination={true} />;
 };

--- a/components/src/preact/mutations/getInsertionsTableData.spec.ts
+++ b/components/src/preact/mutations/getInsertionsTableData.spec.ts
@@ -5,16 +5,18 @@ import { Insertion } from '../../utils/mutations';
 
 describe('getInsertionsTableData', () => {
     test('should return the correct data', () => {
+        const insertion1 = new Insertion('segment1', 123, 'T');
+        const insertion2 = new Insertion('segment2', 234, 'AAA');
         const data = [
             {
                 type: 'insertion' as const,
-                mutation: new Insertion('segment1', 123, 'T'),
+                mutation: insertion1,
                 count: 1,
                 proportion: 0.1,
             },
             {
                 type: 'insertion' as const,
-                mutation: new Insertion('segment2', 234, 'AAA'),
+                mutation: insertion2,
                 count: 2,
                 proportion: 0.2,
             },
@@ -24,11 +26,11 @@ describe('getInsertionsTableData', () => {
 
         expect(result).toEqual([
             {
-                insertion: 'ins_segment1:123:T',
+                insertion: insertion1,
                 count: 1,
             },
             {
-                insertion: 'ins_segment2:234:AAA',
+                insertion: insertion2,
                 count: 2,
             },
         ]);

--- a/components/src/preact/mutations/getInsertionsTableData.ts
+++ b/components/src/preact/mutations/getInsertionsTableData.ts
@@ -3,7 +3,7 @@ import { type InsertionEntry } from '../../types';
 export function getInsertionsTableData(data: InsertionEntry[]) {
     return data.map((mutationEntry) => {
         return {
-            insertion: mutationEntry.mutation.toString(),
+            insertion: mutationEntry.mutation,
             count: mutationEntry.count,
         };
     });

--- a/components/src/preact/mutations/getMutationsTableData.spec.ts
+++ b/components/src/preact/mutations/getMutationsTableData.spec.ts
@@ -4,7 +4,7 @@ import { getMutationsTableData } from './getMutationsTableData';
 import { Deletion, Substitution } from '../../utils/mutations';
 
 describe('getMutationsTableData', () => {
-    test('should return the correct data', () => {
+    test('should not filter anything, when proportions are in interval', () => {
         const data = [
             {
                 type: 'substitution' as const,
@@ -24,20 +24,7 @@ describe('getMutationsTableData', () => {
 
         const result = getMutationsTableData(data, proportionInterval);
 
-        expect(result).toEqual([
-            {
-                mutation: 'segment1:A123T',
-                type: 'substitution',
-                count: 1,
-                proportion: 0.1,
-            },
-            {
-                mutation: 'segment2:C123-',
-                type: 'deletion',
-                count: 2,
-                proportion: 0.2,
-            },
-        ]);
+        expect(result).toEqual(data);
     });
 
     test('should filter out data below/above proportionInterval', () => {
@@ -45,10 +32,13 @@ describe('getMutationsTableData', () => {
         const aboveInterval = 0.95;
         const inInterval = 0.5;
 
+        const substitutionInInterval = new Substitution('segment1', 'A', 'T', 123);
+        const deletionInInterval = new Deletion('segment2', 'C', 123);
+
         const data = [
             {
                 type: 'substitution' as const,
-                mutation: new Substitution('segment1', 'A', 'T', 123),
+                mutation: substitutionInInterval,
                 count: 1,
                 proportion: inInterval,
             },
@@ -60,7 +50,7 @@ describe('getMutationsTableData', () => {
             },
             {
                 type: 'deletion' as const,
-                mutation: new Deletion('segment2', 'C', 123),
+                mutation: deletionInInterval,
                 count: 2,
                 proportion: inInterval,
             },
@@ -78,13 +68,13 @@ describe('getMutationsTableData', () => {
 
         expect(result).toEqual([
             {
-                mutation: 'segment1:A123T',
+                mutation: substitutionInInterval,
                 type: 'substitution',
                 count: 1,
                 proportion: inInterval,
             },
             {
-                mutation: 'segment2:C123-',
+                mutation: deletionInInterval,
                 type: 'deletion',
                 count: 2,
                 proportion: inInterval,

--- a/components/src/preact/mutations/getMutationsTableData.ts
+++ b/components/src/preact/mutations/getMutationsTableData.ts
@@ -8,7 +8,7 @@ export function getMutationsTableData(data: SubstitutionOrDeletionEntry[], propo
 
     return data.filter(byProportion).map((mutationEntry) => {
         return {
-            mutation: mutationEntry.mutation.toString(),
+            mutation: mutationEntry.mutation,
             type: mutationEntry.type,
             count: mutationEntry.count,
             proportion: mutationEntry.proportion,

--- a/components/src/preact/mutations/mutations-insertions-table.tsx
+++ b/components/src/preact/mutations/mutations-insertions-table.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent } from 'preact';
 
 import { getInsertionsTableData } from './getInsertionsTableData';
 import { type InsertionEntry } from '../../types';
+import { type Insertion } from '../../utils/mutations';
 import { Table } from '../components/table';
 import { sortInsertions } from '../shared/sort/sortInsertions';
 
@@ -15,10 +16,11 @@ export const InsertionsTable: FunctionComponent<InsertionsTableProps> = ({ data 
             {
                 name: 'Insertion',
                 sort: {
-                    compare: (a: string, b: string) => {
+                    compare: (a: Insertion, b: Insertion) => {
                         return sortInsertions(a, b);
                     },
                 },
+                formatter: (cell: Insertion) => cell.toString(),
             },
             {
                 name: 'Count',

--- a/components/src/preact/mutations/mutations-table.tsx
+++ b/components/src/preact/mutations/mutations-table.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent } from 'preact';
 
 import { getMutationsTableData } from './getMutationsTableData';
 import { type SubstitutionOrDeletionEntry } from '../../types';
+import { type Deletion, type Substitution } from '../../utils/mutations';
 import type { ProportionInterval } from '../components/proportion-selector';
 import { Table } from '../components/table';
 import { sortSubstitutionsAndDeletions } from '../shared/sort/sortSubstitutionsAndDeletions';
@@ -18,10 +19,11 @@ const MutationsTable: FunctionComponent<MutationsTableProps> = ({ data, proporti
             {
                 name: 'Mutation',
                 sort: {
-                    compare: (a: string, b: string) => {
+                    compare: (a: Substitution | Deletion, b: Substitution | Deletion) => {
                         return sortSubstitutionsAndDeletions(a, b);
                     },
                 },
+                formatter: (cell: Substitution | Deletion) => cell.toString(),
             },
             {
                 name: 'Type',

--- a/components/src/preact/mutations/mutations.tsx
+++ b/components/src/preact/mutations/mutations.tsx
@@ -182,7 +182,14 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
             {activeTab === 'Insertions' && (
                 <CsvDownloadButton
                     className='mx-1 btn btn-xs'
-                    getData={() => getInsertionsTableData(filteredData.insertions)}
+                    getData={() =>
+                        getInsertionsTableData(filteredData.insertions).map((row) => {
+                            return {
+                                insertion: row.insertion.toString(),
+                                count: row.count,
+                            };
+                        })
+                    }
                     filename='insertions.csv'
                 />
             )}

--- a/components/src/preact/shared/sort/sortInsertions.spec.ts
+++ b/components/src/preact/shared/sort/sortInsertions.spec.ts
@@ -1,19 +1,20 @@
 import { describe, expect, test } from 'vitest';
 
 import { sortInsertions } from './sortInsertions';
+import { Insertion } from '../../../utils/mutations';
 
 describe('sortInsertions with no segments', () => {
     test('should sort for positions first', () => {
-        const a = 'ins_1:A';
-        const b = 'ins_2:A';
+        const a = new Insertion(undefined, 1, 'A');
+        const b = new Insertion(undefined, 2, 'A');
 
         expect(sortInsertions(a, b)).toBeLessThan(0);
         expect(sortInsertions(b, a)).toBeGreaterThan(0);
     });
 
     test('should sort for symbols second', () => {
-        const a = 'ins_1:A';
-        const b = 'ins_1:B';
+        const a = new Insertion(undefined, 1, 'A');
+        const b = new Insertion(undefined, 1, 'B');
 
         expect(sortInsertions(a, b)).toBeLessThan(0);
         expect(sortInsertions(b, a)).toBeGreaterThan(0);
@@ -22,24 +23,24 @@ describe('sortInsertions with no segments', () => {
 
 describe('sortInsertions with segments', () => {
     test('should sort for segments first', () => {
-        const a = 'ins_AA1:1:A';
-        const b = 'ins_BB2:1:A';
+        const a = new Insertion('AA1', 1, 'A');
+        const b = new Insertion('BB1', 1, 'A');
 
         expect(sortInsertions(a, b)).toBeLessThan(0);
         expect(sortInsertions(b, a)).toBeGreaterThan(0);
     });
 
     test('should sort for positions second', () => {
-        const a = 'ins_AA1:1:A';
-        const b = 'ins_AA1:2:A';
+        const a = new Insertion('AA1', 1, 'A');
+        const b = new Insertion('AA1', 2, 'A');
 
         expect(sortInsertions(a, b)).toBeLessThan(0);
         expect(sortInsertions(b, a)).toBeGreaterThan(0);
     });
 
     test('should sort for symbols third', () => {
-        const a = 'ins_AA1:1:A';
-        const b = 'ins_AA1:1:B';
+        const a = new Insertion('AA1', 1, 'A');
+        const b = new Insertion('AA1', 1, 'B');
 
         expect(sortInsertions(a, b)).toBeLessThan(0);
         expect(sortInsertions(b, a)).toBeGreaterThan(0);

--- a/components/src/preact/shared/sort/sortInsertions.ts
+++ b/components/src/preact/shared/sort/sortInsertions.ts
@@ -1,21 +1,14 @@
-import { Insertion } from '../../../utils/mutations';
+import { comparePositions, compareSegments } from './sortSubstitutionsAndDeletions';
+import { type Insertion } from '../../../utils/mutations';
 
-export const sortInsertions = (a: string, b: string) => {
-    const insertionA = Insertion.parse(a);
-    const insertionB = Insertion.parse(b);
-
-    if (insertionA && insertionB) {
-        const segmentA = insertionA.segment;
-        const segmentB = insertionB.segment;
-        if (segmentA !== undefined && segmentB !== undefined && segmentA !== segmentB) {
-            return segmentA.localeCompare(segmentB);
-        }
-        const positionA = insertionA.position;
-        const positionB = insertionB.position;
-        if (positionA !== positionB) {
-            return positionA - positionB;
-        }
-        return insertionA.insertedSymbols.localeCompare(insertionB.insertedSymbols);
+export const sortInsertions = (a: Insertion, b: Insertion) => {
+    if (a.segment !== b.segment) {
+        return compareSegments(a.segment, b.segment);
     }
-    throw new Error(`Invalid insertion: ${a} or ${b}`);
+
+    if (a.position !== b.position) {
+        return comparePositions(a.position, b.position);
+    }
+
+    return a.insertedSymbols.localeCompare(b.insertedSymbols);
 };

--- a/components/src/preact/shared/sort/sortSubstitutionsAndDeletions.spec.ts
+++ b/components/src/preact/shared/sort/sortSubstitutionsAndDeletions.spec.ts
@@ -1,19 +1,28 @@
 import { describe, expect, test } from 'vitest';
 
 import { sortSubstitutionsAndDeletions } from './sortSubstitutionsAndDeletions';
+import { Deletion, Substitution } from '../../../utils/mutations';
 
 describe('sortSubstitutionsAndDeletions with no segments', () => {
     test('should sort for positions first', () => {
-        const a = 'A123B';
-        const b = 'A234B';
+        const a = new Substitution(undefined, 'A', 'B', 123);
+        const b = new Substitution(undefined, 'A', 'B', 234);
 
         expect(sortSubstitutionsAndDeletions(a, b)).toBeLessThan(0);
         expect(sortSubstitutionsAndDeletions(b, a)).toBeGreaterThan(0);
     });
 
     test('should sort for substitutionValue second', () => {
-        const a = 'A123A';
-        const b = 'A123B';
+        const a = new Substitution(undefined, 'A', 'A', 123);
+        const b = new Substitution(undefined, 'A', 'B', 123);
+
+        expect(sortSubstitutionsAndDeletions(a, b)).toBeLessThan(0);
+        expect(sortSubstitutionsAndDeletions(b, a)).toBeGreaterThan(0);
+    });
+
+    test('should sort for substitutionValue over deletion', () => {
+        const a = new Substitution(undefined, 'A', 'A', 123);
+        const b = new Deletion(undefined, 'A', 123);
 
         expect(sortSubstitutionsAndDeletions(a, b)).toBeLessThan(0);
         expect(sortSubstitutionsAndDeletions(b, a)).toBeGreaterThan(0);
@@ -22,24 +31,24 @@ describe('sortSubstitutionsAndDeletions with no segments', () => {
 
 describe('sortSubstitutionsAndDeletions with segments', () => {
     test('should sort for segment first', () => {
-        const a = 'AA1:A123B';
-        const b = 'BB1:A234B';
+        const a = new Substitution('AA1', 'A', 'B', 123);
+        const b = new Substitution('BB1', 'A', 'B', 234);
 
         expect(sortSubstitutionsAndDeletions(a, b)).toBeLessThan(0);
         expect(sortSubstitutionsAndDeletions(b, a)).toBeGreaterThan(0);
     });
 
     test('should sort for position second', () => {
-        const a = 'AA1:A123B';
-        const b = 'AA1:A234B';
+        const a = new Substitution('AA1', 'A', 'B', 123);
+        const b = new Substitution('AA1', 'A', 'B', 234);
 
         expect(sortSubstitutionsAndDeletions(a, b)).toBeLessThan(0);
         expect(sortSubstitutionsAndDeletions(b, a)).toBeGreaterThan(0);
     });
 
     test('should sort for substitutionValue third', () => {
-        const a = 'AA1:A123A';
-        const b = 'AA1:A123B';
+        const a = new Substitution('AA1', 'A', 'A', 123);
+        const b = new Substitution('AA1', 'A', 'B', 123);
 
         expect(sortSubstitutionsAndDeletions(a, b)).toBeLessThan(0);
         expect(sortSubstitutionsAndDeletions(b, a)).toBeGreaterThan(0);

--- a/components/src/preact/shared/sort/sortSubstitutionsAndDeletions.ts
+++ b/components/src/preact/shared/sort/sortSubstitutionsAndDeletions.ts
@@ -1,17 +1,50 @@
-export const substitutionAndDeletionRegex = /(?:([A-Za-z0-9]+):)?([A-Za-z])(\d+)([A-Za-z]|-|\*)/;
+import { Deletion, type Substitution } from '../../../utils/mutations';
 
-export const sortSubstitutionsAndDeletions = (a: string, b: string) => {
-    const aMatch = a.match(substitutionAndDeletionRegex);
-    const bMatch = b.match(substitutionAndDeletionRegex);
-
-    if (aMatch && bMatch) {
-        if (aMatch[1] !== bMatch[1]) {
-            return aMatch[1].localeCompare(bMatch[1]);
-        }
-        if (aMatch[3] !== bMatch[3]) {
-            return parseInt(aMatch[3], 10) - parseInt(bMatch[3], 10);
-        }
-        return aMatch[4].localeCompare(bMatch[4]);
+export const sortSubstitutionsAndDeletions = (a: Substitution | Deletion, b: Substitution | Deletion) => {
+    if (a.segment !== b.segment) {
+        compareSegments(a.segment, b.segment);
     }
-    throw new Error(`Invalid substitution or deletion: ${a} or ${b}`);
+
+    if (a.position !== b.position) {
+        return comparePositions(a.position, b.position);
+    }
+
+    const aIsDeletion = a instanceof Deletion;
+    const bIsDeletion = b instanceof Deletion;
+
+    if (aIsDeletion !== bIsDeletion) {
+        return aIsDeletion ? 1 : -1;
+    }
+
+    if (!aIsDeletion && !bIsDeletion) {
+        if (a.substitutionValue !== b.substitutionValue) {
+            return compareSubstitutionValues(a.substitutionValue, b.substitutionValue);
+        }
+    }
+
+    return 0;
+};
+
+export const compareSegments = (a: string | undefined, b: string | undefined) => {
+    if (a === undefined) {
+        return -1;
+    }
+    if (b === undefined) {
+        return 1;
+    }
+    return a.localeCompare(b);
+};
+
+export const comparePositions = (a: number, b: number) => {
+    return a - b;
+};
+
+const compareSubstitutionValues = (a: string | undefined, b: string | undefined) => {
+    if (a === undefined) {
+        return -1;
+    }
+    if (b === undefined) {
+        return 1;
+    }
+    return a.localeCompare(b);
 };


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #153

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Refactors the table for the mutations and mutation comparison, so that is uses the mutation type directly instead of its string representation.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
