### PR TITLE
263 gs location filter if value becomes empty then also fire event

### DIFF
--- a/components/src/preact/locationFilter/location-filter.tsx
+++ b/components/src/preact/locationFilter/location-filter.tsx
@@ -51,11 +51,11 @@ export const LocationFilterInner = ({ initialValue, fields }: LocationFilterInne
     const onInput = (event: JSXInternal.TargetedInputEvent<HTMLInputElement>) => {
         const inputValue = event.currentTarget.value;
         setValue(inputValue);
-        if (inputValue.trim() === value.trim()) {
+        if (inputValue.trim() === value.trim() && inputValue !== '') {
             return;
         }
         const eventDetail = parseLocation(inputValue, fields);
-        if (hasMatchingEntry(data, eventDetail)) {
+        if (hasAllUndefined(eventDetail) || hasMatchingEntry(data, eventDetail)) {
             divRef.current?.dispatchEvent(
                 new CustomEvent('gs-location-changed', {
                     detail: eventDetail,
@@ -92,9 +92,16 @@ export const LocationFilterInner = ({ initialValue, fields }: LocationFilterInne
 };
 
 const parseLocation = (location: string, fields: string[]) => {
+    if (location === '') {
+        return fields.reduce((acc, field) => ({ ...acc, [field]: undefined }), {});
+    }
     const fieldValues = location.split('/').map((part) => part.trim());
+
     return fields.reduce((acc, field, i) => ({ ...acc, [field]: fieldValues[i] }), {});
 };
+
+const hasAllUndefined = (obj: Record<string, string | undefined>) =>
+    Object.values(obj).every((value) => value === undefined);
 
 const hasMatchingEntry = (data: Record<string, string>[] | null, eventDetail: Record<string, string>) => {
     if (data === null) {

--- a/components/src/preact/textInput/text-input.tsx
+++ b/components/src/preact/textInput/text-input.tsx
@@ -56,7 +56,7 @@ export const TextInputInner: FunctionComponent<TextInputInnerProps> = ({
     }
 
     const onInput = () => {
-        const value = inputRef.current?.value;
+        const value = inputRef.current?.value === '' ? undefined : inputRef.current?.value;
 
         if (isValidValue(value)) {
             inputRef.current?.dispatchEvent(
@@ -71,7 +71,7 @@ export const TextInputInner: FunctionComponent<TextInputInnerProps> = ({
 
     const isValidValue = (value: string | undefined) => {
         if (value === undefined) {
-            return false;
+            return true;
         }
         return data.includes(value);
     };

--- a/components/src/web-components/input/gs-location-filter.stories.ts
+++ b/components/src/web-components/input/gs-location-filter.stories.ts
@@ -185,7 +185,16 @@ export const FiresEvent: StoryObj<LocationFilterProps> = {
         await step('Input invalid location', async () => {
             await userEvent.type(inputField(), 'Not / A / Location');
             await expect(listenerMock).not.toHaveBeenCalled();
+        });
+
+        await step('Empty input', async () => {
             await userEvent.type(inputField(), '{backspace>18/}');
+            await expect(listenerMock.mock.calls.at(-1)[0].detail).toStrictEqual({
+                region: undefined,
+                country: undefined,
+                division: undefined,
+                location: undefined,
+            });
         });
 
         await step('Select Asia', async () => {

--- a/components/src/web-components/input/gs-text-input.stories.ts
+++ b/components/src/web-components/input/gs-text-input.stories.ts
@@ -118,7 +118,13 @@ export const FiresEvent: StoryObj<Required<TextInputProps>> = {
         await step('Enters an invalid host name', async () => {
             await userEvent.type(inputField(), 'notInList');
             await expect(listenerMock).not.toHaveBeenCalled();
+        });
+
+        await step('Empty input', async () => {
             await userEvent.type(inputField(), '{backspace>9/}');
+            await expect(listenerMock.mock.calls.at(-1)[0].detail).toStrictEqual({
+                host: undefined,
+            });
         });
 
         await step('Enter a valid host name', async () => {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #263

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
location filter and text input now fire an event, when the input field is empty. The content is then the field with an "undefined" value.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
