### PR TITLE
chore(github-actions): google-github-actions/release-please-action is deprecated, migrate to new namespace

### DIFF
--- a/.github/workflows/release-components.yml
+++ b/.github/workflows/release-components.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           path: components


### PR DESCRIPTION
### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Apparently https://github.com/google-github-actions/release-please-action is deprecated, they move it to https://github.com/googleapis/release-please-action.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
