### PR TITLE
feat(components): make x-axis date field of `gs-relative-growth-advantage` configurable

### DIFF
--- a/components/src/operator/RenameFieldOperator.spec.ts
+++ b/components/src/operator/RenameFieldOperator.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { MockOperator } from './MockOperator';
+import { RenameFieldOperator } from './RenameFieldOperator';
+
+const mockOperator = new MockOperator([
+    { id: 1, value: 1 },
+    { id: 2, value: 2 },
+    { id: 3, value: 3 },
+    { id: 4, value: 4 },
+    { id: 5, value: 5 },
+]);
+
+describe('RenameFieldOperator', () => {
+    it('should map the keys', async () => {
+        const underTest = new RenameFieldOperator(mockOperator, 'value', 'mappedValue');
+
+        const result = await underTest.evaluate('lapis');
+
+        expect(result.content).deep.equal([
+            { id: 1, value: 1, mappedValue: 1 },
+            { id: 2, value: 2, mappedValue: 2 },
+            { id: 3, value: 3, mappedValue: 3 },
+            { id: 4, value: 4, mappedValue: 4 },
+            { id: 5, value: 5, mappedValue: 5 },
+        ]);
+    });
+});

--- a/components/src/operator/RenameFieldOperator.ts
+++ b/components/src/operator/RenameFieldOperator.ts
@@ -1,0 +1,19 @@
+import { MapOperator } from './MapOperator';
+import type { Operator } from './Operator';
+
+export class RenameFieldOperator<
+    OldFieldName extends string,
+    NewFieldName extends string,
+    Data extends { [key in OldFieldName]: unknown },
+> extends MapOperator<Data, Data & { [key in NewFieldName]: Data[OldFieldName] }> {
+    constructor(child: Operator<Data>, oldFieldName: OldFieldName, newFieldName: NewFieldName) {
+        super(
+            child,
+            (value) =>
+                ({
+                    ...value,
+                    [newFieldName]: value[oldFieldName],
+                }) as Data & { [key in NewFieldName]: Data[OldFieldName] },
+        );
+    }
+}

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
@@ -48,6 +48,7 @@ const Template = {
                 width={args.width}
                 height={args.height}
                 headline={args.headline}
+                lapisDateField={args.lapisDateField}
             />
         </LapisUrlContext.Provider>
     ),
@@ -68,6 +69,7 @@ export const TwoVariants = {
         width: '100%',
         height: '700px',
         headline: 'Prevalence over time',
+        lapisDateField: 'date',
     },
     parameters: {
         fetchMock: {
@@ -139,6 +141,7 @@ export const OneVariant = {
         width: '100%',
         height: '700px',
         headline: 'Prevalence over time',
+        lapisDateField: 'date',
     },
     parameters: {
         fetchMock: {

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -39,6 +39,7 @@ export interface PrevalenceOverTimeInnerProps {
     smoothingWindow: number;
     views: View[];
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
+    lapisDateField: string;
 }
 
 export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
@@ -51,6 +52,7 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
     width,
     height,
     headline = 'Prevalence over time',
+    lapisDateField,
 }) => {
     const size = { height, width };
 
@@ -65,6 +67,7 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
                         smoothingWindow={smoothingWindow}
                         views={views}
                         confidenceIntervalMethods={confidenceIntervalMethods}
+                        lapisDateField={lapisDateField}
                     />
                 </Headline>
             </ResizeContainer>
@@ -79,11 +82,12 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
     smoothingWindow,
     views,
     confidenceIntervalMethods,
+    lapisDateField,
 }) => {
     const lapis = useContext(LapisUrlContext);
 
     const { data, error, isLoading } = useQuery(
-        () => queryPrevalenceOverTime(numerator, denominator, granularity, smoothingWindow, lapis),
+        () => queryPrevalenceOverTime(numerator, denominator, granularity, smoothingWindow, lapis, lapisDateField),
         [lapis, numerator, denominator, granularity, smoothingWindow],
     );
 

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.stories.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.stories.tsx
@@ -35,6 +35,7 @@ export const Primary = {
                 width={args.width}
                 height={args.height}
                 headline={args.headline}
+                lapisDateField={args.lapisDateField}
             />
         </LapisUrlContext.Provider>
     ),
@@ -46,6 +47,7 @@ export const Primary = {
         width: '100%',
         height: '700px',
         headline: 'Relative growth advantage',
+        lapisDateField: 'date',
     },
     parameters: {
         fetchMock: {

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -33,6 +33,7 @@ export interface RelativeGrowthAdvantagePropsInner {
     denominator: LapisFilter;
     generationTime: number;
     views: View[];
+    lapisDateField: string;
 }
 
 export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageProps> = ({
@@ -43,6 +44,7 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
     denominator,
     generationTime,
     headline = 'Relative growth advantage',
+    lapisDateField,
 }) => {
     const size = { height, width };
 
@@ -55,6 +57,7 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
                         numerator={numerator}
                         denominator={denominator}
                         generationTime={generationTime}
+                        lapisDateField={lapisDateField}
                     />
                 </Headline>
             </ResizeContainer>
@@ -67,12 +70,13 @@ export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvan
     denominator,
     generationTime,
     views,
+    lapisDateField,
 }) => {
     const lapis = useContext(LapisUrlContext);
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
 
     const { data, error, isLoading } = useQuery(
-        () => queryRelativeGrowthAdvantage(numerator, denominator, generationTime, lapis),
+        () => queryRelativeGrowthAdvantage(numerator, denominator, generationTime, lapis, lapisDateField),
         [lapis, numerator, denominator, generationTime, views],
     );
 

--- a/components/src/web-components/visualization/gs-prevalence-over-time.stories.ts
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.stories.ts
@@ -23,8 +23,9 @@ const codeExample = String.raw`
     views='["bar", "line", "bubble", "table"]'
     confidenceIntervalMethods='["wilson"]'
     headline="Prevalence over time"
-    width='100%'
-    height='700px'
+    width="100%"
+    height="700px"
+    lapisDateField="date"
 ></gs-prevalence-over-time>`;
 
 const meta: Meta<Required<PrevalenceOverTimeProps>> = {
@@ -75,6 +76,7 @@ const Template: StoryObj<Required<PrevalenceOverTimeProps>> = {
                 .width=${args.width}
                 .height=${args.height}
                 .headline=${args.headline}
+                .lapisDateField=${args.lapisDateField}
             ></gs-prevalence-over-time>
         </gs-app>
     `,
@@ -95,6 +97,7 @@ export const TwoVariants: StoryObj<Required<PrevalenceOverTimeProps>> = {
         width: '100%',
         height: '700px',
         headline: 'Prevalence over time',
+        lapisDateField: 'date',
     },
     parameters: {
         fetchMock: {
@@ -166,6 +169,7 @@ export const OneVariant: StoryObj<Required<PrevalenceOverTimeProps>> = {
         width: '100%',
         height: '700px',
         headline: 'Prevalence over time',
+        lapisDateField: 'date',
     },
     parameters: {
         fetchMock: {

--- a/components/src/web-components/visualization/gs-prevalence-over-time.tsx
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.tsx
@@ -126,6 +126,16 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
     @property({ type: String })
     height: string = '700px';
 
+    /**
+     * Required.
+     *
+     * The LAPIS field that the data should be aggregated by.
+     * The values will be used on the x-axis of the diagram.
+     * Must be a field of type `date` in LAPIS.
+     */
+    @property({ type: String })
+    lapisDateField: string = 'date';
+
     override render() {
         return (
             <PrevalenceOverTime
@@ -138,6 +148,7 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
                 width={this.width}
                 height={this.height}
                 headline={this.headline}
+                lapisDateField={this.lapisDateField}
             />
         );
     }

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.stories.ts
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.stories.ts
@@ -18,6 +18,7 @@ const codeExample = String.raw`
     width='100%'
     height='700px'
     headline="Relative growth advantage"
+    lapisDateField="date"
 ></gs-relative-growth-advantage>`;
 
 const meta: Meta<RelativeGrowthAdvantageProps> = {
@@ -58,6 +59,7 @@ const Template: StoryObj<Required<RelativeGrowthAdvantageProps>> = {
                 .width=${args.width}
                 .height=${args.height}
                 .headline=${args.headline}
+                .lapisDateField=${args.lapisDateField}
             ></gs-relative-growth-advantage>
         </gs-app>
     `,
@@ -73,6 +75,7 @@ export const Default: StoryObj<Required<RelativeGrowthAdvantageProps>> = {
         width: '100%',
         height: '700px',
         headline: 'Relative growth advantage',
+        lapisDateField: 'date',
     },
     parameters: {
         fetchMock: {

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
@@ -85,6 +85,8 @@ export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {
     height: string = '700px';
 
     /**
+     * Required.
+     *
      * The LAPIS field that the data should be aggregated by.
      * The values will be used on the x-axis of the diagram.
      * Must be a field of type `date` in LAPIS.

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
@@ -84,6 +84,14 @@ export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {
     @property({ type: String })
     height: string = '700px';
 
+    /**
+     * The LAPIS field that the data should be aggregated by.
+     * The values will be used on the x-axis of the diagram.
+     * Must be a field of type `date` in LAPIS.
+     */
+    @property({ type: String })
+    lapisDateField: string = 'date';
+
     override render() {
         return (
             <RelativeGrowthAdvantage
@@ -94,6 +102,7 @@ export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {
                 width={this.width}
                 height={this.height}
                 headline={this.headline}
+                lapisDateField={this.lapisDateField}
             />
         );
     }


### PR DESCRIPTION
 <!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #215

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
`gs-relative-growth-advantage` now has an attribute `lapisDateField`. 

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
