### PR TITLE
fix(components): remove date range selector fixed height for responsive design

### DIFF
--- a/components/src/preact/dateRangeSelector/date-range-selector.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.tsx
@@ -11,7 +11,6 @@ import {
     type PresetOptionValues,
 } from './selectableOptions';
 import { ErrorBoundary } from '../components/error-boundary';
-import { ResizeContainer } from '../components/resize-container';
 import { Select } from '../components/select';
 import type { ScaleType } from '../shared/charts/getYAxisScale';
 
@@ -41,7 +40,7 @@ export const DateRangeSelector = <CustomLabel extends string>({
 
     return (
         <ErrorBoundary size={size}>
-            <ResizeContainer size={size}>
+            <div style={{ width }}>
                 <DateRangeSelectorInner
                     customSelectOptions={customSelectOptions}
                     earliestDate={earliestDate}
@@ -50,7 +49,7 @@ export const DateRangeSelector = <CustomLabel extends string>({
                     initialDateFrom={initialDateFrom}
                     initialDateTo={initialDateTo}
                 />
-            </ResizeContainer>
+            </div>
         </ErrorBoundary>
     );
 };


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #283

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This removes the default height from the date range selector, so it works as expected on small screens. The error boundary still uses the default height, so when the component throws an error, then the component will shrink to this size.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/410ac47d-bb9d-41c2-91ec-114466795f88)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
