### PR TITLE
feat: info button opens a scrollable info panel

### DIFF
--- a/components/src/preact/aggregatedData/aggregate.tsx
+++ b/components/src/preact/aggregatedData/aggregate.tsx
@@ -96,7 +96,7 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({ data }) => {
     return (
         <div class='flex flex-row'>
             <CsvDownloadButton className='mx-1 btn btn-xs' getData={() => data} filename='aggregate.csv' />
-            <Info className='mx-1' content='Info for aggregate' />
+            <Info>Info for aggregate</Info>
         </div>
     );
 };

--- a/components/src/preact/components/info.stories.tsx
+++ b/components/src/preact/components/info.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
+import { expect, fireEvent, waitFor, within } from '@storybook/test';
 
 import Info, { type InfoProps } from './info';
 
@@ -7,16 +8,36 @@ const meta: Meta<InfoProps> = {
     component: Info,
     parameters: { fetchMock: {} },
     args: {
-        content: 'This is a tooltip which shows some information.',
+        size: { width: '400px', height: '100px' },
     },
 };
 
 export default meta;
 
+const tooltipText = 'This is a tooltip which shows some information.';
+
 export const InfoStory: StoryObj<InfoProps> = {
     render: (args) => (
-        <div class='flex justify-center px-4 py-16 bg-base-200'>
-            <Info {...args} />
+        <div class='flex justify-center px-4 py-16'>
+            <Info {...args}>{tooltipText}</Info>
         </div>
     ),
+};
+
+export const ShowsInfoOnClick: StoryObj<InfoProps> = {
+    ...InfoStory,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const loading = canvas.getByRole('button', { name: '?' });
+
+        await waitFor(() => expect(loading).toBeInTheDocument());
+
+        await fireEvent.click(loading);
+
+        await waitFor(() => expect(canvas.getByText(tooltipText, { exact: false })).toBeInTheDocument());
+
+        await fireEvent.click(canvas.getByRole('button', { name: 'Close' }));
+
+        await waitFor(() => expect(canvas.queryByText(tooltipText, { exact: false })).not.toBeInTheDocument());
+    },
 };

--- a/components/src/preact/components/info.tsx
+++ b/components/src/preact/components/info.tsx
@@ -1,15 +1,59 @@
 import { type FunctionComponent } from 'preact';
+import { useState } from 'preact/hooks';
 
 export interface InfoProps {
-    content: string;
-    className?: string;
+    size?: {
+        height?: string;
+        width?: string;
+    };
 }
 
-const Info: FunctionComponent<InfoProps> = ({ content, className }) => {
+const Info: FunctionComponent<InfoProps> = ({ children, size }) => {
+    const [showHelp, setShowHelp] = useState(false);
+
+    const toggleHelp = () => {
+        setShowHelp(!showHelp);
+    };
+
     return (
-        <div class={`${className} tooltip`} data-tip={content}>
-            <button class='btn btn-xs'>?</button>
+        <div className='relative'>
+            <button className='btn btn-xs' onClick={toggleHelp}>
+                ?
+            </button>
+            {showHelp && (
+                <div
+                    className='absolute top-8 right-6 bg-white p-2 border border-black flex flex-col overflow-auto shadow-lg rounded z-50'
+                    style={size}
+                >
+                    <div className='flex flex-col'>{children}</div>
+                    <div className='flex justify-end'>
+                        <button className='text-sm underline mt-2' onClick={toggleHelp}>
+                            Close
+                        </button>
+                    </div>
+                </div>
+            )}
         </div>
+    );
+};
+
+export const InfoHeadline1: FunctionComponent = ({ children }) => {
+    return <h1 className='text-lg font-bold'>{children}</h1>;
+};
+
+export const InfoHeadline2: FunctionComponent = ({ children }) => {
+    return <h2 className='text-base font-bold mt-4'>{children}</h2>;
+};
+
+export const InfoParagraph: FunctionComponent = ({ children }) => {
+    return <p className='text-justify my-1'>{children}</p>;
+};
+
+export const InfoLink: FunctionComponent<{ href: string }> = ({ children, href }) => {
+    return (
+        <a className='text-blue-600 hover:text-blue-800' href={href} target='_blank' rel='noopener noreferrer'>
+            {children}
+        </a>
     );
 };
 

--- a/components/src/preact/mutationComparison/mutation-comparison.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.tsx
@@ -182,7 +182,7 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
                 getData={() => getMutationComparisonTableData({ content: filteredData }, proportionInterval)}
                 filename='mutation_comparison.csv'
             />
-            <Info className='mx-1' content='Info for mutation comparison' />
+            <Info>Info for mutation comparison</Info>
         </div>
     );
 };

--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -90,7 +90,7 @@ export const MutationFilter: FunctionComponent<MutationFilterProps> = ({ initial
                     setSelectedFilters={setSelectedFilters}
                     fireChangeEvent={fireChangeEvent}
                 />
-                <Info className='mx-1' content='Info for mutation filter' />
+                <Info>Info for mutation filter</Info>
             </div>
 
             <form className='mt-2 w-full' onSubmit={handleSubmit} ref={formRef}>

--- a/components/src/preact/mutations/mutations.tsx
+++ b/components/src/preact/mutations/mutations.tsx
@@ -197,7 +197,7 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
                     filename='insertions.csv'
                 />
             )}
-            <Info className='mx-1' content='Info for mutations' />
+            <Info>Info for mutations</Info>
         </div>
     );
 };

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -13,7 +13,7 @@ import { ConfidenceIntervalSelector } from '../components/confidence-interval-se
 import { CsvDownloadButton } from '../components/csv-download-button';
 import { ErrorDisplay } from '../components/error-display';
 import Headline from '../components/headline';
-import Info from '../components/info';
+import Info, { InfoHeadline1, InfoParagraph } from '../components/info';
 import { LoadingDisplay } from '../components/loading-display';
 import { NoDataDisplay } from '../components/no-data-display';
 import { ResizeContainer, type Size } from '../components/resize-container';
@@ -202,8 +202,18 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
                 getData={() => getPrevalenceOverTimeTableData(data, granularity)}
                 filename='prevalence-over-time.csv'
             />
-            <Info className='ml-1' content='Info for prevalence over time' />
+
+            <PrevalenceOverTimeInfo />
         </div>
+    );
+};
+
+const PrevalenceOverTimeInfo: FunctionComponent = () => {
+    return (
+        <Info size={{ width: '600px', height: '30vh' }}>
+            <InfoHeadline1>Prevalence over time</InfoHeadline1>
+            <InfoParagraph>Prevalence over time info.</InfoParagraph>
+        </Info>
     );
 };
 

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -10,7 +10,7 @@ import { type LapisFilter } from '../../types';
 import { LapisUrlContext } from '../LapisUrlContext';
 import { ErrorDisplay } from '../components/error-display';
 import Headline from '../components/headline';
-import Info from '../components/info';
+import Info, { InfoHeadline1, InfoHeadline2, InfoLink, InfoParagraph } from '../components/info';
 import { LoadingDisplay } from '../components/loading-display';
 import { NoDataDisplay } from '../components/no-data-display';
 import { ResizeContainer, type Size } from '../components/resize-container';
@@ -77,6 +77,7 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
                     yAxisScaleType={yAxisScaleType}
                     setYAxisScaleType={setYAxisScaleType}
                     views={views}
+                    generationTime={generationTime}
                 />
             </Headline>
         </ResizeContainer>
@@ -88,6 +89,7 @@ type RelativeGrowthAdvantageTabsProps = {
     yAxisScaleType: ScaleType;
     setYAxisScaleType: (scaleType: ScaleType) => void;
     views: View[];
+    generationTime: number;
 };
 
 const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabsProps> = ({
@@ -95,6 +97,7 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
     yAxisScaleType,
     setYAxisScaleType,
     views,
+    generationTime,
 }) => {
     const getTab = (view: View) => {
         switch (view) {
@@ -117,7 +120,11 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
 
     const tabs = views.map((view) => getTab(view));
     const toolbar = () => (
-        <RelativeGrowthAdvantageToolbar yAxisScaleType={yAxisScaleType} setYAxisScaleType={setYAxisScaleType} />
+        <RelativeGrowthAdvantageToolbar
+            generationTime={generationTime}
+            yAxisScaleType={yAxisScaleType}
+            setYAxisScaleType={setYAxisScaleType}
+        />
     );
 
     return <Tabs tabs={tabs} toolbar={toolbar} />;
@@ -126,16 +133,53 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
 type RelativeGrowthAdvantageToolbarProps = {
     yAxisScaleType: ScaleType;
     setYAxisScaleType: (scaleType: ScaleType) => void;
+    generationTime: number;
 };
 
 const RelativeGrowthAdvantageToolbar: FunctionComponent<RelativeGrowthAdvantageToolbarProps> = ({
     yAxisScaleType,
     setYAxisScaleType,
+    generationTime,
 }) => {
     return (
         <div class='flex'>
             <ScalingSelector yAxisScaleType={yAxisScaleType} setYAxisScaleType={setYAxisScaleType} />
-            <Info className='ml-1' content='Line chart' />
+            <RelativeGrowthAdvantageInfo generationTime={generationTime} />
         </div>
+    );
+};
+
+const RelativeGrowthAdvantageInfo: FunctionComponent<{ generationTime: number }> = ({ generationTime }) => {
+    return (
+        <Info size={{ width: '600px', height: '30vh' }}>
+            <InfoHeadline1>Relative growth advantage</InfoHeadline1>
+            <InfoParagraph>
+                If variants spread pre-dominantly by local transmission across demographic groups, this estimate
+                reflects the relative viral intrinsic growth advantage of the focal variant in the selected country and
+                time frame. We report the relative growth advantage per {generationTime} days (in percentage; 0% means
+                equal growth). Importantly, the relative growth advantage estimate reflects the advantage compared to
+                the co-circulating variants. Thus, as new variants spread, the advantage of the focal variant may
+                decrease. Different mechanisms can alter the intrinsic growth rate, including an intrinsic transmission
+                advantage, immune evasion, and a prolonged infectious period. When absolute numbers of a variant are
+                low, the growth advantage may merely reflect the current importance of introductions from abroad or the
+                variant spreading in a particular demographic group. In this case, the estimate does not provide
+                information on any intrinsic fitness advantages.
+            </InfoParagraph>
+            <InfoParagraph>
+                Example: Assume that 10 infections from the focal variant and 100 infections from the co-circulating
+                variants occur today and that the focal variant has a relative growth advantage of 50%. Then, if the
+                number of new infections from the co-circulating variants remains at 100 in {generationTime} days from
+                today, we expect the number of new infections from the focal variant to be 15.
+            </InfoParagraph>
+
+            <InfoHeadline2>Reference</InfoHeadline2>
+            <InfoParagraph>
+                Chen, Chaoran, et al. "Quantification of the spread of SARS-CoV-2 variant B.1.1.7 in Switzerland."
+                Epidemics (2021); doi:{' '}
+                <InfoLink href='https://www.sciencedirect.com/science/article/pii/S1755436521000335?via=ihub'>
+                    10.1016/j.epidem.2021.100480
+                </InfoLink>
+            </InfoParagraph>
+        </Info>
     );
 };


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #193

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The info component can now be passed children to show. The size of the tooltip increases by the size of the displayed children. The size can also be provided as a prop.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/e4c01c70-b20a-4aed-80ef-81a2ffd08792)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
