### PR TITLE
feat(components): add error boundary to components

### DIFF
--- a/components/src/preact/components/error-boundary.stories.tsx
+++ b/components/src/preact/components/error-boundary.stories.tsx
@@ -1,0 +1,62 @@
+import { type Meta, type StoryObj } from '@storybook/preact';
+import { expect, waitFor, within } from '@storybook/test';
+
+import { ErrorBoundary } from './error-boundary';
+
+const meta: Meta = {
+    title: 'Component/Error boundary',
+    component: ErrorBoundary,
+    parameters: { fetchMock: {} },
+    argTypes: {
+        size: { control: 'object' },
+        defaultSize: { control: 'object' },
+        headline: { control: 'text' },
+    },
+};
+
+export default meta;
+
+export const ErrorBoundaryWithoutErrorStory: StoryObj = {
+    render: (args) => (
+        <ErrorBoundary size={args.size} defaultSize={args.defaultSize} headline={args.headline}>
+            <div>Some content</div>
+        </ErrorBoundary>
+    ),
+    args: {
+        size: { height: '600px', width: '100%' },
+        defaultSize: { height: '600px', width: '100%' },
+        headline: 'Some headline',
+    },
+
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const content = canvas.getByText('Some content', { exact: false });
+        await waitFor(() => expect(content).toBeInTheDocument());
+        await waitFor(() => expect(canvas.queryByText('Some headline')).not.toBeInTheDocument());
+    },
+};
+
+export const ErrorBoundaryWithErrorStory: StoryObj = {
+    render: (args) => (
+        <ErrorBoundary size={args.size} defaultSize={args.defaultSize} headline={args.headline}>
+            <ContentThatThrowsError />
+        </ErrorBoundary>
+    ),
+    args: {
+        size: { height: '600px', width: '100%' },
+        defaultSize: { height: '600px', width: '100%' },
+        headline: 'Some headline',
+    },
+
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const content = canvas.queryByText('Some content.', { exact: false });
+        await waitFor(() => expect(content).not.toBeInTheDocument());
+        await waitFor(() => expect(canvas.getByText('Some headline')).toBeInTheDocument());
+        await waitFor(() => expect(canvas.getByText('Error')).toBeInTheDocument());
+    },
+};
+
+const ContentThatThrowsError = () => {
+    throw new Error('Some error');
+};

--- a/components/src/preact/components/error-boundary.tsx
+++ b/components/src/preact/components/error-boundary.tsx
@@ -1,0 +1,31 @@
+import type { FunctionComponent } from 'preact';
+import { useErrorBoundary } from 'preact/hooks';
+
+import { ErrorDisplay } from './error-display';
+import { ResizeContainer, type Size } from './resize-container';
+import Headline from '../components/headline';
+
+export const ErrorBoundary: FunctionComponent<{ size?: Size; defaultSize: Size; headline?: string }> = ({
+    size,
+    defaultSize,
+    headline,
+    children,
+}) => {
+    const [internalError] = useErrorBoundary();
+
+    if (internalError) {
+        console.error(internalError);
+    }
+
+    if (internalError) {
+        return (
+            <ResizeContainer defaultSize={defaultSize} size={size}>
+                <Headline heading={headline}>
+                    <ErrorDisplay error={internalError} />
+                </Headline>
+            </ResizeContainer>
+        );
+    }
+
+    return <>{children}</>;
+};

--- a/components/src/preact/components/error-display.stories.tsx
+++ b/components/src/preact/components/error-display.stories.tsx
@@ -1,7 +1,8 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
 import { expect, waitFor, within } from '@storybook/test';
 
-import { ErrorDisplay } from './error-display';
+import { ErrorDisplay, UserFacingError } from './error-display';
+import { ResizeContainer } from './resize-container';
 
 const meta: Meta = {
     title: 'Component/Error',
@@ -12,11 +13,31 @@ const meta: Meta = {
 export default meta;
 
 export const ErrorStory: StoryObj = {
-    render: () => <ErrorDisplay error={new Error('some message')} />,
+    render: () => (
+        <ResizeContainer defaultSize={{ height: '600px', width: '100%' }}>
+            <ErrorDisplay error={new Error('some message')} />
+        </ResizeContainer>
+    ),
 
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        const error = canvas.getByText('Error: ', { exact: false });
+        const error = canvas.getByText('Oops! Something went wrong.', { exact: false });
         await waitFor(() => expect(error).toBeInTheDocument());
+        await waitFor(() => expect(canvas.queryByText('some message')).not.toBeInTheDocument());
+    },
+};
+
+export const UserFacingErrorStory: StoryObj = {
+    render: () => (
+        <ResizeContainer defaultSize={{ height: '600px', width: '100%' }}>
+            <ErrorDisplay error={new UserFacingError('some message')} />
+        </ResizeContainer>
+    ),
+
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const error = canvas.getByText('Oops! Something went wrong.', { exact: false });
+        await waitFor(() => expect(error).toBeInTheDocument());
+        await waitFor(() => expect(canvas.getByText('some message')).toBeInTheDocument());
     },
 };

--- a/components/src/preact/components/error-display.tsx
+++ b/components/src/preact/components/error-display.tsx
@@ -1,5 +1,18 @@
 import { type FunctionComponent } from 'preact';
 
+export class UserFacingError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'UserFacingError';
+    }
+}
+
 export const ErrorDisplay: FunctionComponent<{ error: Error }> = ({ error }) => {
-    return <div>Error: {error.message}</div>;
+    return (
+        <div className='h-full w-full rounded-md border-2 border-gray-100 p-2 flex items-center justify-center flex-col'>
+            <div className='text-red-700 font-bold'>Error</div>
+            <div>Oops! Something went wrong.</div>
+            {error instanceof UserFacingError && <div className='text-sm text-gray-600'>{error.message}</div>}
+        </div>
+    );
 };

--- a/components/src/preact/components/loading-display.stories.tsx
+++ b/components/src/preact/components/loading-display.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
-import { expect, waitFor, within } from '@storybook/test';
 
 import { LoadingDisplay } from './loading-display';
+import { ResizeContainer } from './resize-container';
 
 const meta: Meta = {
     title: 'Component/Loading',
@@ -12,9 +12,9 @@ const meta: Meta = {
 export default meta;
 
 export const LoadingStory: StoryObj = {
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
-        const loading = canvas.getByText('Loading...');
-        await waitFor(() => expect(loading).toBeInTheDocument());
-    },
+    render: () => (
+        <ResizeContainer defaultSize={{ height: '600px', width: '100%' }}>
+            <LoadingDisplay />
+        </ResizeContainer>
+    ),
 };

--- a/components/src/preact/components/loading-display.tsx
+++ b/components/src/preact/components/loading-display.tsx
@@ -1,5 +1,5 @@
 import { type FunctionComponent } from 'preact';
 
 export const LoadingDisplay: FunctionComponent = () => {
-    return <div>Loading...</div>;
+    return <div aria-label={'Loading'} className='h-full w-full skeleton' />;
 };

--- a/components/src/preact/components/no-data-display.tsx
+++ b/components/src/preact/components/no-data-display.tsx
@@ -1,5 +1,9 @@
 import { type FunctionComponent } from 'preact';
 
 export const NoDataDisplay: FunctionComponent = () => {
-    return <div>No data available.</div>;
+    return (
+        <div className='h-full w-full rounded-md border-2 border-gray-100 p-2 flex items-center justify-center'>
+            <div>No data available.</div>
+        </div>
+    );
 };

--- a/components/src/preact/dateRangeSelector/date-range-selector.stories.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.stories.tsx
@@ -40,11 +40,27 @@ const meta: Meta<DateRangeSelectorProps<'CustomDateRange'>> = {
                 'CustomDateRange',
             ],
         },
+        customSelectOptions: {
+            control: {
+                type: 'object',
+            },
+        },
+        earliestDate: {
+            control: {
+                type: 'text',
+            },
+        },
+        width: {
+            control: {
+                type: 'text',
+            },
+        },
     },
     args: {
         customSelectOptions: [{ label: 'CustomDateRange', dateFrom: '2021-01-01', dateTo: '2021-12-31' }],
         earliestDate: '1970-01-01',
         initialValue: PRESET_VALUE_LAST_3_MONTHS,
+        width: '100%',
     },
     decorators: [withActions],
 };
@@ -58,6 +74,7 @@ export const Primary: StoryObj<DateRangeSelectorProps<'CustomDateRange'>> = {
                 customSelectOptions={args.customSelectOptions}
                 earliestDate={args.earliestDate}
                 initialValue={args.initialValue}
+                width={args.width}
             />
         </LapisUrlContext.Provider>
     ),

--- a/components/src/preact/dateRangeSelector/date-range-selector.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.tsx
@@ -3,12 +3,18 @@ import 'flatpickr/dist/flatpickr.min.css';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { toYYYYMMDD } from './dateConversion';
+import { ErrorBoundary } from '../components/error-boundary';
+import { ResizeContainer } from '../components/resize-container';
 import { Select } from '../components/select';
 import type { ScaleType } from '../shared/charts/getYAxisScale';
 
 export type CustomSelectOption<CustomLabel extends string> = { label: CustomLabel; dateFrom: string; dateTo: string };
 
-export interface DateRangeSelectorProps<CustomLabel extends string> {
+export interface DateRangeSelectorProps<CustomLabel extends string> extends DateRangeSelectorPropsInner<CustomLabel> {
+    width?: string;
+}
+
+export interface DateRangeSelectorPropsInner<CustomLabel extends string> {
     customSelectOptions: CustomSelectOption<CustomLabel>[];
     earliestDate?: string;
     initialValue?: PresetOptionValues | CustomLabel;
@@ -35,6 +41,28 @@ export const presets = {
 export type PresetOptionValues = keyof typeof presets;
 
 export const DateRangeSelector = <CustomLabel extends string>({
+    customSelectOptions,
+    earliestDate = '1900-01-01',
+    initialValue,
+    width,
+}: DateRangeSelectorProps<CustomLabel>) => {
+    const defaultSize = { width: '100%', height: '3rem' };
+    const size = width === undefined ? undefined : { width, height: defaultSize.height };
+
+    return (
+        <ErrorBoundary defaultSize={defaultSize} size={size}>
+            <ResizeContainer defaultSize={defaultSize} size={size}>
+                <DateRangeSelectorInner
+                    customSelectOptions={customSelectOptions}
+                    earliestDate={earliestDate}
+                    initialValue={initialValue}
+                />
+            </ResizeContainer>
+        </ErrorBoundary>
+    );
+};
+
+export const DateRangeSelectorInner = <CustomLabel extends string>({
     customSelectOptions,
     earliestDate = '1900-01-01',
     initialValue,
@@ -151,11 +179,11 @@ export const DateRangeSelector = <CustomLabel extends string>({
     };
 
     return (
-        <div class='join' ref={divRef}>
+        <div class='join w-full' ref={divRef}>
             <Select
                 items={selectableOptions}
                 selected={selectedDateRange}
-                selectStyle='select-bordered rounded-none join-item'
+                selectStyle='select-bordered rounded-none join-item grow'
                 onChange={(event: Event) => {
                     event.preventDefault();
                     const select = event.target as HTMLSelectElement;
@@ -164,7 +192,7 @@ export const DateRangeSelector = <CustomLabel extends string>({
                 }}
             />
             <input
-                class='input input-bordered rounded-none join-item'
+                class='input input-bordered rounded-none join-item grow'
                 type='text'
                 placeholder='Date from'
                 ref={fromDatePickerRef}
@@ -172,7 +200,7 @@ export const DateRangeSelector = <CustomLabel extends string>({
                 onBlur={onChangeDateFrom}
             />
             <input
-                class='input input-bordered rounded-none join-item'
+                class='input input-bordered rounded-none join-item grow'
                 type='text'
                 placeholder='Date to'
                 ref={toDatePickerRef}

--- a/components/src/preact/locationFilter/location-filter.stories.tsx
+++ b/components/src/preact/locationFilter/location-filter.stories.tsx
@@ -6,7 +6,7 @@ import { LocationFilter, type LocationFilterProps } from './location-filter';
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
 import { LapisUrlContext } from '../LapisUrlContext';
 
-const meta: Meta<typeof LocationFilter> = {
+const meta: Meta<LocationFilterProps> = {
     title: 'Input/LocationFilter',
     component: LocationFilter,
     parameters: {
@@ -32,7 +32,26 @@ const meta: Meta<typeof LocationFilter> = {
         },
     },
     args: {
+        width: '100%',
         fields: ['region', 'country', 'division', 'location'],
+        initialValue: 'United States',
+    },
+    argTypes: {
+        fields: {
+            control: {
+                type: 'object',
+            },
+        },
+        initialValue: {
+            control: {
+                type: 'text',
+            },
+        },
+        width: {
+            control: {
+                type: 'text',
+            },
+        },
     },
     decorators: [withActions],
 };
@@ -41,10 +60,8 @@ export default meta;
 
 export const Primary: StoryObj<LocationFilterProps> = {
     render: (args) => (
-        <div class='max-w-screen-lg'>
-            <LapisUrlContext.Provider value={LAPIS_URL}>
-                <LocationFilter fields={args.fields} />
-            </LapisUrlContext.Provider>
-        </div>
+        <LapisUrlContext.Provider value={LAPIS_URL}>
+            <LocationFilter fields={args.fields} initialValue={args.initialValue} width={args.width} />
+        </LapisUrlContext.Provider>
     ),
 };

--- a/components/src/preact/mutationComparison/mutation-comparison.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.tsx
@@ -9,6 +9,7 @@ import { type LapisFilter, type SequenceType } from '../../types';
 import { LapisUrlContext } from '../LapisUrlContext';
 import { type DisplayedSegment, SegmentSelector, useDisplayedSegments } from '../components/SegmentSelector';
 import { CsvDownloadButton } from '../components/csv-download-button';
+import { ErrorBoundary } from '../components/error-boundary';
 import { ErrorDisplay } from '../components/error-display';
 import Headline from '../components/headline';
 import Info from '../components/info';
@@ -28,12 +29,15 @@ export interface MutationComparisonVariant {
     displayName: string;
 }
 
-export interface MutationComparisonProps {
+export interface MutationComparisonProps extends MutationComparisonInnerProps {
+    size?: Size;
+    headline?: string;
+}
+
+export interface MutationComparisonInnerProps {
     variants: MutationComparisonVariant[];
     sequenceType: SequenceType;
     views: View[];
-    size?: Size;
-    headline?: string;
 }
 
 export const MutationComparison: FunctionComponent<MutationComparisonProps> = ({
@@ -43,6 +47,24 @@ export const MutationComparison: FunctionComponent<MutationComparisonProps> = ({
     size,
     headline = 'Mutation comparison',
 }) => {
+    const defaultSize = { height: '600px', width: '100%' };
+
+    return (
+        <ErrorBoundary size={size} defaultSize={defaultSize} headline={headline}>
+            <ResizeContainer size={size} defaultSize={defaultSize}>
+                <Headline heading={headline}>
+                    <MutationComparisonInner variants={variants} sequenceType={sequenceType} views={views} />
+                </Headline>
+            </ResizeContainer>
+        </ErrorBoundary>
+    );
+};
+
+export const MutationComparisonInner: FunctionComponent<MutationComparisonInnerProps> = ({
+    variants,
+    sequenceType,
+    views,
+}) => {
     const lapis = useContext(LapisUrlContext);
 
     const { data, error, isLoading } = useQuery(async () => {
@@ -50,36 +72,18 @@ export const MutationComparison: FunctionComponent<MutationComparisonProps> = ({
     }, [variants, sequenceType, lapis]);
 
     if (isLoading) {
-        return (
-            <Headline heading={headline}>
-                <LoadingDisplay />
-            </Headline>
-        );
+        return <LoadingDisplay />;
     }
 
     if (error !== null) {
-        return (
-            <Headline heading={headline}>
-                <ErrorDisplay error={error} />
-            </Headline>
-        );
+        return <ErrorDisplay error={error} />;
     }
 
     if (data === null) {
-        return (
-            <Headline heading={headline}>
-                <NoDataDisplay />
-            </Headline>
-        );
+        return <NoDataDisplay />;
     }
 
-    return (
-        <ResizeContainer size={size} defaultSize={{ height: '700px', width: '100%' }}>
-            <Headline heading={headline}>
-                <MutationComparisonTabs data={data.mutationData} sequenceType={sequenceType} views={views} />
-            </Headline>
-        </ResizeContainer>
-    );
+    return <MutationComparisonTabs data={data.mutationData} sequenceType={sequenceType} views={views} />;
 };
 
 type MutationComparisonTabsProps = {

--- a/components/src/preact/mutationFilter/mutation-filter.stories.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.stories.tsx
@@ -18,19 +18,34 @@ const meta: Meta<MutationFilterProps> = {
         },
         fetchMock: {},
     },
+    argTypes: {
+        size: {
+            control: {
+                type: 'object',
+            },
+        },
+        initialValue: {
+            control: {
+                type: 'object',
+            },
+        },
+    },
     decorators: [withActions],
 };
 
 export default meta;
 
 export const Default: StoryObj<MutationFilterProps> = {
-    render: () => (
+    render: (args) => (
         <LapisUrlContext.Provider value={LAPIS_URL}>
             <ReferenceGenomeContext.Provider value={referenceGenome}>
-                <MutationFilter />
+                <MutationFilter size={args.size} initialValue={args.initialValue} />
             </ReferenceGenomeContext.Provider>
         </LapisUrlContext.Provider>
     ),
+    args: {
+        size: { width: '100%' },
+    },
 };
 
 export const FiresFilterChangedEvents: StoryObj<MutationFilterProps> = {

--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -5,13 +5,19 @@ import { parseAndValidateMutation } from './parseAndValidateMutation';
 import { type ReferenceGenome } from '../../lapisApi/ReferenceGenome';
 import { type Deletion, type Insertion, type Mutation, type Substitution } from '../../utils/mutations';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
+import { ErrorBoundary } from '../components/error-boundary';
 import Info from '../components/info';
+import { ResizeContainer, type Size } from '../components/resize-container';
 import { singleGraphColorRGBByName } from '../shared/charts/colors';
 import { DeleteIcon } from '../shared/icons/DeleteIcon';
 
-export type MutationFilterProps = {
+export interface MutationFilterInnerProps {
     initialValue?: SelectedMutationFilterStrings | string[] | undefined;
-};
+}
+
+export interface MutationFilterProps extends MutationFilterInnerProps {
+    size?: Size;
+}
 
 export type SelectedFilters = {
     nucleotideMutations: (Substitution | Deletion)[];
@@ -24,7 +30,19 @@ export type SelectedMutationFilterStrings = {
     [Key in keyof SelectedFilters]: string[];
 };
 
-export const MutationFilter: FunctionComponent<MutationFilterProps> = ({ initialValue }) => {
+export const MutationFilter: FunctionComponent<MutationFilterProps> = ({ initialValue, size }) => {
+    const defaultSize = { width: '100%', height: '6.5rem' };
+
+    return (
+        <ErrorBoundary size={size} defaultSize={defaultSize}>
+            <ResizeContainer size={size} defaultSize={defaultSize}>
+                <MutationFilterInner initialValue={initialValue} />
+            </ResizeContainer>
+        </ErrorBoundary>
+    );
+};
+
+export const MutationFilterInner: FunctionComponent<MutationFilterInnerProps> = ({ initialValue }) => {
     const referenceGenome = useContext(ReferenceGenomeContext);
     const [selectedFilters, setSelectedFilters] = useState<SelectedFilters>(
         getInitialState(initialValue, referenceGenome),
@@ -83,7 +101,7 @@ export const MutationFilter: FunctionComponent<MutationFilterProps> = ({ initial
     };
 
     return (
-        <div class={`rounded-lg border border-gray-300 bg-white p-2`}>
+        <div class={`h-full w-full rounded-lg border border-gray-300 bg-white p-2 overflow-scroll`}>
             <div class='flex justify-between'>
                 <SelectedMutationDisplay
                     selectedFilters={selectedFilters}
@@ -295,11 +313,11 @@ const SelectedFilter = <MutationType extends Mutation>({
 }: SelectedFilterProps<MutationType>) => {
     return (
         <div
-            class='flex items-center flex-nowrap gap-1 rounded me-1 px-2.5 py-0.5 font-medium text-xs mb-1'
+            class='flex items-center flex-nowrap gap-1 rounded me-1 px-2.5 py-0.5 font-medium text-xs mb-1 min-w-max'
             style={{ backgroundColor, color: textColor }}
         >
-            <div>{mutation.toString()}</div>
-            <button onClick={() => onDelete(mutation)}>
+            <div className='whitespace-nowrap min-w-max'>{mutation.toString()}</div>
+            <button type='button' onClick={() => onDelete(mutation)}>
                 <DeleteIcon />
             </button>
         </div>

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -11,6 +11,7 @@ import { type NamedLapisFilter, type TemporalGranularity } from '../../types';
 import { LapisUrlContext } from '../LapisUrlContext';
 import { ConfidenceIntervalSelector } from '../components/confidence-interval-selector';
 import { CsvDownloadButton } from '../components/csv-download-button';
+import { ErrorBoundary } from '../components/error-boundary';
 import { ErrorDisplay } from '../components/error-display';
 import Headline from '../components/headline';
 import Info, { InfoHeadline1, InfoParagraph } from '../components/info';
@@ -25,15 +26,18 @@ import { useQuery } from '../useQuery';
 
 export type View = 'bar' | 'line' | 'bubble' | 'table';
 
-export interface PrevalenceOverTimeProps {
+export interface PrevalenceOverTimeProps extends PrevalenceOverTimeInnerProps {
+    size?: Size;
+    headline?: string;
+}
+
+export interface PrevalenceOverTimeInnerProps {
     numerator: NamedLapisFilter | NamedLapisFilter[];
     denominator: NamedLapisFilter;
     granularity: TemporalGranularity;
     smoothingWindow: number;
     views: View[];
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
-    size?: Size;
-    headline?: string;
 }
 
 export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
@@ -46,6 +50,34 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
     size,
     headline = 'Prevalence over time',
 }) => {
+    const defaultSize = { height: '600px', width: '100%' };
+
+    return (
+        <ErrorBoundary size={size} defaultSize={defaultSize} headline={headline}>
+            <ResizeContainer size={size} defaultSize={defaultSize}>
+                <Headline heading={headline}>
+                    <PrevalenceOverTimeInner
+                        numerator={numerator}
+                        denominator={denominator}
+                        granularity={granularity}
+                        smoothingWindow={smoothingWindow}
+                        views={views}
+                        confidenceIntervalMethods={confidenceIntervalMethods}
+                    />
+                </Headline>
+            </ResizeContainer>
+        </ErrorBoundary>
+    );
+};
+
+export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerProps> = ({
+    numerator,
+    denominator,
+    granularity,
+    smoothingWindow,
+    views,
+    confidenceIntervalMethods,
+}) => {
     const lapis = useContext(LapisUrlContext);
 
     const { data, error, isLoading } = useQuery(
@@ -54,40 +86,24 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
     );
 
     if (isLoading) {
-        return (
-            <Headline heading={headline}>
-                <LoadingDisplay />
-            </Headline>
-        );
+        return <LoadingDisplay />;
     }
 
     if (error !== null) {
-        return (
-            <Headline heading={headline}>
-                <ErrorDisplay error={error} />
-            </Headline>
-        );
+        return <ErrorDisplay error={error} />;
     }
 
     if (data === null) {
-        return (
-            <Headline heading={headline}>
-                <NoDataDisplay />
-            </Headline>
-        );
+        return <NoDataDisplay />;
     }
 
     return (
-        <ResizeContainer size={size} defaultSize={{ height: '600px', width: '100%' }}>
-            <Headline heading={headline}>
-                <PrevalenceOverTimeTabs
-                    views={views}
-                    data={data}
-                    granularity={granularity}
-                    confidenceIntervalMethods={confidenceIntervalMethods}
-                />
-            </Headline>
-        </ResizeContainer>
+        <PrevalenceOverTimeTabs
+            views={views}
+            data={data}
+            granularity={granularity}
+            confidenceIntervalMethods={confidenceIntervalMethods}
+        />
     );
 };
 

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../query/queryRelativeGrowthAdvantage';
 import { type LapisFilter } from '../../types';
 import { LapisUrlContext } from '../LapisUrlContext';
+import { ErrorBoundary } from '../components/error-boundary';
 import { ErrorDisplay } from '../components/error-display';
 import Headline from '../components/headline';
 import Info, { InfoHeadline1, InfoHeadline2, InfoLink, InfoParagraph } from '../components/info';
@@ -21,22 +22,49 @@ import { useQuery } from '../useQuery';
 
 export type View = 'line';
 
-export interface RelativeGrowthAdvantageProps {
-    numerator: LapisFilter;
-    denominator: LapisFilter;
-    generationTime: number;
-    views: View[];
+export interface RelativeGrowthAdvantageProps extends RelativeGrowthAdvantagePropsInner {
     size?: Size;
     headline?: string;
 }
 
+export interface RelativeGrowthAdvantagePropsInner {
+    numerator: LapisFilter;
+    denominator: LapisFilter;
+    generationTime: number;
+    views: View[];
+}
+
 export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageProps> = ({
+    views,
+    size,
+    numerator,
+    denominator,
+    generationTime,
+    headline = 'Relative growth advantage',
+}) => {
+    const defaultSize = { height: '600px', width: '100%' };
+
+    return (
+        <ErrorBoundary size={size} defaultSize={defaultSize} headline={headline}>
+            <ResizeContainer size={size} defaultSize={defaultSize}>
+                <Headline heading={headline}>
+                    <RelativeGrowthAdvantageInner
+                        views={views}
+                        numerator={numerator}
+                        denominator={denominator}
+                        generationTime={generationTime}
+                    />
+                </Headline>
+            </ResizeContainer>
+        </ErrorBoundary>
+    );
+};
+
+export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvantageProps> = ({
     numerator,
     denominator,
     generationTime,
     views,
-    size,
-    headline = 'Relative growth advantage',
 }) => {
     const lapis = useContext(LapisUrlContext);
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
@@ -47,41 +75,25 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
     );
 
     if (isLoading) {
-        return (
-            <Headline heading={headline}>
-                <LoadingDisplay />
-            </Headline>
-        );
+        return <LoadingDisplay />;
     }
 
     if (error !== null) {
-        return (
-            <Headline heading={headline}>
-                <ErrorDisplay error={error} />
-            </Headline>
-        );
+        return <ErrorDisplay error={error} />;
     }
 
     if (data === null) {
-        return (
-            <Headline heading={headline}>
-                <NoDataDisplay />
-            </Headline>
-        );
+        return <NoDataDisplay />;
     }
 
     return (
-        <ResizeContainer size={size} defaultSize={{ height: '700px', width: '100%' }}>
-            <Headline heading={headline}>
-                <RelativeGrowthAdvantageTabs
-                    data={data}
-                    yAxisScaleType={yAxisScaleType}
-                    setYAxisScaleType={setYAxisScaleType}
-                    views={views}
-                    generationTime={generationTime}
-                />
-            </Headline>
-        </ResizeContainer>
+        <RelativeGrowthAdvantageTabs
+            data={data}
+            yAxisScaleType={yAxisScaleType}
+            setYAxisScaleType={setYAxisScaleType}
+            views={views}
+            generationTime={generationTime}
+        />
     );
 };
 

--- a/components/src/preact/textInput/text-input.tsx
+++ b/components/src/preact/textInput/text-input.tsx
@@ -3,18 +3,41 @@ import { useContext, useRef } from 'preact/hooks';
 
 import { fetchAutocompleteList } from './fetchAutocompleteList';
 import { LapisUrlContext } from '../LapisUrlContext';
+import { ErrorBoundary } from '../components/error-boundary';
 import { ErrorDisplay } from '../components/error-display';
 import { LoadingDisplay } from '../components/loading-display';
 import { NoDataDisplay } from '../components/no-data-display';
+import { ResizeContainer } from '../components/resize-container';
 import { useQuery } from '../useQuery';
 
-export interface TextInputProps {
+export interface TextInputInnerProps {
     lapisField: string;
     placeholderText?: string;
     initialValue?: string;
 }
 
-export const TextInput: FunctionComponent<TextInputProps> = ({ lapisField, placeholderText, initialValue }) => {
+export interface TextInputProps extends TextInputInnerProps {
+    width?: string;
+}
+
+export const TextInput: FunctionComponent<TextInputProps> = ({ width, lapisField, placeholderText, initialValue }) => {
+    const defaultSize = { width: '100%', height: '3rem' };
+    const size = width === undefined ? undefined : { width, height: defaultSize.height };
+
+    return (
+        <ErrorBoundary defaultSize={defaultSize} size={size}>
+            <ResizeContainer size={size} defaultSize={defaultSize}>
+                <TextInputInner lapisField={lapisField} placeholderText={placeholderText} initialValue={initialValue} />
+            </ResizeContainer>
+        </ErrorBoundary>
+    );
+};
+
+export const TextInputInner: FunctionComponent<TextInputInnerProps> = ({
+    lapisField,
+    placeholderText,
+    initialValue,
+}) => {
     const lapis = useContext(LapisUrlContext);
 
     const inputRef = useRef<HTMLInputElement>(null);
@@ -58,7 +81,7 @@ export const TextInput: FunctionComponent<TextInputProps> = ({ lapisField, place
         <>
             <input
                 type='text'
-                class='input input-bordered'
+                class='input input-bordered w-full'
                 placeholder={placeholderText !== undefined ? placeholderText : lapisField}
                 onInput={onInput}
                 ref={inputRef}

--- a/components/src/web-components/app.stories.ts
+++ b/components/src/web-components/app.stories.ts
@@ -91,7 +91,7 @@ export const FailsToFetchReferenceGenome: StoryObj<{ lapis: string }> = {
         const canvas = within(canvasElement);
 
         await waitFor(() => {
-            expect(canvas.getByText('Error')).toBeVisible();
+            expect(canvas.getByText('Error', { exact: false })).toBeVisible();
         });
     },
 };

--- a/components/src/web-components/app.ts
+++ b/components/src/web-components/app.ts
@@ -55,8 +55,10 @@ export class App extends LitElement {
     override render() {
         return this.updateReferenceGenome.render({
             complete: () => html` <slot></slot>`,
-            error: () => html`<p>Error</p>`, // TODO(#143): Add more advanced error handling
-            pending: () => html` <p>Loading reference genomes...</p> `,
+            error: () =>
+                html` <div class="m-2 w-full alert alert-error">
+                    Error: Cannot fetch reference genome. Is LAPIS available?
+                </div>`,
         });
     }
 

--- a/components/src/web-components/input/gs-date-range-selector.stories.ts
+++ b/components/src/web-components/input/gs-date-range-selector.stories.ts
@@ -25,6 +25,7 @@ const codeExample = String.raw`
     customSelectOptions='[{ "label": "Year 2021", "dateFrom": "2021-01-01", "dateTo": "2021-12-31" }]'
     earliestDate="1970-01-01"
     initialValue="${PRESET_VALUE_LAST_6_MONTHS}"
+    width="100%"
 ></gs-date-range-selector>`;
 
 const meta: Meta<DateRangeSelectorProps<'CustomDateRange'>> = {
@@ -57,11 +58,27 @@ const meta: Meta<DateRangeSelectorProps<'CustomDateRange'>> = {
                 'CustomDateRange',
             ],
         },
+        customSelectOptions: {
+            control: {
+                type: 'object',
+            },
+        },
+        earliestDate: {
+            control: {
+                type: 'text',
+            },
+        },
+        width: {
+            control: {
+                type: 'text',
+            },
+        },
     },
     args: {
         customSelectOptions: [{ label: 'CustomDateRange', dateFrom: '2021-01-01', dateTo: '2021-12-31' }],
         earliestDate: '1970-01-01',
         initialValue: PRESET_VALUE_LAST_6_MONTHS,
+        width: '100%',
     },
     decorators: [withActions],
     tags: ['autodocs'],
@@ -77,6 +94,7 @@ export const DateRangeSelectorStory: StoryObj<DateRangeSelectorProps<'CustomDate
                     .customSelectOptions=${args.customSelectOptions}
                     .earliestDate=${args.earliestDate}
                     .initialValue=${args.initialValue}
+                    .width=${args.width}
                 ></gs-date-range-selector>
             </div>
         </gs-app>`,

--- a/components/src/web-components/input/gs-date-range-selector.tsx
+++ b/components/src/web-components/input/gs-date-range-selector.tsx
@@ -64,12 +64,24 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
         | string
         | undefined = 'last6Months';
 
+    /**
+     * The width of the component.
+     *
+     * If not set, the component will take the full width of its container.
+     *
+     * The width should be a string with a unit in css style, e.g. '100%', '500px' or '50vw'.
+     * If the unit is %, the size will be relative to the container of the component.
+     */
+    @property({ type: Object })
+    width: string | undefined = undefined;
+
     override render() {
         return (
             <DateRangeSelector
                 customSelectOptions={this.customSelectOptions}
                 earliestDate={this.earliestDate}
                 initialValue={this.initialValue}
+                width={this.width}
             />
         );
     }

--- a/components/src/web-components/input/gs-location-filter.stories.ts
+++ b/components/src/web-components/input/gs-location-filter.stories.ts
@@ -12,6 +12,13 @@ import data from '../../preact/locationFilter/__mockData__/aggregated.json';
 import { type LocationFilterProps } from '../../preact/locationFilter/location-filter';
 import { withinShadowRoot } from '../withinShadowRoot.story';
 
+const codeExample = String.raw`
+<gs-location-filter
+    fields="['region', 'country']"
+    value='Europe / Switzerland'
+    width="100%"
+></gs-location-filter>`;
+
 const meta: Meta = {
     title: 'Input/Location filter',
     component: 'gs-location-filter',
@@ -22,9 +29,26 @@ const meta: Meta = {
         componentDocs: {
             opensShadowDom: true,
             expectsChildren: false,
-            codeExample: `<gs-location-filter fields="['continent', 'country']" value='Europe / Switzerland'></gs-location-filter>`,
+            codeExample,
         },
     }),
+    argTypes: {
+        fields: {
+            control: {
+                type: 'object',
+            },
+        },
+        initialValue: {
+            control: {
+                type: 'text',
+            },
+        },
+        width: {
+            control: {
+                type: 'text',
+            },
+        },
+    },
     decorators: [withActions],
     tags: ['autodocs'],
 };
@@ -38,6 +62,7 @@ const Template: StoryObj<LocationFilterProps> = {
                 <gs-location-filter
                     .fields=${args.fields}
                     initialValue=${ifDefined(args.initialValue)}
+                    .width=${args.width}
                 ></gs-location-filter>
             </div>
         </gs-app>`;
@@ -45,6 +70,7 @@ const Template: StoryObj<LocationFilterProps> = {
     args: {
         fields: ['region', 'country', 'division', 'location'],
         initialValue: '',
+        width: '100%',
     },
 };
 
@@ -118,7 +144,7 @@ export const FetchingLocationsFails: StoryObj<LocationFilterProps> = {
         const canvas = await withinShadowRoot(canvasElement, 'gs-location-filter');
 
         await waitFor(() =>
-            expect(canvas.getByText('Bad Request: {"error":"no data"} ', { exact: false })).toBeInTheDocument(),
+            expect(canvas.getByText('Oops! Something went wrong.', { exact: false })).toBeInTheDocument(),
         );
     },
 };

--- a/components/src/web-components/input/gs-location-filter.tsx
+++ b/components/src/web-components/input/gs-location-filter.tsx
@@ -48,8 +48,19 @@ export class LocationFilterComponent extends PreactLitAdapter {
     @property({ type: Array })
     fields: string[] = [];
 
+    /**
+     * The width of the component.
+     *
+     * If not set, the component will take the full width of its container.
+     *
+     * The width should be a string with a unit in css style, e.g. '100%', '500px' or '50vw'.
+     * If the unit is %, the size will be relative to the container of the component.
+     */
+    @property({ type: Object })
+    width: string | undefined = undefined;
+
     override render() {
-        return <LocationFilter initialValue={this.initialValue} fields={this.fields} />;
+        return <LocationFilter initialValue={this.initialValue} fields={this.fields} width={this.width} />;
     }
 }
 

--- a/components/src/web-components/input/gs-mutation-filter.stories.ts
+++ b/components/src/web-components/input/gs-mutation-filter.stories.ts
@@ -10,7 +10,11 @@ import { type MutationFilterProps } from '../../preact/mutationFilter/mutation-f
 import { withinShadowRoot } from '../withinShadowRoot.story';
 import './gs-mutation-filter';
 
-const codeExample = String.raw`<gs-mutation-filter initialValue='["A123T"]'></gs-mutation-filter>`;
+const codeExample = String.raw`
+<gs-mutation-filter 
+    initialValue='["A123T"]'
+    size='{ "width": "100%", "height": "6.5rem" }'
+></gs-mutation-filter>`;
 
 const meta: Meta<MutationFilterProps> = {
     title: 'Input/Mutation filter',
@@ -26,6 +30,18 @@ const meta: Meta<MutationFilterProps> = {
             codeExample,
         },
     }),
+    argTypes: {
+        initialValue: {
+            control: {
+                type: 'object',
+            },
+        },
+        size: {
+            control: {
+                type: 'object',
+            },
+        },
+    },
     decorators: [withActions],
     tags: ['autodocs'],
 };
@@ -36,12 +52,13 @@ const Template: StoryObj<MutationFilterProps> = {
     render: (args) => {
         return html` <gs-app lapis="${LAPIS_URL}">
             <div class="max-w-screen-lg">
-                <gs-mutation-filter .initialValue=${args.initialValue}></gs-mutation-filter>
+                <gs-mutation-filter .initialValue=${args.initialValue} .size=${args.size}></gs-mutation-filter>
             </div>
         </gs-app>`;
     },
     args: {
         initialValue: [],
+        size: { width: '100%', height: '3rem' },
     },
 };
 

--- a/components/src/web-components/input/gs-mutation-filter.tsx
+++ b/components/src/web-components/input/gs-mutation-filter.tsx
@@ -76,10 +76,21 @@ export class MutationFilterComponent extends PreactLitAdapter {
         | string[]
         | undefined = undefined;
 
+    /**
+     * The size of the component.
+     *
+     * If not set, the component will take the full width of its container with height 700px.
+     *
+     * The width and height should be a string with a unit in css style, e.g. '100%', '500px' or '50vh'.
+     * If the unit is %, the size will be relative to the container of the component.
+     */
+    @property({ type: Object })
+    size: { width?: string; height?: string } | undefined = undefined;
+
     override render() {
         return (
             <ReferenceGenomesAwaiter>
-                <MutationFilter initialValue={this.initialValue} />
+                <MutationFilter initialValue={this.initialValue} size={this.size} />
             </ReferenceGenomesAwaiter>
         );
     }

--- a/components/src/web-components/input/gs-text-input.stories.ts
+++ b/components/src/web-components/input/gs-text-input.stories.ts
@@ -12,7 +12,12 @@ import type { TextInputProps } from '../../preact/textInput/text-input';
 import { withinShadowRoot } from '../withinShadowRoot.story';
 
 const codeExample = String.raw`
-<gs-text-input lapisField="host" placeholderText="Enter host name" initialValue="Homo sapiens"></gs-text-input>`;
+<gs-text-input 
+    lapisField="host"
+    placeholderText="Enter host name"
+    initialValue="Homo sapiens"
+    width="50%">
+</gs-text-input>`;
 
 const meta: Meta<TextInputProps> = {
     title: 'Input/Text input',
@@ -44,6 +49,28 @@ const meta: Meta<TextInputProps> = {
             codeExample,
         },
     }),
+    argTypes: {
+        lapisField: {
+            control: {
+                type: 'text',
+            },
+        },
+        placeholderText: {
+            control: {
+                type: 'text',
+            },
+        },
+        initialValue: {
+            control: {
+                type: 'text',
+            },
+        },
+        width: {
+            control: {
+                type: 'text',
+            },
+        },
+    },
     decorators: [withActions],
     tags: ['autodocs'],
 };
@@ -58,6 +85,7 @@ export const Default: StoryObj<TextInputProps> = {
                     .lapisField=${args.lapisField}
                     .placeholderText=${args.placeholderText}
                     .initialValue=${args.initialValue}
+                    .width=${args.width}
                 ></gs-text-input>
             </div>
         </gs-app>`;
@@ -66,6 +94,7 @@ export const Default: StoryObj<TextInputProps> = {
         lapisField: 'host',
         placeholderText: 'Enter host name',
         initialValue: 'Homo sapiens',
+        width: '100%',
     },
 };
 

--- a/components/src/web-components/input/gs-text-input.tsx
+++ b/components/src/web-components/input/gs-text-input.tsx
@@ -39,12 +39,24 @@ export class TextInputComponent extends PreactLitAdapter {
     @property()
     placeholderText: string | undefined = '';
 
+    /**
+     * The width of the component.
+     *
+     * If not set, the component will take the full width of its container.
+     *
+     * The width should be a string with a unit in css style, e.g. '100%', '500px' or '50vw'.
+     * If the unit is %, the size will be relative to the container of the component.
+     */
+    @property({ type: Object })
+    width: string | undefined = undefined;
+
     override render() {
         return (
             <TextInput
                 lapisField={this.lapisField}
                 placeholderText={this.placeholderText}
                 initialValue={this.initialValue}
+                width={this.width}
             />
         );
     }

--- a/components/tests/snapshots.spec.ts
+++ b/components/tests/snapshots.spec.ts
@@ -1,14 +1,15 @@
 import { expect } from '@playwright/test';
+
 import { test } from './componentsFixture';
-import { visualizationStories } from './visualizationStories';
 import { getDownloadedContent } from './getDownloadedContent';
+import { visualizationStories } from './visualizationStories';
 
 visualizationStories.forEach((story) => {
     test.describe(story.title, () => {
         test(`Story ${story.id} should match screenshot`, async ({ page, storybook }) => {
             await storybook.gotoStory(story.id);
             await expect(page.getByRole('heading', { name: story.title })).toBeVisible();
-            await page.getByText('Loading...', { exact: false }).waitFor({ state: 'hidden' });
+            await page.getByLabel('Loading', { exact: false }).waitFor({ state: 'hidden' });
             await expect(page).toHaveScreenshot({ maxDiffPixelRatio: 0.005 });
         });
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #143

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Adds a error boundary to each component. This will catch every error thrown in its children. If the error is a `UserFacingError` then the content of the error message will also be shown. Otherwise it will be omitted. The error should take up as much space as the original component. 

This also introduces a loading skeleton for those components, which have this state.

When the reference genome can not be fetched, an error banner will be shown.


### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/502fbdc0-72b7-4313-9053-5bfb0490c04c)

Error banner when error while fetching reference genome.
![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/18906a6a-66ac-4101-9c56-48bdf5fe4bb2)



### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
