### PR TITLE
235 make info button mobile friendly

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.3.2",
             "license": "AGPL-3.0-only",
             "dependencies": {
+                "@floating-ui/dom": "^1.6.5",
                 "@lit/context": "^1.1.1",
                 "@lit/reactive-element": "^2.0.4",
                 "@lit/task": "^1.0.0",
@@ -2704,6 +2705,28 @@
             "resolved": "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz",
             "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
             "dev": true
+        },
+        "node_modules/@floating-ui/core": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
+            "integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.0"
+            }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.6.5",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
+            "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
+            "dependencies": {
+                "@floating-ui/core": "^1.0.0",
+                "@floating-ui/utils": "^0.2.0"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
+            "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
         },
         "node_modules/@github/catalyst": {
             "version": "1.6.0",

--- a/components/package.json
+++ b/components/package.json
@@ -56,6 +56,7 @@
         "lit"
     ],
     "dependencies": {
+        "@floating-ui/dom": "^1.6.5",
         "@lit/context": "^1.1.1",
         "@lit/reactive-element": "^2.0.4",
         "@lit/task": "^1.0.0",

--- a/components/src/preact/aggregatedData/aggregate.tsx
+++ b/components/src/preact/aggregatedData/aggregate.tsx
@@ -103,7 +103,7 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({ data }) => {
     return (
         <div class='flex flex-row'>
             <CsvDownloadButton className='mx-1 btn btn-xs' getData={() => data} filename='aggregate.csv' />
-            <Info>Info for aggregate</Info>
+            <Info height={'100px'}>Info for aggregate</Info>
         </div>
     );
 };

--- a/components/src/preact/components/info.stories.tsx
+++ b/components/src/preact/components/info.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<InfoProps> = {
     component: Info,
     parameters: { fetchMock: {} },
     args: {
-        size: { width: '400px', height: '100px' },
+        height: '100px',
     },
 };
 

--- a/components/src/preact/components/info.stories.tsx
+++ b/components/src/preact/components/info.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
-import { expect, fireEvent, waitFor, within } from '@storybook/test';
+import { expect, userEvent, waitFor, within } from '@storybook/test';
 
 import Info, { type InfoProps } from './info';
 
@@ -28,16 +28,16 @@ export const ShowsInfoOnClick: StoryObj<InfoProps> = {
     ...InfoStory,
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        const loading = canvas.getByRole('button', { name: '?' });
+        const openInfo = canvas.getByRole('button', { name: '?' });
 
-        await waitFor(() => expect(loading).toBeInTheDocument());
+        await waitFor(() => expect(openInfo).toBeInTheDocument());
 
-        await fireEvent.click(loading);
+        await userEvent.click(openInfo);
 
-        await waitFor(() => expect(canvas.getByText(tooltipText, { exact: false })).toBeInTheDocument());
+        await waitFor(() => expect(canvas.getByText(tooltipText, { exact: false })).toBeVisible());
 
-        await fireEvent.click(canvas.getByRole('button', { name: 'Close' }));
+        await userEvent.click(document.body);
 
-        await waitFor(() => expect(canvas.queryByText(tooltipText, { exact: false })).not.toBeInTheDocument());
+        await waitFor(() => expect(canvas.queryByText(tooltipText, { exact: false })).not.toBeVisible());
     },
 };

--- a/components/src/preact/components/info.tsx
+++ b/components/src/preact/components/info.tsx
@@ -14,7 +14,7 @@ const Info: FunctionComponent<InfoProps> = ({ children, height }) => {
 
     return (
         <div className='relative'>
-            <button className='btn btn-xs' onClick={toggleHelp}>
+            <button type='button' className='btn btn-xs' onClick={toggleHelp}>
                 ?
             </button>
             {showHelp && (

--- a/components/src/preact/components/info.tsx
+++ b/components/src/preact/components/info.tsx
@@ -1,5 +1,7 @@
+import { autoUpdate, computePosition, offset, shift, size } from '@floating-ui/dom';
 import { type FunctionComponent } from 'preact';
-import { useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { type MutableRefObject } from 'react';
 
 export interface InfoProps {
     height?: string;
@@ -7,32 +9,126 @@ export interface InfoProps {
 
 const Info: FunctionComponent<InfoProps> = ({ children, height }) => {
     const [showHelp, setShowHelp] = useState(false);
+    const referenceRef = useRef<HTMLButtonElement>(null);
+    const floatingRef = useRef<HTMLDivElement>(null);
+
+    useFloatingUi(referenceRef, floatingRef, height, showHelp);
 
     const toggleHelp = () => {
         setShowHelp(!showHelp);
     };
 
+    useCloseOnEsc(setShowHelp);
+    useCloseOnClickOutside(floatingRef, referenceRef, setShowHelp);
+
     return (
-        <div className='relative'>
-            <button type='button' className='btn btn-xs' onClick={toggleHelp}>
+        <div className='relative z-10'>
+            <button type='button' className='btn btn-xs' onClick={toggleHelp} ref={referenceRef}>
                 ?
             </button>
-            {showHelp && (
-                <div
-                    className='absolute top-8 right-6 bg-white p-2 border border-black flex flex-col overflow-auto shadow-lg rounded z-50 max-w-72 sm:max-w-xl '
-                    style={{ width: 'max-content', height }}
+            <div
+                ref={floatingRef}
+                className='bg-white p-2 border border-gray-100 shadow-lg rounded overflow-y-auto opacity-90'
+                style={{ position: 'absolute', zIndex: 10, display: showHelp ? '' : 'none' }}
+            >
+                <div className={'flex flex-col'}>{children}</div>
+                <button
+                    onClick={() => setShowHelp(false)}
+                    className={'float-right underline text-sm hover:text-blue-700 mr-2'}
                 >
-                    <div className='flex flex-col'>{children}</div>
-                    <div className='flex justify-end'>
-                        <button className='text-sm underline mt-2' onClick={toggleHelp}>
-                            Close
-                        </button>
-                    </div>
-                </div>
-            )}
+                    Close
+                </button>
+            </div>
         </div>
     );
 };
+
+function useFloatingUi(
+    referenceRef: MutableRefObject<HTMLButtonElement | null>,
+    floatingRef: MutableRefObject<HTMLDivElement | null>,
+    height: string | undefined,
+    showHelp: boolean,
+) {
+    const cleanupRef = useRef<Function | null>(null);
+
+    useEffect(() => {
+        if (!referenceRef.current || !floatingRef.current) {
+            return;
+        }
+
+        const { current: reference } = referenceRef;
+        const { current: floating } = floatingRef;
+
+        const update = () => {
+            computePosition(reference, floating, {
+                middleware: [
+                    offset(10),
+                    shift(),
+                    size({
+                        apply({}) {
+                            floating.style.width = '100vw';
+                            floating.style.height = height ? height : '50vh';
+                        },
+                    }),
+                ],
+            }).then(({ x, y }) => {
+                floating.style.left = `${x}px`;
+                floating.style.top = `${y}px`;
+            });
+        };
+
+        update();
+        cleanupRef.current = autoUpdate(reference, floating, update);
+
+        return () => {
+            if (cleanupRef.current) {
+                cleanupRef.current();
+            }
+        };
+    }, [showHelp, height, referenceRef, floatingRef]);
+}
+
+function useCloseOnClickOutside(
+    floatingRef: MutableRefObject<HTMLDivElement | null>,
+    referenceRef: MutableRefObject<HTMLButtonElement | null>,
+    setShowHelp: (value: ((prevState: boolean) => boolean) | boolean) => void,
+) {
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            const path = event.composedPath();
+            if (
+                floatingRef.current &&
+                !path.includes(floatingRef.current) &&
+                referenceRef.current &&
+                !path.includes(referenceRef.current)
+            ) {
+                setShowHelp(false);
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [floatingRef, referenceRef, setShowHelp]);
+}
+
+function useCloseOnEsc(setShowHelp: (value: ((prevState: boolean) => boolean) | boolean) => void) {
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setShowHelp(false);
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [setShowHelp]);
+}
 
 export const InfoHeadline1: FunctionComponent = ({ children }) => {
     return <h1 className='text-lg font-bold'>{children}</h1>;

--- a/components/src/preact/components/info.tsx
+++ b/components/src/preact/components/info.tsx
@@ -2,13 +2,10 @@ import { type FunctionComponent } from 'preact';
 import { useState } from 'preact/hooks';
 
 export interface InfoProps {
-    size?: {
-        height?: string;
-        width?: string;
-    };
+    height?: string;
 }
 
-const Info: FunctionComponent<InfoProps> = ({ children, size }) => {
+const Info: FunctionComponent<InfoProps> = ({ children, height }) => {
     const [showHelp, setShowHelp] = useState(false);
 
     const toggleHelp = () => {
@@ -22,8 +19,8 @@ const Info: FunctionComponent<InfoProps> = ({ children, size }) => {
             </button>
             {showHelp && (
                 <div
-                    className='absolute top-8 right-6 bg-white p-2 border border-black flex flex-col overflow-auto shadow-lg rounded z-50'
-                    style={size}
+                    className='absolute top-8 right-6 bg-white p-2 border border-black flex flex-col overflow-auto shadow-lg rounded z-50 max-w-72 sm:max-w-xl '
+                    style={{ width: 'max-content', height }}
                 >
                     <div className='flex flex-col'>{children}</div>
                     <div className='flex justify-end'>

--- a/components/src/preact/mutationComparison/mutation-comparison.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.tsx
@@ -183,7 +183,7 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
                 getData={() => getMutationComparisonTableData({ content: filteredData }, proportionInterval)}
                 filename='mutation_comparison.csv'
             />
-            <Info>Info for mutation comparison</Info>
+            <Info height={'100px'}>Info for mutation comparison</Info>
         </div>
     );
 };

--- a/components/src/preact/mutationFilter/mutation-filter.stories.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.stories.tsx
@@ -20,7 +20,6 @@ const meta: Meta<MutationFilterProps> = {
     },
     argTypes: {
         width: { control: 'text' },
-        height: { control: 'text' },
         initialValue: {
             control: {
                 type: 'object',
@@ -36,13 +35,12 @@ export const Default: StoryObj<MutationFilterProps> = {
     render: (args) => (
         <LapisUrlContext.Provider value={LAPIS_URL}>
             <ReferenceGenomeContext.Provider value={referenceGenome}>
-                <MutationFilter width={args.width} height={args.height} initialValue={args.initialValue} />
+                <MutationFilter width={args.width} initialValue={args.initialValue} />
             </ReferenceGenomeContext.Provider>
         </LapisUrlContext.Provider>
     ),
     args: {
         width: '100%',
-        height: '700px',
     },
 };
 
@@ -106,7 +104,7 @@ export const FiresFilterChangedEvents: StoryObj<MutationFilterProps> = {
         });
 
         await step('Remove the first mutation', async () => {
-            const firstMutationDeleteButton = canvas.getAllByRole('button')[0];
+            const firstMutationDeleteButton = canvas.getAllByRole('button')[1];
             await waitFor(() => fireEvent.click(firstMutationDeleteButton));
 
             await expect(changedListenerMock).toHaveBeenCalledWith(
@@ -153,7 +151,7 @@ export const WithInitialValue: StoryObj<MutationFilterProps> = {
     render: (args) => (
         <LapisUrlContext.Provider value={LAPIS_URL}>
             <ReferenceGenomeContext.Provider value={referenceGenome}>
-                <MutationFilter initialValue={args.initialValue} width={args.width} height={args.height} />
+                <MutationFilter initialValue={args.initialValue} width={args.width} />
             </ReferenceGenomeContext.Provider>
         </LapisUrlContext.Provider>
     ),
@@ -165,7 +163,6 @@ export const WithInitialValue: StoryObj<MutationFilterProps> = {
             aminoAcidInsertions: ['ins_S:123:AAA'],
         },
         width: '100%',
-        height: '700px',
     },
     play: async ({ canvasElement, step }) => {
         const { canvas, onBlurListenerMock } = await prepare(canvasElement, step);

--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -101,9 +101,9 @@ export const MutationFilterInner: FunctionComponent<MutationFilterInnerProps> = 
     };
 
     return (
-        <form className='w-full  border boder-gray-300 rounded-md' onSubmit={handleSubmit} ref={formRef}>
-            <div className='absolute top-1 right-1'>
-                <Info height={`min(100vh, 300px`}>Info for mutation filter</Info>
+        <form className='w-full border boder-gray-300 rounded-md relative' onSubmit={handleSubmit} ref={formRef}>
+            <div className='absolute -top-3 -right-3'>
+                <Info height={'100px'}>Info for mutation filter</Info>
             </div>
             <div className='w-full flex p-2 flex-wrap items-center'>
                 <SelectedMutationDisplay
@@ -112,10 +112,10 @@ export const MutationFilterInner: FunctionComponent<MutationFilterInnerProps> = 
                     fireChangeEvent={fireChangeEvent}
                 />
                 <div
-                    className={`block w-full flex focus:outline-none focus:ring-0 border ${isError ? 'border-red-500' : 'border-gray-300'} border-solid m-2 text-sm`}
+                    className={`w-full flex border ${isError ? 'border-red-500' : 'border-gray-300'} border-solid m-2 text-sm focus-within:border-gray-400 `}
                 >
                     <input
-                        className='grow'
+                        className='grow flex-1 p-1 border-none focus:outline-none focus:ring-0'
                         type='text'
                         value={inputValue}
                         onInput={handleInputChange}

--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -7,7 +7,6 @@ import { type Deletion, type Insertion, type Mutation, type Substitution } from 
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
 import { ErrorBoundary } from '../components/error-boundary';
 import Info from '../components/info';
-import { ResizeContainer } from '../components/resize-container';
 import { singleGraphColorRGBByName } from '../shared/charts/colors';
 import { DeleteIcon } from '../shared/icons/DeleteIcon';
 
@@ -17,7 +16,6 @@ export interface MutationFilterInnerProps {
 
 export interface MutationFilterProps extends MutationFilterInnerProps {
     width: string;
-    height: string;
 }
 
 export type SelectedFilters = {
@@ -31,14 +29,12 @@ export type SelectedMutationFilterStrings = {
     [Key in keyof SelectedFilters]: string[];
 };
 
-export const MutationFilter: FunctionComponent<MutationFilterProps> = ({ initialValue, width, height }) => {
-    const size = { height, width };
-
+export const MutationFilter: FunctionComponent<MutationFilterProps> = ({ initialValue, width }) => {
     return (
-        <ErrorBoundary size={size}>
-            <ResizeContainer size={size}>
+        <ErrorBoundary size={{ height: '3.375rem', width }}>
+            <div style={width}>
                 <MutationFilterInner initialValue={initialValue} />
-            </ResizeContainer>
+            </div>
         </ErrorBoundary>
     );
 };
@@ -54,6 +50,9 @@ export const MutationFilterInner: FunctionComponent<MutationFilterInnerProps> = 
 
     const handleSubmit = (event: Event) => {
         event.preventDefault();
+        if (inputValue === '') {
+            return;
+        }
 
         const parsedMutation = parseAndValidateMutation(inputValue, referenceGenome);
 
@@ -102,30 +101,33 @@ export const MutationFilterInner: FunctionComponent<MutationFilterInnerProps> = 
     };
 
     return (
-        <div class={`h-full w-full rounded-lg border border-gray-300 bg-white p-2 overflow-scroll`}>
-            <div class='flex justify-between'>
+        <form className='w-full  border boder-gray-300 rounded-md' onSubmit={handleSubmit} ref={formRef}>
+            <div className='absolute top-1 right-1'>
+                <Info height={`min(100vh, 300px`}>Info for mutation filter</Info>
+            </div>
+            <div className='w-full flex p-2 flex-wrap items-center'>
                 <SelectedMutationDisplay
                     selectedFilters={selectedFilters}
                     setSelectedFilters={setSelectedFilters}
                     fireChangeEvent={fireChangeEvent}
                 />
-                <Info>Info for mutation filter</Info>
-            </div>
-
-            <form className='mt-2 w-full' onSubmit={handleSubmit} ref={formRef}>
-                <label className={`input flex items-center gap-2 ${isError ? 'input-error' : 'input-bordered'}`}>
+                <div
+                    className={`block w-full flex focus:outline-none focus:ring-0 border ${isError ? 'border-red-500' : 'border-gray-300'} border-solid m-2 text-sm`}
+                >
                     <input
-                        className='grow min-w-0'
+                        className='grow'
                         type='text'
                         value={inputValue}
                         onInput={handleInputChange}
                         placeholder={getPlaceholder(referenceGenome)}
                         onBlur={handleOnBlur}
                     />
-                    <button className='btn btn-sm'>+</button>
-                </label>
-            </form>
-        </div>
+                    <button type='submit' className='btn btn-xs m-1'>
+                        +
+                    </button>
+                </div>
+            </div>
+        </form>
     );
 };
 
@@ -193,44 +195,36 @@ const SelectedMutationDisplay: FunctionComponent<{
     };
 
     return (
-        <ul class='flex flex-wrap'>
+        <>
             {selectedFilters.nucleotideMutations.map((mutation) => (
-                <li key={mutation.toString()}>
-                    <SelectedNucleotideMutation
-                        mutation={mutation}
-                        onDelete={(mutation: Substitution | Deletion) =>
-                            onSelectedRemoved(mutation, 'nucleotideMutations')
-                        }
-                    />
-                </li>
+                <SelectedNucleotideMutation
+                    key={mutation.toString()}
+                    mutation={mutation}
+                    onDelete={(mutation: Substitution | Deletion) => onSelectedRemoved(mutation, 'nucleotideMutations')}
+                />
             ))}
             {selectedFilters.aminoAcidMutations.map((mutation) => (
-                <li key={mutation.toString()}>
-                    <SelectedAminoAcidMutation
-                        mutation={mutation}
-                        onDelete={(mutation: Substitution | Deletion) =>
-                            onSelectedRemoved(mutation, 'aminoAcidMutations')
-                        }
-                    />
-                </li>
+                <SelectedAminoAcidMutation
+                    key={mutation.toString()}
+                    mutation={mutation}
+                    onDelete={(mutation: Substitution | Deletion) => onSelectedRemoved(mutation, 'aminoAcidMutations')}
+                />
             ))}
             {selectedFilters.nucleotideInsertions.map((insertion) => (
-                <li key={insertion.toString()}>
-                    <SelectedNucleotideInsertion
-                        insertion={insertion}
-                        onDelete={(insertion) => onSelectedRemoved(insertion, 'nucleotideInsertions')}
-                    />
-                </li>
+                <SelectedNucleotideInsertion
+                    key={insertion.toString()}
+                    insertion={insertion}
+                    onDelete={(insertion) => onSelectedRemoved(insertion, 'nucleotideInsertions')}
+                />
             ))}
             {selectedFilters.aminoAcidInsertions.map((insertion) => (
-                <li key={insertion.toString()}>
-                    <SelectedAminoAcidInsertion
-                        insertion={insertion}
-                        onDelete={(insertion: Insertion) => onSelectedRemoved(insertion, 'aminoAcidInsertions')}
-                    />
-                </li>
+                <SelectedAminoAcidInsertion
+                    key={insertion.toString()}
+                    insertion={insertion}
+                    onDelete={(insertion: Insertion) => onSelectedRemoved(insertion, 'aminoAcidInsertions')}
+                />
             ))}
-        </ul>
+        </>
     );
 };
 
@@ -313,15 +307,15 @@ const SelectedFilter = <MutationType extends Mutation>({
     textColor,
 }: SelectedFilterProps<MutationType>) => {
     return (
-        <div
-            class='flex items-center flex-nowrap gap-1 rounded me-1 px-2.5 py-0.5 font-medium text-xs mb-1 min-w-max'
+        <span
+            class='inline-block mx-1 px-2 py-1 font-medium text-xs rounded-full'
             style={{ backgroundColor, color: textColor }}
         >
-            <div className='whitespace-nowrap min-w-max'>{mutation.toString()}</div>
+            {mutation.toString()}
             <button type='button' onClick={() => onDelete(mutation)}>
                 <DeleteIcon />
             </button>
-        </div>
+        </span>
     );
 };
 

--- a/components/src/preact/mutations/mutations.tsx
+++ b/components/src/preact/mutations/mutations.tsx
@@ -205,7 +205,7 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
                     filename='insertions.csv'
                 />
             )}
-            <Info>Info for mutations</Info>
+            <Info height={'100px'}>Info for mutations</Info>
         </div>
     );
 };

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -28,7 +28,7 @@ export type View = 'bar' | 'line' | 'bubble' | 'table';
 
 export interface PrevalenceOverTimeProps extends PrevalenceOverTimeInnerProps {
     width: string;
-    height: string;
+
     headline?: string;
 }
 
@@ -40,6 +40,7 @@ export interface PrevalenceOverTimeInnerProps {
     views: View[];
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     lapisDateField: string;
+    height: string;
 }
 
 export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
@@ -68,6 +69,7 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
                         views={views}
                         confidenceIntervalMethods={confidenceIntervalMethods}
                         lapisDateField={lapisDateField}
+                        height={height}
                     />
                 </Headline>
             </ResizeContainer>
@@ -83,6 +85,7 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
     views,
     confidenceIntervalMethods,
     lapisDateField,
+    height,
 }) => {
     const lapis = useContext(LapisUrlContext);
 
@@ -109,6 +112,7 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
             data={data}
             granularity={granularity}
             confidenceIntervalMethods={confidenceIntervalMethods}
+            height={height}
         />
     );
 };
@@ -118,6 +122,7 @@ type PrevalenceOverTimeTabsProps = {
     data: PrevalenceOverTimeData;
     granularity: TemporalGranularity;
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
+    height: string;
 };
 
 const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = ({
@@ -125,6 +130,7 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
     data,
     granularity,
     confidenceIntervalMethods,
+    height,
 }) => {
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
     const [confidenceIntervalMethod, setConfidenceIntervalMethod] = useState<ConfidenceIntervalMethod>(
@@ -180,6 +186,7 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
             confidenceIntervalMethods={confidenceIntervalMethods}
             confidenceIntervalMethod={confidenceIntervalMethod}
             setConfidenceIntervalMethod={setConfidenceIntervalMethod}
+            height={height}
         />
     );
 
@@ -195,6 +202,7 @@ type ToolbarProps = {
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     confidenceIntervalMethod: ConfidenceIntervalMethod;
     setConfidenceIntervalMethod: (confidenceIntervalMethod: ConfidenceIntervalMethod) => void;
+    height: string;
 };
 
 const Toolbar: FunctionComponent<ToolbarProps> = ({
@@ -206,6 +214,7 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
     setConfidenceIntervalMethod,
     data,
     granularity,
+    height,
 }) => {
     return (
         <div class='flex'>
@@ -225,14 +234,14 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
                 filename='prevalence-over-time.csv'
             />
 
-            <PrevalenceOverTimeInfo />
+            <PrevalenceOverTimeInfo height={height} />
         </div>
     );
 };
 
-const PrevalenceOverTimeInfo: FunctionComponent = () => {
+const PrevalenceOverTimeInfo: FunctionComponent<{ height: string }> = ({ height }) => {
     return (
-        <Info size={{ width: '600px', height: '30vh' }}>
+        <Info height={`min(100vh, 0.8*${height})`}>
             <InfoHeadline1>Prevalence over time</InfoHeadline1>
             <InfoParagraph>Prevalence over time info.</InfoParagraph>
         </Info>

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -28,7 +28,7 @@ export type View = 'bar' | 'line' | 'bubble' | 'table';
 
 export interface PrevalenceOverTimeProps extends PrevalenceOverTimeInnerProps {
     width: string;
-
+    height: string;
     headline?: string;
 }
 
@@ -40,7 +40,6 @@ export interface PrevalenceOverTimeInnerProps {
     views: View[];
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     lapisDateField: string;
-    height: string;
 }
 
 export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
@@ -69,7 +68,6 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
                         views={views}
                         confidenceIntervalMethods={confidenceIntervalMethods}
                         lapisDateField={lapisDateField}
-                        height={height}
                     />
                 </Headline>
             </ResizeContainer>
@@ -85,7 +83,6 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
     views,
     confidenceIntervalMethods,
     lapisDateField,
-    height,
 }) => {
     const lapis = useContext(LapisUrlContext);
 
@@ -112,7 +109,6 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
             data={data}
             granularity={granularity}
             confidenceIntervalMethods={confidenceIntervalMethods}
-            height={height}
         />
     );
 };
@@ -122,7 +118,6 @@ type PrevalenceOverTimeTabsProps = {
     data: PrevalenceOverTimeData;
     granularity: TemporalGranularity;
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
-    height: string;
 };
 
 const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = ({
@@ -130,7 +125,6 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
     data,
     granularity,
     confidenceIntervalMethods,
-    height,
 }) => {
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
     const [confidenceIntervalMethod, setConfidenceIntervalMethod] = useState<ConfidenceIntervalMethod>(
@@ -186,7 +180,6 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
             confidenceIntervalMethods={confidenceIntervalMethods}
             confidenceIntervalMethod={confidenceIntervalMethod}
             setConfidenceIntervalMethod={setConfidenceIntervalMethod}
-            height={height}
         />
     );
 
@@ -202,7 +195,6 @@ type ToolbarProps = {
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     confidenceIntervalMethod: ConfidenceIntervalMethod;
     setConfidenceIntervalMethod: (confidenceIntervalMethod: ConfidenceIntervalMethod) => void;
-    height: string;
 };
 
 const Toolbar: FunctionComponent<ToolbarProps> = ({
@@ -214,7 +206,6 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
     setConfidenceIntervalMethod,
     data,
     granularity,
-    height,
 }) => {
     return (
         <div class='flex'>
@@ -234,14 +225,14 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
                 filename='prevalence-over-time.csv'
             />
 
-            <PrevalenceOverTimeInfo height={height} />
+            <PrevalenceOverTimeInfo />
         </div>
     );
 };
 
-const PrevalenceOverTimeInfo: FunctionComponent<{ height: string }> = ({ height }) => {
+const PrevalenceOverTimeInfo: FunctionComponent = ({}) => {
     return (
-        <Info height={`min(100vh, 0.8*${height})`}>
+        <Info height={'100px'}>
             <InfoHeadline1>Prevalence over time</InfoHeadline1>
             <InfoParagraph>Prevalence over time info.</InfoParagraph>
         </Info>

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -24,6 +24,7 @@ export type View = 'line';
 
 export interface RelativeGrowthAdvantageProps extends RelativeGrowthAdvantagePropsInner {
     width: string;
+    height: string;
     headline?: string;
 }
 
@@ -32,7 +33,6 @@ export interface RelativeGrowthAdvantagePropsInner {
     denominator: LapisFilter;
     generationTime: number;
     views: View[];
-    height: string;
     lapisDateField: string;
 }
 
@@ -58,7 +58,6 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
                         denominator={denominator}
                         generationTime={generationTime}
                         lapisDateField={lapisDateField}
-                        height={height}
                     />
                 </Headline>
             </ResizeContainer>
@@ -71,7 +70,6 @@ export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvan
     denominator,
     generationTime,
     views,
-    height,
     lapisDateField,
 }) => {
     const lapis = useContext(LapisUrlContext);
@@ -101,7 +99,6 @@ export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvan
             setYAxisScaleType={setYAxisScaleType}
             views={views}
             generationTime={generationTime}
-            height={height}
         />
     );
 };
@@ -112,7 +109,6 @@ type RelativeGrowthAdvantageTabsProps = {
     setYAxisScaleType: (scaleType: ScaleType) => void;
     views: View[];
     generationTime: number;
-    height: string;
 };
 
 const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabsProps> = ({
@@ -121,7 +117,6 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
     setYAxisScaleType,
     views,
     generationTime,
-    height,
 }) => {
     const getTab = (view: View) => {
         switch (view) {
@@ -148,7 +143,6 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
             generationTime={generationTime}
             yAxisScaleType={yAxisScaleType}
             setYAxisScaleType={setYAxisScaleType}
-            height={height}
         />
     );
 
@@ -159,29 +153,24 @@ type RelativeGrowthAdvantageToolbarProps = {
     yAxisScaleType: ScaleType;
     setYAxisScaleType: (scaleType: ScaleType) => void;
     generationTime: number;
-    height: string;
 };
 
 const RelativeGrowthAdvantageToolbar: FunctionComponent<RelativeGrowthAdvantageToolbarProps> = ({
     yAxisScaleType,
     setYAxisScaleType,
     generationTime,
-    height,
 }) => {
     return (
         <div class='flex'>
             <ScalingSelector yAxisScaleType={yAxisScaleType} setYAxisScaleType={setYAxisScaleType} />
-            <RelativeGrowthAdvantageInfo generationTime={generationTime} height={height} />
+            <RelativeGrowthAdvantageInfo generationTime={generationTime} />
         </div>
     );
 };
 
-const RelativeGrowthAdvantageInfo: FunctionComponent<{ generationTime: number; height: string }> = ({
-    generationTime,
-    height,
-}) => {
+const RelativeGrowthAdvantageInfo: FunctionComponent<{ generationTime: number }> = ({ generationTime }) => {
     return (
-        <Info height={`min(100vh, 0.8*${height}`}>
+        <Info>
             <InfoHeadline1>Relative growth advantage</InfoHeadline1>
             <InfoParagraph>
                 If variants spread pre-dominantly by local transmission across demographic groups, this estimate

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -24,7 +24,6 @@ export type View = 'line';
 
 export interface RelativeGrowthAdvantageProps extends RelativeGrowthAdvantagePropsInner {
     width: string;
-    height: string;
     headline?: string;
 }
 
@@ -33,6 +32,7 @@ export interface RelativeGrowthAdvantagePropsInner {
     denominator: LapisFilter;
     generationTime: number;
     views: View[];
+    height: string;
     lapisDateField: string;
 }
 
@@ -58,6 +58,7 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
                         denominator={denominator}
                         generationTime={generationTime}
                         lapisDateField={lapisDateField}
+                        height={height}
                     />
                 </Headline>
             </ResizeContainer>
@@ -70,6 +71,7 @@ export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvan
     denominator,
     generationTime,
     views,
+    height,
     lapisDateField,
 }) => {
     const lapis = useContext(LapisUrlContext);
@@ -99,6 +101,7 @@ export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvan
             setYAxisScaleType={setYAxisScaleType}
             views={views}
             generationTime={generationTime}
+            height={height}
         />
     );
 };
@@ -109,6 +112,7 @@ type RelativeGrowthAdvantageTabsProps = {
     setYAxisScaleType: (scaleType: ScaleType) => void;
     views: View[];
     generationTime: number;
+    height: string;
 };
 
 const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabsProps> = ({
@@ -117,6 +121,7 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
     setYAxisScaleType,
     views,
     generationTime,
+    height,
 }) => {
     const getTab = (view: View) => {
         switch (view) {
@@ -143,6 +148,7 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
             generationTime={generationTime}
             yAxisScaleType={yAxisScaleType}
             setYAxisScaleType={setYAxisScaleType}
+            height={height}
         />
     );
 
@@ -153,24 +159,29 @@ type RelativeGrowthAdvantageToolbarProps = {
     yAxisScaleType: ScaleType;
     setYAxisScaleType: (scaleType: ScaleType) => void;
     generationTime: number;
+    height: string;
 };
 
 const RelativeGrowthAdvantageToolbar: FunctionComponent<RelativeGrowthAdvantageToolbarProps> = ({
     yAxisScaleType,
     setYAxisScaleType,
     generationTime,
+    height,
 }) => {
     return (
         <div class='flex'>
             <ScalingSelector yAxisScaleType={yAxisScaleType} setYAxisScaleType={setYAxisScaleType} />
-            <RelativeGrowthAdvantageInfo generationTime={generationTime} />
+            <RelativeGrowthAdvantageInfo generationTime={generationTime} height={height} />
         </div>
     );
 };
 
-const RelativeGrowthAdvantageInfo: FunctionComponent<{ generationTime: number }> = ({ generationTime }) => {
+const RelativeGrowthAdvantageInfo: FunctionComponent<{ generationTime: number; height: string }> = ({
+    generationTime,
+    height,
+}) => {
     return (
-        <Info height={'max(300px, 30vh)'}>
+        <Info height={`min(100vh, 0.8*${height}`}>
             <InfoHeadline1>Relative growth advantage</InfoHeadline1>
             <InfoParagraph>
                 If variants spread pre-dominantly by local transmission across demographic groups, this estimate

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -170,7 +170,7 @@ const RelativeGrowthAdvantageToolbar: FunctionComponent<RelativeGrowthAdvantageT
 
 const RelativeGrowthAdvantageInfo: FunctionComponent<{ generationTime: number }> = ({ generationTime }) => {
     return (
-        <Info size={{ width: '600px', height: '30vh' }}>
+        <Info height={'max(300px, 30vh)'}>
             <InfoHeadline1>Relative growth advantage</InfoHeadline1>
             <InfoParagraph>
                 If variants spread pre-dominantly by local transmission across demographic groups, this estimate

--- a/components/src/web-components/input/gs-mutation-filter.stories.ts
+++ b/components/src/web-components/input/gs-mutation-filter.stories.ts
@@ -14,7 +14,6 @@ const codeExample = String.raw`
 <gs-mutation-filter 
     initialValue='["A123T"]'
     width='100%'
-    height='6.5rem'
 ></gs-mutation-filter>`;
 
 const meta: Meta<MutationFilterProps> = {

--- a/components/src/web-components/input/gs-mutation-filter.stories.ts
+++ b/components/src/web-components/input/gs-mutation-filter.stories.ts
@@ -38,7 +38,6 @@ const meta: Meta<MutationFilterProps> = {
             },
         },
         width: { control: 'text' },
-        height: { control: 'text' },
     },
     decorators: [withActions],
     tags: ['autodocs'],
@@ -50,18 +49,13 @@ const Template: StoryObj<MutationFilterProps> = {
     render: (args) => {
         return html` <gs-app lapis="${LAPIS_URL}">
             <div class="max-w-screen-lg">
-                <gs-mutation-filter
-                    .initialValue=${args.initialValue}
-                    .width=${args.width}
-                    .height=${args.height}
-                ></gs-mutation-filter>
+                <gs-mutation-filter .initialValue=${args.initialValue} .width=${args.width}></gs-mutation-filter>
             </div>
         </gs-app>`;
     },
     args: {
         initialValue: [],
         width: '100%',
-        height: '3rem',
     },
 };
 

--- a/components/src/web-components/input/gs-mutation-filter.tsx
+++ b/components/src/web-components/input/gs-mutation-filter.tsx
@@ -91,18 +91,10 @@ export class MutationFilterComponent extends PreactLitAdapter {
     @property({ type: String })
     width: string = '100%';
 
-    /**
-     * The height of the component.
-     *
-     * Visit https://genspectrum.github.io/dashboards/?path=/docs/components-size-of-components--docs for more information.
-     */
-    @property({ type: String })
-    height: string = '6.5rem';
-
     override render() {
         return (
             <ReferenceGenomesAwaiter>
-                <MutationFilter initialValue={this.initialValue} width={this.width} height={this.height} />
+                <MutationFilter initialValue={this.initialValue} width={this.width} />
             </ReferenceGenomesAwaiter>
         );
     }

--- a/examples/React/src/App.tsx
+++ b/examples/React/src/App.tsx
@@ -92,6 +92,15 @@ function App() {
                     views='["line", "table"]'
                 ></gs-prevalence-over-time>
             </div>
+            <gs-relative-growth-advantage
+                numerator='{ "country": "Switzerland", "pangoLineage": "B.1.1.7", "dateFrom": "2020-12-01" }'
+                denominator='{ "country": "Switzerland", "dateFrom": "2020-12-01" }'
+                generationTime="7"
+                views='["line"]'
+                width='100%'
+                height='700px'
+                headline="Relative growth advantage"
+            ></gs-relative-growth-advantage>
         </gs-app>
     );
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #235

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The info component, now resizes to a smaller size, when on a small screen. This way it should not go outside of the screen. It still is next to the info button. (When the maintainer of a website decides to put the info button outside of the viewport also the info text will be displayed outside. This can also be the case for the prevalence over time component on mobile view. This issue will be adressed in #234)
Also the mutation filter component is redisigned, so it works better with the info button and is more similar to loculus input field.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![Bildschirmfoto 2024-05-20 um 12 26 51](https://github.com/GenSpectrum/dashboards/assets/122305307/2640f68e-5ece-4020-9d9b-8aa469d3c3e0)
![Bildschirmfoto 2024-05-20 um 13 33 03](https://github.com/GenSpectrum/dashboards/assets/122305307/740044bc-e43e-49d3-9805-0e998c5f40b6)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [ ] The implemented feature is covered by an appropriate test.
