### PR TITLE
feat(components): configurable target column for date range selector

### DIFF
--- a/components/src/preact/dateRangeSelector/date-range-selector.stories.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.stories.tsx
@@ -60,6 +60,7 @@ const meta: Meta<DateRangeSelectorProps<'CustomDateRange'>> = {
         customSelectOptions: [{ label: 'CustomDateRange', dateFrom: '2021-01-01', dateTo: '2021-12-31' }],
         earliestDate: '1970-01-01',
         initialValue: PRESET_VALUE_LAST_3_MONTHS,
+        dateColumn: 'aDateColumn',
         width: '100%',
     },
     decorators: [withActions],
@@ -75,6 +76,7 @@ export const Primary: StoryObj<DateRangeSelectorProps<'CustomDateRange'>> = {
                 earliestDate={args.earliestDate}
                 initialValue={args.initialValue}
                 width={args.width}
+                dateColumn={args.dateColumn}
             />
         </LapisUrlContext.Provider>
     ),

--- a/components/src/preact/dateRangeSelector/date-range-selector.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.tsx
@@ -18,6 +18,7 @@ export interface DateRangeSelectorPropsInner<CustomLabel extends string> {
     customSelectOptions: CustomSelectOption<CustomLabel>[];
     earliestDate?: string;
     initialValue?: PresetOptionValues | CustomLabel;
+    dateColumn: string;
 }
 
 export const PRESET_VALUE_CUSTOM = 'custom';
@@ -45,6 +46,7 @@ export const DateRangeSelector = <CustomLabel extends string>({
     earliestDate = '1900-01-01',
     initialValue,
     width,
+    dateColumn,
 }: DateRangeSelectorProps<CustomLabel>) => {
     const defaultSize = { width: '100%', height: '3rem' };
     const size = width === undefined ? undefined : { width, height: defaultSize.height };
@@ -56,6 +58,7 @@ export const DateRangeSelector = <CustomLabel extends string>({
                     customSelectOptions={customSelectOptions}
                     earliestDate={earliestDate}
                     initialValue={initialValue}
+                    dateColumn={dateColumn}
                 />
             </ResizeContainer>
         </ErrorBoundary>
@@ -66,6 +69,7 @@ export const DateRangeSelectorInner = <CustomLabel extends string>({
     customSelectOptions,
     earliestDate = '1900-01-01',
     initialValue,
+    dateColumn,
 }: DateRangeSelectorProps<CustomLabel>) => {
     const fromDatePickerRef = useRef<HTMLInputElement>(null);
     const toDatePickerRef = useRef<HTMLInputElement>(null);
@@ -165,8 +169,8 @@ export const DateRangeSelectorInner = <CustomLabel extends string>({
         const dateTo = toYYYYMMDD(dateToPicker?.selectedDates[0]);
 
         const detail = {
-            ...(dateFrom !== undefined && { dateFrom }),
-            ...(dateTo !== undefined && { dateTo }),
+            ...(dateFrom !== undefined && { [`${dateColumn}From`]: dateFrom }),
+            ...(dateTo !== undefined && { [`${dateColumn}To`]: dateTo }),
         };
 
         divRef.current?.dispatchEvent(

--- a/components/src/web-components/input/gs-date-range-selector.stories.ts
+++ b/components/src/web-components/input/gs-date-range-selector.stories.ts
@@ -58,6 +58,7 @@ const meta: Meta<DateRangeSelectorProps<'CustomDateRange'>> = {
                 'CustomDateRange',
             ],
         },
+        dateColumn: { control: { type: 'text' } },
         customSelectOptions: {
             control: {
                 type: 'object',
@@ -78,6 +79,7 @@ const meta: Meta<DateRangeSelectorProps<'CustomDateRange'>> = {
         customSelectOptions: [{ label: 'CustomDateRange', dateFrom: '2021-01-01', dateTo: '2021-12-31' }],
         earliestDate: '1970-01-01',
         initialValue: PRESET_VALUE_LAST_6_MONTHS,
+        dateColumn: 'aDateColumn',
         width: '100%',
     },
     decorators: [withActions],
@@ -95,6 +97,7 @@ export const DateRangeSelectorStory: StoryObj<DateRangeSelectorProps<'CustomDate
                     .earliestDate=${args.earliestDate}
                     .initialValue=${args.initialValue}
                     .width=${args.width}
+                    .dateColumn=${args.dateColumn}
                 ></gs-date-range-selector>
             </div>
         </gs-app>`,
@@ -108,5 +111,9 @@ export const DateRangeSelectorStory: StoryObj<DateRangeSelectorProps<'CustomDate
                 expect(dateTo()).toHaveValue(toYYYYMMDD(new Date()));
             });
         });
+
+        // Due to the limitations of storybook testing which does not fire an event,
+        // when selecting a value from the dropdown we can't test the fired event here.
+        // An e2e test (using playwright) for that can be found in tests/dateRangeSelector.spec.ts
     },
 };

--- a/components/src/web-components/input/gs-date-range-selector.tsx
+++ b/components/src/web-components/input/gs-date-range-selector.tsx
@@ -10,7 +10,8 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
 
 /**
  * ## Context
- * This component is a group of input fields designed to specify a date range. It consists of 3 fields:
+ * This component is a group of input fields designed to specify date range filters
+ * for a given date column of this Lapis instance. It consists of 3 fields:
  *
  * - a select field to choose a predefined date range,
  * - an input field with an attached date picker for the start date,
@@ -20,12 +21,20 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  * Setting a value in either of the date pickers will set the select field to "custom",
  * which represents an arbitrary date range.
  *
- * @fires {CustomEvent<{ dateFrom: string; dateTo: string; }>} gs-date-range-changed
+ * @fires {CustomEvent<{ `${dateColumn}From`: string; `${dateColumn}To`: string; }>} gs-date-range-changed
  * Fired when:
  * - The select field is changed,
  * - A date is selected in either of the date pickers,
  * - A date was typed into either of the date input fields, and the input field loses focus ("on blur").
  * Contains the dates in the format `YYYY-MM-DD`.
+ *
+ * Example for dateColumn = `yourDate`:
+ * ```
+ * {
+ *  yourDataFrom: "2021-01-01",
+ *  yourDataTo: "2021-12-31"
+ * }
+ *  ```
  */
 @customElement('gs-date-range-selector')
 export class DateRangeSelectorComponent extends PreactLitAdapter {
@@ -75,12 +84,19 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
     @property({ type: Object })
     width: string | undefined = undefined;
 
+    /**
+     * The name of the column in LAPIS that contains the date information.
+     */
+    @property({ type: String })
+    dateColumn: string = 'date';
+
     override render() {
         return (
             <DateRangeSelector
                 customSelectOptions={this.customSelectOptions}
                 earliestDate={this.earliestDate}
                 initialValue={this.initialValue}
+                dateColumn={this.dateColumn}
                 width={this.width}
             />
         );
@@ -93,10 +109,7 @@ declare global {
     }
 
     interface HTMLElementEventMap {
-        'gs-date-range-changed': CustomEvent<{
-            dateFrom: string;
-            dateTo: string;
-        }>;
+        'gs-date-range-changed': CustomEvent<Record<string, string>>;
     }
 }
 

--- a/components/tests/dateRangeSelector.spec.ts
+++ b/components/tests/dateRangeSelector.spec.ts
@@ -1,9 +1,10 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
+
 import { toYYYYMMDD } from '../src/preact/dateRangeSelector/dateConversion';
 
 interface DateRangeDetail {
-    dateFrom: string;
-    dateTo: string;
+    aDateColumnFrom: string;
+    aDateColumnTo: string;
 }
 
 const getEventPromiseInsideTestBrowser = async (page: Page) => {
@@ -36,8 +37,8 @@ test('date selector should switch to custom and back', async ({ page }) => {
 
     const today = new Date();
     const firstEvent = await firstEventPromise;
-    expect(firstEvent.dateFrom).toBe(someDateInThePast);
-    expect(firstEvent.dateTo).toBe(toYYYYMMDD(today));
+    expect(firstEvent.aDateColumnFrom).toBe(someDateInThePast);
+    expect(firstEvent.aDateColumnTo).toBe(toYYYYMMDD(today));
 
     const secondEventPromise = getEventPromiseInsideTestBrowser(page);
     await selectBox.selectOption('last3Months');
@@ -49,6 +50,6 @@ test('date selector should switch to custom and back', async ({ page }) => {
     expect(await dateTo.inputValue()).toBe(toYYYYMMDD(today));
     expect(await selectBox.inputValue()).toBe('last3Months');
     const secondEvent = await secondEventPromise;
-    expect(secondEvent.dateFrom).toBe(toYYYYMMDD(threeMonthAgo));
-    expect(secondEvent.dateTo).toBe(toYYYYMMDD(today));
+    expect(secondEvent.aDateColumnFrom).toBe(toYYYYMMDD(threeMonthAgo));
+    expect(secondEvent.aDateColumnTo).toBe(toYYYYMMDD(today));
 });


### PR DESCRIPTION
resolves #213
BREAKING CHANGE: Add mandatory dateColumn prop to date range selector 

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~

As last time: I wasn't able to use the play function to click on the selectors. Therefore no tests were added.
