### PR TITLE
feat(components): gs-location-filter: set all values in `gs-location-changed` event details

### DIFF
--- a/components/src/preact/locationFilter/location-filter.tsx
+++ b/components/src/preact/locationFilter/location-filter.tsx
@@ -93,7 +93,7 @@ export const LocationFilterInner = ({ initialValue, fields }: LocationFilterInne
 
 const parseLocation = (location: string, fields: string[]) => {
     const fieldValues = location.split('/').map((part) => part.trim());
-    return fieldValues.reduce((acc, fieldValue, i) => ({ ...acc, [fields[i]]: fieldValue }), {});
+    return fields.reduce((acc, field, i) => ({ ...acc, [field]: fieldValues[i] }), {});
 };
 
 const hasMatchingEntry = (data: Record<string, string>[] | null, eventDetail: Record<string, string>) => {

--- a/components/src/web-components/input/gs-location-filter.stories.ts
+++ b/components/src/web-components/input/gs-location-filter.stories.ts
@@ -190,13 +190,12 @@ export const FiresEvent: StoryObj<LocationFilterProps> = {
 
         await step('Select Asia', async () => {
             await userEvent.type(inputField(), 'Asia');
-            await expect(listenerMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    detail: {
-                        region: 'Asia',
-                    },
-                }),
-            );
+            await expect(listenerMock.mock.calls.at(-1)[0].detail).toStrictEqual({
+                region: 'Asia',
+                country: undefined,
+                division: undefined,
+                location: undefined,
+            });
         });
 
         await step('Select Asia / Bangladesh / Rajshahi / Chapainawabgonj', async () => {

--- a/components/src/web-components/input/gs-location-filter.tsx
+++ b/components/src/web-components/input/gs-location-filter.tsx
@@ -20,13 +20,14 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  * @fires {CustomEvent<Record<string, string>>} gs-location-changed
  * Fired when a value from the datalist is selected or when a valid value is typed into the field.
  * The `details` of this event contain an object with all `fields` as keys
- * and the corresponding values as values, if they are not `undefined`.
+ * and the corresponding values as values, even if they are `undefined`.
  * Example:
  * ```
  * {
  *   continent: "Asia",
  *   country: "China",
- *   city: "Beijing"
+ *   city: "Beijing",
+ *   district: undefined,
  * }
  * ```
  */


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves  #265

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

If the value is not present, explicitly set it to undefined. That way, receivers can overwrite previously set values by using the spread operator on the event details.

Event details may look like:
```typescript
{
  country: undefined,
  division: undefined,
  location: undefined,
  region: "Asia",
}
``` 

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
