### PR TITLE
feat(components): move width and height outside of size property

### DIFF
--- a/components/src/preact/aggregatedData/aggregate.stories.tsx
+++ b/components/src/preact/aggregatedData/aggregate.stories.tsx
@@ -10,7 +10,8 @@ const meta: Meta<AggregateProps> = {
     component: Aggregate,
     argTypes: {
         fields: [{ control: 'object' }],
-        size: [{ control: 'object' }],
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
     parameters: {
@@ -49,7 +50,8 @@ export const Default: StoryObj<AggregateProps> = {
         filter: {
             country: 'USA',
         },
-        size: { width: '100%', height: '70vh' },
+        width: '100%',
+        height: '700px',
         headline: 'Aggregate',
     },
 };

--- a/components/src/preact/aggregatedData/aggregate.tsx
+++ b/components/src/preact/aggregatedData/aggregate.tsx
@@ -12,14 +12,15 @@ import Headline from '../components/headline';
 import Info from '../components/info';
 import { LoadingDisplay } from '../components/loading-display';
 import { NoDataDisplay } from '../components/no-data-display';
-import { ResizeContainer, type Size } from '../components/resize-container';
+import { ResizeContainer } from '../components/resize-container';
 import Tabs from '../components/tabs';
 import { useQuery } from '../useQuery';
 
 export type View = 'table';
 
 export type AggregateProps = {
-    size?: Size;
+    width: string;
+    height: string;
     headline?: string;
 } & AggregateInnerProps;
 
@@ -31,16 +32,17 @@ export interface AggregateInnerProps {
 
 export const Aggregate: FunctionComponent<AggregateProps> = ({
     views,
-    size,
+    width,
+    height,
     headline = 'Mutations',
     filter,
     fields,
 }) => {
-    const defaultSize = { height: '600px', width: '100%' };
+    const size = { height, width };
 
     return (
-        <ErrorBoundary size={size} defaultSize={defaultSize} headline={headline}>
-            <ResizeContainer size={size} defaultSize={defaultSize}>
+        <ErrorBoundary size={size} headline={headline}>
+            <ResizeContainer size={size}>
                 <Headline heading={headline}>
                     <AggregateInner fields={fields} filter={filter} views={views} />
                 </Headline>

--- a/components/src/preact/components/error-boundary.stories.tsx
+++ b/components/src/preact/components/error-boundary.stories.tsx
@@ -12,22 +12,20 @@ const meta: Meta = {
         defaultSize: { control: 'object' },
         headline: { control: 'text' },
     },
+    args: {
+        size: { height: '600px', width: '100%' },
+        headline: 'Some headline',
+    },
 };
 
 export default meta;
 
 export const ErrorBoundaryWithoutErrorStory: StoryObj = {
     render: (args) => (
-        <ErrorBoundary size={args.size} defaultSize={args.defaultSize} headline={args.headline}>
+        <ErrorBoundary size={args.size} headline={args.headline}>
             <div>Some content</div>
         </ErrorBoundary>
     ),
-    args: {
-        size: { height: '600px', width: '100%' },
-        defaultSize: { height: '600px', width: '100%' },
-        headline: 'Some headline',
-    },
-
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
         const content = canvas.getByText('Some content', { exact: false });
@@ -38,16 +36,10 @@ export const ErrorBoundaryWithoutErrorStory: StoryObj = {
 
 export const ErrorBoundaryWithErrorStory: StoryObj = {
     render: (args) => (
-        <ErrorBoundary size={args.size} defaultSize={args.defaultSize} headline={args.headline}>
+        <ErrorBoundary size={args.size} headline={args.headline}>
             <ContentThatThrowsError />
         </ErrorBoundary>
     ),
-    args: {
-        size: { height: '600px', width: '100%' },
-        defaultSize: { height: '600px', width: '100%' },
-        headline: 'Some headline',
-    },
-
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
         const content = canvas.queryByText('Some content.', { exact: false });

--- a/components/src/preact/components/error-boundary.tsx
+++ b/components/src/preact/components/error-boundary.tsx
@@ -5,12 +5,7 @@ import { ErrorDisplay } from './error-display';
 import { ResizeContainer, type Size } from './resize-container';
 import Headline from '../components/headline';
 
-export const ErrorBoundary: FunctionComponent<{ size?: Size; defaultSize: Size; headline?: string }> = ({
-    size,
-    defaultSize,
-    headline,
-    children,
-}) => {
+export const ErrorBoundary: FunctionComponent<{ size: Size; headline?: string }> = ({ size, headline, children }) => {
     const [internalError] = useErrorBoundary();
 
     if (internalError) {
@@ -19,7 +14,7 @@ export const ErrorBoundary: FunctionComponent<{ size?: Size; defaultSize: Size; 
 
     if (internalError) {
         return (
-            <ResizeContainer defaultSize={defaultSize} size={size}>
+            <ResizeContainer size={size}>
                 <Headline heading={headline}>
                     <ErrorDisplay error={internalError} />
                 </Headline>

--- a/components/src/preact/components/error-display.stories.tsx
+++ b/components/src/preact/components/error-display.stories.tsx
@@ -14,7 +14,7 @@ export default meta;
 
 export const ErrorStory: StoryObj = {
     render: () => (
-        <ResizeContainer defaultSize={{ height: '600px', width: '100%' }}>
+        <ResizeContainer size={{ height: '600px', width: '100%' }}>
             <ErrorDisplay error={new Error('some message')} />
         </ResizeContainer>
     ),
@@ -29,7 +29,7 @@ export const ErrorStory: StoryObj = {
 
 export const UserFacingErrorStory: StoryObj = {
     render: () => (
-        <ResizeContainer defaultSize={{ height: '600px', width: '100%' }}>
+        <ResizeContainer size={{ height: '600px', width: '100%' }}>
             <ErrorDisplay error={new UserFacingError('some message')} />
         </ResizeContainer>
     ),

--- a/components/src/preact/components/loading-display.stories.tsx
+++ b/components/src/preact/components/loading-display.stories.tsx
@@ -13,7 +13,7 @@ export default meta;
 
 export const LoadingStory: StoryObj = {
     render: () => (
-        <ResizeContainer defaultSize={{ height: '600px', width: '100%' }}>
+        <ResizeContainer size={{ height: '600px', width: '100%' }}>
             <LoadingDisplay />
         </ResizeContainer>
     ),

--- a/components/src/preact/components/resize-container.tsx
+++ b/components/src/preact/components/resize-container.tsx
@@ -1,23 +1,14 @@
 import { type FunctionComponent } from 'preact';
 
 export type Size = {
-    width?: string;
-    height?: string;
+    width: string;
+    height: string;
 };
 
 export interface ResizeContainerProps {
-    size?: Size;
-    defaultSize: Size;
+    size: Size;
 }
 
-export const ResizeContainer: FunctionComponent<ResizeContainerProps> = ({ children, size, defaultSize }) => {
-    return <div style={extendByDefault(size, defaultSize)}>{children}</div>;
-};
-
-const extendByDefault = (size: Size | undefined, defaultSize: Size) => {
-    if (size === undefined) {
-        return defaultSize;
-    }
-
-    return { ...defaultSize, ...size };
+export const ResizeContainer: FunctionComponent<ResizeContainerProps> = ({ children, size }) => {
+    return <div style={size}>{children}</div>;
 };

--- a/components/src/preact/dateRangeSelector/date-range-selector.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.tsx
@@ -11,7 +11,7 @@ import type { ScaleType } from '../shared/charts/getYAxisScale';
 export type CustomSelectOption<CustomLabel extends string> = { label: CustomLabel; dateFrom: string; dateTo: string };
 
 export interface DateRangeSelectorProps<CustomLabel extends string> extends DateRangeSelectorPropsInner<CustomLabel> {
-    width?: string;
+    width: string;
 }
 
 export interface DateRangeSelectorPropsInner<CustomLabel extends string> {
@@ -48,12 +48,11 @@ export const DateRangeSelector = <CustomLabel extends string>({
     width,
     dateColumn,
 }: DateRangeSelectorProps<CustomLabel>) => {
-    const defaultSize = { width: '100%', height: '3rem' };
-    const size = width === undefined ? undefined : { width, height: defaultSize.height };
+    const size = { width, height: '3rem' };
 
     return (
-        <ErrorBoundary defaultSize={defaultSize} size={size}>
-            <ResizeContainer defaultSize={defaultSize} size={size}>
+        <ErrorBoundary size={size}>
+            <ResizeContainer size={size}>
                 <DateRangeSelectorInner
                     customSelectOptions={customSelectOptions}
                     earliestDate={earliestDate}
@@ -70,7 +69,7 @@ export const DateRangeSelectorInner = <CustomLabel extends string>({
     earliestDate = '1900-01-01',
     initialValue,
     dateColumn,
-}: DateRangeSelectorProps<CustomLabel>) => {
+}: DateRangeSelectorPropsInner<CustomLabel>) => {
     const fromDatePickerRef = useRef<HTMLInputElement>(null);
     const toDatePickerRef = useRef<HTMLInputElement>(null);
     const divRef = useRef<HTMLDivElement>(null);

--- a/components/src/preact/locationFilter/location-filter.tsx
+++ b/components/src/preact/locationFilter/location-filter.tsx
@@ -15,16 +15,15 @@ export interface LocationFilterInnerProps {
 }
 
 export interface LocationFilterProps extends LocationFilterInnerProps {
-    width?: string;
+    width: string;
 }
 
 export const LocationFilter: FunctionComponent<LocationFilterProps> = ({ width, initialValue, fields }) => {
-    const defaultSize = { width: '100%', height: '3rem' };
-    const size = width === undefined ? undefined : { width, height: defaultSize.height };
+    const size = { width, height: '3rem' };
 
     return (
-        <ErrorBoundary defaultSize={defaultSize} size={size}>
-            <ResizeContainer size={size} defaultSize={defaultSize}>
+        <ErrorBoundary size={size}>
+            <ResizeContainer size={size}>
                 <LocationFilterInner initialValue={initialValue} fields={fields} />
             </ResizeContainer>
         </ErrorBoundary>

--- a/components/src/preact/mutationComparison/mutation-comparison.stories.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.stories.tsx
@@ -27,7 +27,8 @@ const meta: Meta<MutationComparisonProps> = {
             options: ['table', 'venn'],
             control: { type: 'check' },
         },
-        size: [{ control: 'object' }],
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
     parameters: {
@@ -81,7 +82,8 @@ const Template: StoryObj<MutationComparisonProps> = {
                     variants={args.variants}
                     sequenceType={args.sequenceType}
                     views={args.views}
-                    size={args.size}
+                    width={args.width}
+                    height={args.height}
                     headline={args.headline}
                 />
             </ReferenceGenomeContext.Provider>
@@ -109,7 +111,8 @@ export const TwoVariants: StoryObj<MutationComparisonProps> = {
         ],
         sequenceType: 'nucleotide',
         views: ['table', 'venn'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Mutation comparison',
     },
 };

--- a/components/src/preact/mutationComparison/mutation-comparison.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.tsx
@@ -18,7 +18,7 @@ import { type DisplayedMutationType, MutationTypeSelector } from '../components/
 import { NoDataDisplay } from '../components/no-data-display';
 import { type ProportionInterval } from '../components/proportion-selector';
 import { ProportionSelectorDropdown } from '../components/proportion-selector-dropdown';
-import { ResizeContainer, type Size } from '../components/resize-container';
+import { ResizeContainer } from '../components/resize-container';
 import Tabs from '../components/tabs';
 import { useQuery } from '../useQuery';
 
@@ -30,7 +30,8 @@ export interface MutationComparisonVariant {
 }
 
 export interface MutationComparisonProps extends MutationComparisonInnerProps {
-    size?: Size;
+    width: string;
+    height: string;
     headline?: string;
 }
 
@@ -44,14 +45,15 @@ export const MutationComparison: FunctionComponent<MutationComparisonProps> = ({
     variants,
     sequenceType,
     views,
-    size,
+    width,
+    height,
     headline = 'Mutation comparison',
 }) => {
-    const defaultSize = { height: '600px', width: '100%' };
+    const size = { height, width };
 
     return (
-        <ErrorBoundary size={size} defaultSize={defaultSize} headline={headline}>
-            <ResizeContainer size={size} defaultSize={defaultSize}>
+        <ErrorBoundary size={size} headline={headline}>
+            <ResizeContainer size={size}>
                 <Headline heading={headline}>
                     <MutationComparisonInner variants={variants} sequenceType={sequenceType} views={views} />
                 </Headline>

--- a/components/src/preact/mutationFilter/mutation-filter.stories.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.stories.tsx
@@ -19,11 +19,8 @@ const meta: Meta<MutationFilterProps> = {
         fetchMock: {},
     },
     argTypes: {
-        size: {
-            control: {
-                type: 'object',
-            },
-        },
+        width: { control: 'text' },
+        height: { control: 'text' },
         initialValue: {
             control: {
                 type: 'object',
@@ -39,12 +36,13 @@ export const Default: StoryObj<MutationFilterProps> = {
     render: (args) => (
         <LapisUrlContext.Provider value={LAPIS_URL}>
             <ReferenceGenomeContext.Provider value={referenceGenome}>
-                <MutationFilter size={args.size} initialValue={args.initialValue} />
+                <MutationFilter width={args.width} height={args.height} initialValue={args.initialValue} />
             </ReferenceGenomeContext.Provider>
         </LapisUrlContext.Provider>
     ),
     args: {
-        size: { width: '100%' },
+        width: '100%',
+        height: '700px',
     },
 };
 
@@ -155,7 +153,7 @@ export const WithInitialValue: StoryObj<MutationFilterProps> = {
     render: (args) => (
         <LapisUrlContext.Provider value={LAPIS_URL}>
             <ReferenceGenomeContext.Provider value={referenceGenome}>
-                <MutationFilter initialValue={args.initialValue} />
+                <MutationFilter initialValue={args.initialValue} width={args.width} height={args.height} />
             </ReferenceGenomeContext.Provider>
         </LapisUrlContext.Provider>
     ),
@@ -166,6 +164,8 @@ export const WithInitialValue: StoryObj<MutationFilterProps> = {
             nucleotideInsertions: ['ins_123:AAA'],
             aminoAcidInsertions: ['ins_S:123:AAA'],
         },
+        width: '100%',
+        height: '700px',
     },
     play: async ({ canvasElement, step }) => {
         const { canvas, onBlurListenerMock } = await prepare(canvasElement, step);

--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -7,7 +7,7 @@ import { type Deletion, type Insertion, type Mutation, type Substitution } from 
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
 import { ErrorBoundary } from '../components/error-boundary';
 import Info from '../components/info';
-import { ResizeContainer, type Size } from '../components/resize-container';
+import { ResizeContainer } from '../components/resize-container';
 import { singleGraphColorRGBByName } from '../shared/charts/colors';
 import { DeleteIcon } from '../shared/icons/DeleteIcon';
 
@@ -16,7 +16,8 @@ export interface MutationFilterInnerProps {
 }
 
 export interface MutationFilterProps extends MutationFilterInnerProps {
-    size?: Size;
+    width: string;
+    height: string;
 }
 
 export type SelectedFilters = {
@@ -30,12 +31,12 @@ export type SelectedMutationFilterStrings = {
     [Key in keyof SelectedFilters]: string[];
 };
 
-export const MutationFilter: FunctionComponent<MutationFilterProps> = ({ initialValue, size }) => {
-    const defaultSize = { width: '100%', height: '6.5rem' };
+export const MutationFilter: FunctionComponent<MutationFilterProps> = ({ initialValue, width, height }) => {
+    const size = { height, width };
 
     return (
-        <ErrorBoundary size={size} defaultSize={defaultSize}>
-            <ResizeContainer size={size} defaultSize={defaultSize}>
+        <ErrorBoundary size={size}>
+            <ResizeContainer size={size}>
                 <MutationFilterInner initialValue={initialValue} />
             </ResizeContainer>
         </ErrorBoundary>

--- a/components/src/preact/mutations/mutations.stories.tsx
+++ b/components/src/preact/mutations/mutations.stories.tsx
@@ -22,7 +22,8 @@ const meta: Meta<MutationsProps> = {
             options: ['table', 'grid', 'insertions'],
             control: { type: 'check' },
         },
-        size: [{ control: 'object' }],
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
 };
@@ -37,7 +38,8 @@ const Template = {
                     variant={args.variant}
                     sequenceType={args.sequenceType}
                     views={args.views}
-                    size={args.size}
+                    width={args.width}
+                    height={args.height}
                     headline={args.headline}
                 />
             </ReferenceGenomeContext.Provider>
@@ -51,7 +53,8 @@ export const Default: StoryObj<MutationsProps> = {
         variant: { country: 'Switzerland', pangoLineage: 'B.1.1.7', dateTo: '2022-01-01' },
         sequenceType: 'nucleotide',
         views: ['grid', 'table', 'insertions'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Mutations',
     },
     parameters: {

--- a/components/src/preact/mutations/mutations.tsx
+++ b/components/src/preact/mutations/mutations.tsx
@@ -25,7 +25,7 @@ import { type DisplayedMutationType, MutationTypeSelector } from '../components/
 import { NoDataDisplay } from '../components/no-data-display';
 import type { ProportionInterval } from '../components/proportion-selector';
 import { ProportionSelectorDropdown } from '../components/proportion-selector-dropdown';
-import { ResizeContainer, type Size } from '../components/resize-container';
+import { ResizeContainer } from '../components/resize-container';
 import Tabs from '../components/tabs';
 import { useQuery } from '../useQuery';
 
@@ -38,7 +38,8 @@ export interface MutationsInnerProps {
 }
 
 export interface MutationsProps extends MutationsInnerProps {
-    size?: Size;
+    width: string;
+    height: string;
     headline?: string;
 }
 
@@ -46,14 +47,15 @@ export const Mutations: FunctionComponent<MutationsProps> = ({
     variant,
     sequenceType,
     views,
-    size,
+    width,
+    height,
     headline = 'Mutations',
 }) => {
-    const defaultSize = { height: '600px', width: '100%' };
+    const size = { height, width };
 
     return (
-        <ErrorBoundary size={size} defaultSize={defaultSize} headline={headline}>
-            <ResizeContainer size={size} defaultSize={defaultSize}>
+        <ErrorBoundary size={size} headline={headline}>
+            <ResizeContainer size={size}>
                 <Headline heading={headline}>
                     <MutationsInner variant={variant} sequenceType={sequenceType} views={views} />
                 </Headline>

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
@@ -29,7 +29,8 @@ export default {
             options: ['wilson'],
             control: { type: 'check' },
         },
-        size: [{ control: 'object' }],
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
 };
@@ -44,7 +45,8 @@ const Template = {
                 smoothingWindow={args.smoothingWindow}
                 views={args.views}
                 confidenceIntervalMethods={args.confidenceIntervalMethods}
-                size={args.size}
+                width={args.width}
+                height={args.height}
                 headline={args.headline}
             />
         </LapisUrlContext.Provider>
@@ -63,7 +65,8 @@ export const TwoVariants = {
         smoothingWindow: 0,
         views: ['bar', 'line', 'bubble', 'table'],
         confidenceIntervalMethods: ['wilson'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Prevalence over time',
     },
     parameters: {
@@ -130,7 +133,8 @@ export const OneVariant = {
         smoothingWindow: 7,
         views: ['bar', 'line', 'bubble', 'table'],
         confidenceIntervalMethods: ['wilson'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Prevalence over time',
     },
     parameters: {

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -17,7 +17,7 @@ import Headline from '../components/headline';
 import Info, { InfoHeadline1, InfoParagraph } from '../components/info';
 import { LoadingDisplay } from '../components/loading-display';
 import { NoDataDisplay } from '../components/no-data-display';
-import { ResizeContainer, type Size } from '../components/resize-container';
+import { ResizeContainer } from '../components/resize-container';
 import { ScalingSelector } from '../components/scaling-selector';
 import Tabs from '../components/tabs';
 import { type ConfidenceIntervalMethod } from '../shared/charts/confideceInterval';
@@ -27,7 +27,8 @@ import { useQuery } from '../useQuery';
 export type View = 'bar' | 'line' | 'bubble' | 'table';
 
 export interface PrevalenceOverTimeProps extends PrevalenceOverTimeInnerProps {
-    size?: Size;
+    width: string;
+    height: string;
     headline?: string;
 }
 
@@ -47,14 +48,15 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
     smoothingWindow,
     views,
     confidenceIntervalMethods,
-    size,
+    width,
+    height,
     headline = 'Prevalence over time',
 }) => {
-    const defaultSize = { height: '600px', width: '100%' };
+    const size = { height, width };
 
     return (
-        <ErrorBoundary size={size} defaultSize={defaultSize} headline={headline}>
-            <ResizeContainer size={size} defaultSize={defaultSize}>
+        <ErrorBoundary size={size} headline={headline}>
+            <ResizeContainer size={size}>
                 <Headline heading={headline}>
                     <PrevalenceOverTimeInner
                         numerator={numerator}

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.stories.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.stories.tsx
@@ -18,7 +18,8 @@ export default {
             options: ['line'],
             control: { type: 'check' },
         },
-        size: [{ control: 'object' }],
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
 };
@@ -31,7 +32,8 @@ export const Primary = {
                 denominator={args.denominator}
                 generationTime={args.generationTime}
                 views={args.views}
-                size={args.size}
+                width={args.width}
+                height={args.height}
                 headline={args.headline}
             />
         </LapisUrlContext.Provider>
@@ -41,7 +43,8 @@ export const Primary = {
         denominator: { country: 'Switzerland', dateFrom: '2020-12-01', dateTo: '2021-03-01' },
         generationTime: 7,
         views: ['line'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Relative growth advantage',
     },
     parameters: {

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -14,7 +14,7 @@ import Headline from '../components/headline';
 import Info, { InfoHeadline1, InfoHeadline2, InfoLink, InfoParagraph } from '../components/info';
 import { LoadingDisplay } from '../components/loading-display';
 import { NoDataDisplay } from '../components/no-data-display';
-import { ResizeContainer, type Size } from '../components/resize-container';
+import { ResizeContainer } from '../components/resize-container';
 import { ScalingSelector } from '../components/scaling-selector';
 import Tabs from '../components/tabs';
 import { type ScaleType } from '../shared/charts/getYAxisScale';
@@ -23,7 +23,8 @@ import { useQuery } from '../useQuery';
 export type View = 'line';
 
 export interface RelativeGrowthAdvantageProps extends RelativeGrowthAdvantagePropsInner {
-    size?: Size;
+    width: string;
+    height: string;
     headline?: string;
 }
 
@@ -36,17 +37,18 @@ export interface RelativeGrowthAdvantagePropsInner {
 
 export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageProps> = ({
     views,
-    size,
+    width,
+    height,
     numerator,
     denominator,
     generationTime,
     headline = 'Relative growth advantage',
 }) => {
-    const defaultSize = { height: '600px', width: '100%' };
+    const size = { height, width };
 
     return (
-        <ErrorBoundary size={size} defaultSize={defaultSize} headline={headline}>
-            <ResizeContainer size={size} defaultSize={defaultSize}>
+        <ErrorBoundary size={size} headline={headline}>
+            <ResizeContainer size={size}>
                 <Headline heading={headline}>
                     <RelativeGrowthAdvantageInner
                         views={views}
@@ -60,7 +62,7 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
     );
 };
 
-export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvantageProps> = ({
+export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvantagePropsInner> = ({
     numerator,
     denominator,
     generationTime,

--- a/components/src/preact/textInput/text-input.stories.tsx
+++ b/components/src/preact/textInput/text-input.stories.tsx
@@ -33,6 +33,29 @@ const meta: Meta<TextInputProps> = {
         },
     },
     decorators: [withActions],
+    argTypes: {
+        lapisField: {
+            control: {
+                type: 'select',
+            },
+            options: ['host'],
+        },
+        placeholderText: {
+            control: {
+                type: 'text',
+            },
+        },
+        initialValue: {
+            control: {
+                type: 'text',
+            },
+        },
+        width: {
+            control: {
+                type: 'text',
+            },
+        },
+    },
 };
 
 export default meta;
@@ -44,12 +67,15 @@ export const Default: StoryObj<TextInputProps> = {
                 lapisField={args.lapisField}
                 placeholderText={args.placeholderText}
                 initialValue={args.initialValue}
+                width={args.width}
             />
         </LapisUrlContext.Provider>
     ),
     args: {
         lapisField: 'host',
         placeholderText: 'Enter a host name',
+        initialValue: '',
+        width: '100%',
     },
 };
 

--- a/components/src/preact/textInput/text-input.tsx
+++ b/components/src/preact/textInput/text-input.tsx
@@ -17,16 +17,15 @@ export interface TextInputInnerProps {
 }
 
 export interface TextInputProps extends TextInputInnerProps {
-    width?: string;
+    width: string;
 }
 
 export const TextInput: FunctionComponent<TextInputProps> = ({ width, lapisField, placeholderText, initialValue }) => {
-    const defaultSize = { width: '100%', height: '3rem' };
-    const size = width === undefined ? undefined : { width, height: defaultSize.height };
+    const size = { width, height: '3rem' };
 
     return (
-        <ErrorBoundary defaultSize={defaultSize} size={size}>
-            <ResizeContainer size={size} defaultSize={defaultSize}>
+        <ErrorBoundary size={size}>
+            <ResizeContainer size={size}>
                 <TextInputInner lapisField={lapisField} placeholderText={placeholderText} initialValue={initialValue} />
             </ResizeContainer>
         </ErrorBoundary>

--- a/components/src/web-components/input/gs-date-range-selector.tsx
+++ b/components/src/web-components/input/gs-date-range-selector.tsx
@@ -76,13 +76,10 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
     /**
      * The width of the component.
      *
-     * If not set, the component will take the full width of its container.
-     *
-     * The width should be a string with a unit in css style, e.g. '100%', '500px' or '50vw'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    width: string | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
 
     /**
      * The name of the column in LAPIS that contains the date information.

--- a/components/src/web-components/input/gs-location-filter.tsx
+++ b/components/src/web-components/input/gs-location-filter.tsx
@@ -51,13 +51,10 @@ export class LocationFilterComponent extends PreactLitAdapter {
     /**
      * The width of the component.
      *
-     * If not set, the component will take the full width of its container.
-     *
-     * The width should be a string with a unit in css style, e.g. '100%', '500px' or '50vw'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    width: string | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
 
     override render() {
         return <LocationFilter initialValue={this.initialValue} fields={this.fields} width={this.width} />;

--- a/components/src/web-components/input/gs-mutation-filter.stories.ts
+++ b/components/src/web-components/input/gs-mutation-filter.stories.ts
@@ -13,7 +13,8 @@ import './gs-mutation-filter';
 const codeExample = String.raw`
 <gs-mutation-filter 
     initialValue='["A123T"]'
-    size='{ "width": "100%", "height": "6.5rem" }'
+    width='100%'
+    height='6.5rem'
 ></gs-mutation-filter>`;
 
 const meta: Meta<MutationFilterProps> = {
@@ -36,11 +37,8 @@ const meta: Meta<MutationFilterProps> = {
                 type: 'object',
             },
         },
-        size: {
-            control: {
-                type: 'object',
-            },
-        },
+        width: { control: 'text' },
+        height: { control: 'text' },
     },
     decorators: [withActions],
     tags: ['autodocs'],
@@ -52,13 +50,18 @@ const Template: StoryObj<MutationFilterProps> = {
     render: (args) => {
         return html` <gs-app lapis="${LAPIS_URL}">
             <div class="max-w-screen-lg">
-                <gs-mutation-filter .initialValue=${args.initialValue} .size=${args.size}></gs-mutation-filter>
+                <gs-mutation-filter
+                    .initialValue=${args.initialValue}
+                    .width=${args.width}
+                    .height=${args.height}
+                ></gs-mutation-filter>
             </div>
         </gs-app>`;
     },
     args: {
         initialValue: [],
-        size: { width: '100%', height: '3rem' },
+        width: '100%',
+        height: '3rem',
     },
 };
 

--- a/components/src/web-components/input/gs-mutation-filter.tsx
+++ b/components/src/web-components/input/gs-mutation-filter.tsx
@@ -75,29 +75,34 @@ export class MutationFilterComponent extends PreactLitAdapter {
     @property()
     initialValue:
         {
-              nucleotideMutations: string[];
-              aminoAcidMutations: string[];
-              nucleotideInsertions: string[];
-              aminoAcidInsertions: string[];
-          }
+            nucleotideMutations: string[];
+            aminoAcidMutations: string[];
+            nucleotideInsertions: string[];
+            aminoAcidInsertions: string[];
+        }
         | string[]
         | undefined = undefined;
 
     /**
-     * The size of the component.
+     * The width of the component.
      *
-     * If not set, the component will take the full width of its container with height 700px.
-     *
-     * The width and height should be a string with a unit in css style, e.g. '100%', '500px' or '50vh'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    size: { width?: string; height?: string } | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
+
+    /**
+     * The height of the component.
+     *
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
+     */
+    @property({ type: String })
+    height: string = '6.5rem';
 
     override render() {
         return (
             <ReferenceGenomesAwaiter>
-                <MutationFilter initialValue={this.initialValue} size={this.size} />
+                <MutationFilter initialValue={this.initialValue} width={this.width} height={this.height} />
             </ReferenceGenomesAwaiter>
         );
     }

--- a/components/src/web-components/input/gs-text-input.tsx
+++ b/components/src/web-components/input/gs-text-input.tsx
@@ -43,13 +43,10 @@ export class TextInputComponent extends PreactLitAdapter {
     /**
      * The width of the component.
      *
-     * If not set, the component will take the full width of its container.
-     *
-     * The width should be a string with a unit in css style, e.g. '100%', '500px' or '50vw'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    width: string | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
 
     override render() {
         return (

--- a/components/src/web-components/visualization/gs-aggregate.stories.ts
+++ b/components/src/web-components/visualization/gs-aggregate.stories.ts
@@ -9,6 +9,16 @@ import type { AggregateProps } from '../../preact/aggregatedData/aggregate';
 import './gs-aggregate';
 import '../app';
 
+const codeExample = `
+<gs-aggregate 
+    fields='["division", "host"]'
+    filter='{"country": "USA"}'
+    views='["table"]'
+    headline="Aggregate"
+    width='100%'
+    height='700px'
+></gs-aggregate>`;
+
 const meta: Meta<Required<AggregateProps>> = {
     title: 'Visualization/Aggregate',
     component: 'gs-aggregate',
@@ -18,7 +28,8 @@ const meta: Meta<Required<AggregateProps>> = {
             options: ['table'],
             control: { type: 'check' },
         },
-        size: [{ control: 'object' }],
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
     parameters: withComponentDocs({
@@ -43,7 +54,7 @@ const meta: Meta<Required<AggregateProps>> = {
         componentDocs: {
             opensShadowDom: true,
             expectsChildren: false,
-            codeExample: `<gs-aggregate fields='["division", "host"]' filter='{"country": "USA"}' views='["table"]'></gs-aggregate>`,
+            codeExample,
         },
     }),
     tags: ['autodocs'],
@@ -58,7 +69,8 @@ export const Table: StoryObj<Required<AggregateProps>> = {
                 .fields=${args.fields}
                 .filter=${args.filter}
                 .views=${args.views}
-                .size=${args.size}
+                .width=${args.width}
+                .height=${args.height}
                 .headline=${args.headline}
             ></gs-aggregate>
         </gs-app>
@@ -69,7 +81,8 @@ export const Table: StoryObj<Required<AggregateProps>> = {
         filter: {
             country: 'USA',
         },
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Aggregate',
     },
 };

--- a/components/src/web-components/visualization/gs-aggregate.tsx
+++ b/components/src/web-components/visualization/gs-aggregate.tsx
@@ -44,15 +44,20 @@ export class AggregateComponent extends PreactLitAdapterWithGridJsStyles {
     filter: LapisFilter = {};
 
     /**
-     * The size of the component.
+     * The width of the component.
      *
-     * If not set, the component will take the full width of its container with height 700px.
-     *
-     * The width and height should be a string with a unit in css style, e.g. '100%', '500px' or '50vh'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    size: { width?: string; height?: string } | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
+
+    /**
+     * The height of the component.
+     *
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
+     */
+    @property({ type: String })
+    height: string = '700px';
 
     /**
      * The headline of the component. Set to an empty string to hide the headline.
@@ -66,7 +71,8 @@ export class AggregateComponent extends PreactLitAdapterWithGridJsStyles {
                 fields={this.fields}
                 views={this.views}
                 filter={this.filter}
-                size={this.size}
+                width={this.width}
+                height={this.height}
                 headline={this.headline}
             />
         );

--- a/components/src/web-components/visualization/gs-mutation-comparison.stories.ts
+++ b/components/src/web-components/visualization/gs-mutation-comparison.stories.ts
@@ -17,6 +17,8 @@ const codeExample = String.raw`
     sequenceType="nucleotide"
     views='["table", "venn"]'
     headline="Mutation comparison"
+    width='100%'
+    height='700px'
 ></gs-mutation-comparison>`;
 
 const meta: Meta<Required<MutationComparisonProps>> = {
@@ -32,7 +34,8 @@ const meta: Meta<Required<MutationComparisonProps>> = {
             options: ['table', 'venn'],
             control: { type: 'check' },
         },
-        size: { control: 'object' },
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
     parameters: withComponentDocs({
@@ -54,7 +57,8 @@ const Template: StoryObj<Required<MutationComparisonProps>> = {
                 .variants=${args.variants}
                 .sequenceType=${args.sequenceType}
                 .views=${args.views}
-                .size=${args.size}
+                .width=${args.width}
+                .height=${args.height}
                 .headline=${args.headline}
             ></gs-mutation-comparison>
         </gs-app>
@@ -84,7 +88,8 @@ export const Default: StoryObj<Required<MutationComparisonProps>> = {
         ],
         sequenceType: 'nucleotide',
         views: ['table', 'venn'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Mutation comparison',
     },
     parameters: {

--- a/components/src/web-components/visualization/gs-mutation-comparison.tsx
+++ b/components/src/web-components/visualization/gs-mutation-comparison.tsx
@@ -64,15 +64,20 @@ export class MutationComparisonComponent extends PreactLitAdapterWithGridJsStyle
     views: ('table' | 'venn')[] = ['table'];
 
     /**
-     * The size of the component.
+     * The width of the component.
      *
-     * If not set, the component will take the full width of its container with height 700px.
-     *
-     * The width and height should be a string with a unit in css style, e.g. '100%', '500px' or '50vh'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    size: { width?: string; height?: string } | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
+
+    /**
+     * The height of the component.
+     *
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
+     */
+    @property({ type: String })
+    height: string = '700px';
 
     /**
      * The headline of the component. Set to an empty string to hide the headline.
@@ -86,7 +91,8 @@ export class MutationComparisonComponent extends PreactLitAdapterWithGridJsStyle
                 variants={this.variants}
                 sequenceType={this.sequenceType}
                 views={this.views}
-                size={this.size}
+                width={this.width}
+                height={this.height}
                 headline={this.headline}
             />
         );

--- a/components/src/web-components/visualization/gs-mutations.stories.ts
+++ b/components/src/web-components/visualization/gs-mutations.stories.ts
@@ -17,6 +17,8 @@ const codeExample = String.raw`
     sequenceType="nucleotide"
     views='["grid", "table", "insertions"]'
     headline="Mutations"
+    width='100%'
+    height='700px'
 ></gs-mutations>`;
 
 const meta: Meta<Required<MutationsProps>> = {
@@ -32,14 +34,16 @@ const meta: Meta<Required<MutationsProps>> = {
             options: ['table', 'grid', 'insertions'],
             control: { type: 'check' },
         },
-        size: { control: 'object' },
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
     args: {
         variant: { country: 'Switzerland', pangoLineage: 'B.1.1.7', dateTo: '2022-01-01' },
         sequenceType: 'nucleotide',
         views: ['grid', 'table', 'insertions'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Mutations',
     },
     parameters: withComponentDocs({
@@ -61,7 +65,8 @@ const Template: StoryObj<Required<MutationsProps>> = {
                 .variant=${args.variant}
                 .sequenceType=${args.sequenceType}
                 .views=${args.views}
-                .size=${args.size}
+                .width=${args.width}
+                .height=${args.height}
                 .headline=${args.headline}
             ></gs-mutations>
         </gs-app>

--- a/components/src/web-components/visualization/gs-mutations.tsx
+++ b/components/src/web-components/visualization/gs-mutations.tsx
@@ -54,15 +54,20 @@ export class MutationsComponent extends PreactLitAdapterWithGridJsStyles {
     views: ('table' | 'grid' | 'insertions')[] = ['table', 'grid'];
 
     /**
-     * The size of the component.
+     * The width of the component.
      *
-     * If not set, the component will take the full width of its container with height 700px.
-     *
-     * The width and height should be a string with a unit in css style, e.g. '100%', '500px' or '50vh'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    size: { width?: string; height?: string } | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
+
+    /**
+     * The height of the component.
+     *
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
+     */
+    @property({ type: String })
+    height: string = '700px';
 
     /**
      * The headline of the component. Set to an empty string to hide the headline.
@@ -76,7 +81,8 @@ export class MutationsComponent extends PreactLitAdapterWithGridJsStyles {
                 variant={this.variant}
                 sequenceType={this.sequenceType}
                 views={this.views}
-                size={this.size}
+                width={this.width}
+                height={this.height}
                 headline={this.headline}
             />
         );

--- a/components/src/web-components/visualization/gs-prevalence-over-time.stories.ts
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.stories.ts
@@ -23,6 +23,8 @@ const codeExample = String.raw`
     views='["bar", "line", "bubble", "table"]'
     confidenceIntervalMethods='["wilson"]'
     headline="Prevalence over time"
+    width='100%'
+    height='700px'
 ></gs-prevalence-over-time>`;
 
 const meta: Meta<Required<PrevalenceOverTimeProps>> = {
@@ -44,7 +46,8 @@ const meta: Meta<Required<PrevalenceOverTimeProps>> = {
             options: ['wilson'],
             control: { type: 'check' },
         },
-        size: [{ control: 'object' }],
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
     parameters: withComponentDocs({
@@ -69,7 +72,8 @@ const Template: StoryObj<Required<PrevalenceOverTimeProps>> = {
                 .smoothingWindow=${args.smoothingWindow}
                 .views=${args.views}
                 .confidenceIntervalMethods=${args.confidenceIntervalMethods}
-                .size=${args.size}
+                .width=${args.width}
+                .height=${args.height}
                 .headline=${args.headline}
             ></gs-prevalence-over-time>
         </gs-app>
@@ -88,7 +92,8 @@ export const TwoVariants: StoryObj<Required<PrevalenceOverTimeProps>> = {
         smoothingWindow: 0,
         views: ['bar', 'line', 'bubble', 'table'],
         confidenceIntervalMethods: ['wilson'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Prevalence over time',
     },
     parameters: {
@@ -155,7 +160,8 @@ export const OneVariant: StoryObj<Required<PrevalenceOverTimeProps>> = {
         smoothingWindow: 7,
         views: ['bar', 'line', 'bubble', 'table'],
         confidenceIntervalMethods: ['wilson'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Prevalence over time',
     },
     parameters: {

--- a/components/src/web-components/visualization/gs-prevalence-over-time.tsx
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.tsx
@@ -57,8 +57,8 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
     numerator:
         (Record<string, string | number | null | boolean> & { displayName: string })
         | (Record<string, string | number | null | boolean> & {
-              displayName: string;
-          })[] = { displayName: '' };
+        displayName: string;
+    })[] = { displayName: '' };
 
     /**
      * The variant that the variants in `numerator` are compared to.
@@ -105,15 +105,20 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
     headline: string = 'Prevalence over time';
 
     /**
-     * The size of the component.
+     * The width of the component.
      *
-     * If not set, the component will take the full width of its container with height 700px.
-     *
-     * The width and height should be a string with a unit in css style, e.g. '100%', '500px' or '50vh'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    size: { width?: string; height?: string } | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
+
+    /**
+     * The height of the component.
+     *
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
+     */
+    @property({ type: String })
+    height: string = '700px';
 
     override render() {
         return (
@@ -124,7 +129,8 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
                 smoothingWindow={this.smoothingWindow}
                 views={this.views}
                 confidenceIntervalMethods={this.confidenceIntervalMethods}
-                size={this.size}
+                width={this.width}
+                height={this.height}
                 headline={this.headline}
             />
         );

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.stories.ts
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.stories.ts
@@ -15,6 +15,8 @@ const codeExample = String.raw`
     denominator='{ "country": "Switzerland", "dateFrom": "2020-12-01" }'
     generationTime="7"
     views='["line"]'
+    width='100%'
+    height='700px'
     headline="Relative growth advantage"
 ></gs-relative-growth-advantage>`;
 
@@ -29,7 +31,8 @@ const meta: Meta<RelativeGrowthAdvantageProps> = {
             options: ['line'],
             control: { type: 'check' },
         },
-        size: [{ control: 'object' }],
+        width: { control: 'text' },
+        height: { control: 'text' },
         headline: { control: 'text' },
     },
     parameters: withComponentDocs({
@@ -52,7 +55,8 @@ const Template: StoryObj<Required<RelativeGrowthAdvantageProps>> = {
                 .denominator=${args.denominator}
                 .generationTime=${args.generationTime}
                 .views=${args.views}
-                .size=${args.size}
+                .width=${args.width}
+                .height=${args.height}
                 .headline=${args.headline}
             ></gs-relative-growth-advantage>
         </gs-app>
@@ -66,7 +70,8 @@ export const Default: StoryObj<Required<RelativeGrowthAdvantageProps>> = {
         denominator: { country: 'Switzerland', dateFrom: '2020-12-01', dateTo: '2021-03-01' },
         generationTime: 7,
         views: ['line'],
-        size: { width: '100%', height: '700px' },
+        width: '100%',
+        height: '700px',
         headline: 'Relative growth advantage',
     },
     parameters: {

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
@@ -65,15 +65,20 @@ export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {
     headline: string = 'Relative growth advantage';
 
     /**
-     * The size of the component.
+     * The width of the component.
      *
-     * If not set, the component will take the full width of its container with height 700px.
-     *
-     * The width and height should be a string with a unit in css style, e.g. '100%', '500px' or '50vh'.
-     * If the unit is %, the size will be relative to the container of the component.
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
      */
-    @property({ type: Object })
-    size: { width?: string; height?: string } | undefined = undefined;
+    @property({ type: String })
+    width: string = '100%';
+
+    /**
+     * The height of the component.
+     *
+     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
+     */
+    @property({ type: String })
+    height: string = '700px';
 
     override render() {
         return (
@@ -82,7 +87,8 @@ export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {
                 denominator={this.denominator}
                 generationTime={this.generationTime}
                 views={this.views}
-                size={this.size}
+                width={this.width}
+                height={this.height}
                 headline={this.headline}
             />
         );

--- a/examples/React/src/App.tsx
+++ b/examples/React/src/App.tsx
@@ -66,7 +66,8 @@ function App() {
                     granularity='day'
                     smoothingWindow='7'
                     views='["line", "table"]'
-                    size={JSON.stringify({ height: '300px', width: '800px' })}
+                    width='800px'
+                    height='300px'
                 ></gs-prevalence-over-time>
                 <div style={{ height: '300px', width: '1000px' }}>
                     <gs-prevalence-over-time
@@ -75,7 +76,8 @@ function App() {
                         granularity='day'
                         smoothingWindow='7'
                         views='["line", "table"]'
-                        size={JSON.stringify({ height: '100%', width: '80%' })}
+                        width='80%'
+                        height='100%'
                     ></gs-prevalence-over-time>
                 </div>
             </div>


### PR DESCRIPTION
BREAKING CHANGE: remove size property from components and use width and height 

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #237

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
