### PR TITLE
feat(components): responsive date range selector

### DIFF
--- a/components/src/preact/dateRangeSelector/date-range-selector.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.tsx
@@ -182,11 +182,11 @@ export const DateRangeSelectorInner = <CustomLabel extends string>({
     };
 
     return (
-        <div class='join w-full' ref={divRef}>
+        <div class='flex flex-wrap' ref={divRef}>
             <Select
                 items={selectableOptions}
                 selected={selectedDateRange}
-                selectStyle='select-bordered rounded-none join-item grow'
+                selectStyle='select-bordered rounded-none flex-grow w-40'
                 onChange={(event: Event) => {
                     event.preventDefault();
                     const select = event.target as HTMLSelectElement;
@@ -194,22 +194,26 @@ export const DateRangeSelectorInner = <CustomLabel extends string>({
                     onSelectChange(value as CustomLabel | PresetOptionValues);
                 }}
             />
-            <input
-                class='input input-bordered rounded-none join-item grow'
-                type='text'
-                placeholder='Date from'
-                ref={fromDatePickerRef}
-                onChange={onChangeDateFrom}
-                onBlur={onChangeDateFrom}
-            />
-            <input
-                class='input input-bordered rounded-none join-item grow'
-                type='text'
-                placeholder='Date to'
-                ref={toDatePickerRef}
-                onChange={onChangeDateTo}
-                onBlur={onChangeDateTo}
-            />
+            <div className={'flex flex-wrap flex-grow'}>
+                <input
+                    class='input input-bordered rounded-none flex-grow min-w-40'
+                    type='text'
+                    size={10}
+                    placeholder='Date from'
+                    ref={fromDatePickerRef}
+                    onChange={onChangeDateFrom}
+                    onBlur={onChangeDateFrom}
+                />
+                <input
+                    class='input input-bordered rounded-none flex-grow min-w-40'
+                    type='text'
+                    size={10}
+                    placeholder='Date to'
+                    ref={toDatePickerRef}
+                    onChange={onChangeDateTo}
+                    onBlur={onChangeDateTo}
+                />
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #269

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The date range selector now changes it size depending on the available size. It first shows all three elements (dropdown, date from, date to) on one row, then the dropdown on the first and the two dates on the second, and lastly all on a separate line.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/bb370daa-fddb-4e5e-a0de-e727ce1b00aa)

![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/062e5509-2165-45cf-8810-a1e9d0806592)

![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/c8b70332-b461-422c-bd4f-19f7597fac93)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
