### PR TITLE
feat(components): allow to set pagination limit for all tables

### DIFF
--- a/components/src/preact/aggregatedData/aggregate-table.tsx
+++ b/components/src/preact/aggregatedData/aggregate-table.tsx
@@ -7,9 +7,10 @@ import { formatProportion } from '../shared/table/formatProportion';
 type AggregateTableProps = {
     fields: string[];
     data: AggregateData;
+    pageSize: boolean | number;
 };
 
-export const AggregateTable: FunctionComponent<AggregateTableProps> = ({ data, fields }) => {
+export const AggregateTable: FunctionComponent<AggregateTableProps> = ({ data, fields, pageSize }) => {
     const headers = [
         ...fields.map((field) => {
             return {
@@ -28,5 +29,5 @@ export const AggregateTable: FunctionComponent<AggregateTableProps> = ({ data, f
         },
     ];
 
-    return <Table data={data} columns={headers} pagination={true} />;
+    return <Table data={data} columns={headers} pageSize={pageSize} />;
 };

--- a/components/src/preact/aggregatedData/aggregate.stories.tsx
+++ b/components/src/preact/aggregatedData/aggregate.stories.tsx
@@ -15,6 +15,7 @@ const meta: Meta<AggregateProps> = {
         headline: { control: 'text' },
         initialSortField: { control: 'text' },
         initialSortDirection: { control: 'radio', options: ['ascending', 'descending'] },
+        pageSize: { control: 'object' },
     },
     parameters: {
         fetchMock: {
@@ -57,5 +58,6 @@ export const Default: StoryObj<AggregateProps> = {
         headline: 'Aggregate',
         initialSortField: 'count',
         initialSortDirection: 'descending',
+        pageSize: 10,
     },
 };

--- a/components/src/preact/aggregatedData/aggregate.tsx
+++ b/components/src/preact/aggregatedData/aggregate.tsx
@@ -31,6 +31,7 @@ export interface AggregateInnerProps {
     views: View[];
     initialSortField: string;
     initialSortDirection: 'ascending' | 'descending';
+    pageSize: boolean | number;
 }
 
 export const Aggregate: FunctionComponent<AggregateProps> = ({
@@ -40,6 +41,7 @@ export const Aggregate: FunctionComponent<AggregateProps> = ({
     headline = 'Mutations',
     filter,
     fields,
+    pageSize,
     initialSortField,
     initialSortDirection,
 }) => {
@@ -55,6 +57,7 @@ export const Aggregate: FunctionComponent<AggregateProps> = ({
                         views={views}
                         initialSortField={initialSortField}
                         initialSortDirection={initialSortDirection}
+                        pageSize={pageSize}
                     />
                 </Headline>
             </ResizeContainer>
@@ -68,6 +71,7 @@ export const AggregateInner: FunctionComponent<AggregateInnerProps> = ({
     filter,
     initialSortField,
     initialSortDirection,
+    pageSize,
 }) => {
     const lapis = useContext(LapisUrlContext);
 
@@ -87,22 +91,23 @@ export const AggregateInner: FunctionComponent<AggregateInnerProps> = ({
         return <NoDataDisplay />;
     }
 
-    return <AggregatedDataTabs data={data} views={views} fields={fields} />;
+    return <AggregatedDataTabs data={data} views={views} fields={fields} pageSize={pageSize} />;
 };
 
 type AggregatedDataTabsProps = {
     data: AggregateData;
     fields: string[];
     views: View[];
+    pageSize: boolean | number;
 };
 
-const AggregatedDataTabs: FunctionComponent<AggregatedDataTabsProps> = ({ data, views, fields }) => {
+const AggregatedDataTabs: FunctionComponent<AggregatedDataTabsProps> = ({ data, views, fields, pageSize }) => {
     const getTab = (view: View) => {
         switch (view) {
             case 'table':
                 return {
                     title: 'Table',
-                    content: <AggregateTable data={data} fields={fields} />,
+                    content: <AggregateTable data={data} fields={fields} pageSize={pageSize} />,
                 };
         }
     };

--- a/components/src/preact/components/table.stories.tsx
+++ b/components/src/preact/components/table.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
+import { expect, userEvent, waitFor, within } from '@storybook/test';
 
 import { Table } from './table';
 
@@ -6,13 +7,18 @@ const meta: Meta = {
     title: 'Component/Table',
     component: Table,
     parameters: { fetchMock: {} },
+    argTypes: {
+        data: { control: 'object' },
+        columns: { control: 'object' },
+        pageSize: { control: 'object' },
+    },
 };
 
 export default meta;
 
 export const TableStory: StoryObj = {
     render: (args) => {
-        return <Table data={args.data} columns={args.columns} pagination={false} />;
+        return <Table data={args.data} columns={args.columns} pageSize={args.pageSize} />;
     },
     args: {
         data: [
@@ -20,5 +26,49 @@ export const TableStory: StoryObj = {
             ['Jane Doe', 'jane@example.com', '098-765-4321'],
         ],
         columns: [{ name: 'Name' }, { name: 'Email', sort: true }, { name: 'Phone Number' }],
+        pageSize: 1,
+    },
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+
+        const firstRow = () => canvas.queryByText('John Do', { exact: true });
+        const secondRow = () => canvas.queryByText('Jane Doe', { exact: true });
+
+        await step('Expect first row to be visible and not second row', async () => {
+            await waitFor(() => expect(firstRow()).toBeVisible());
+            await expect(secondRow()).toBeNull();
+        });
+
+        await step('Expect second row to be visible and not first row after clicking next', async () => {
+            const nextButton = canvas.getByRole('button', { name: 'Next' });
+            await userEvent.click(nextButton);
+
+            await waitFor(() => expect(secondRow()).toBeVisible());
+            await expect(firstRow()).toBeNull();
+        });
+    },
+};
+
+export const TableStoryNoPagination: StoryObj = {
+    render: (args) => {
+        return <Table data={args.data} columns={args.columns} pageSize={args.pageSize} />;
+    },
+    args: {
+        data: [
+            ['John Do', 'john@example.com', '123-456-7890'],
+            ['Jane Doe', 'jane@example.com', '098-765-4321'],
+        ],
+        columns: [{ name: 'Name' }, { name: 'Email', sort: true }, { name: 'Phone Number' }],
+        pageSize: false,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        const firstRow = () => canvas.queryByText('John Do', { exact: true });
+        const secondRow = () => canvas.queryByText('Jane Doe', { exact: true });
+
+        await waitFor(() => expect(firstRow()).toBeVisible());
+        await expect(secondRow()).toBeVisible();
+        await waitFor(() => expect(canvas.queryByText('Next')).toBeNull());
     },
 };

--- a/components/src/preact/components/table.tsx
+++ b/components/src/preact/components/table.tsx
@@ -1,6 +1,5 @@
 import { Grid } from 'gridjs';
 import { type OneDArray, type TColumn, type TData } from 'gridjs/dist/src/types';
-import { type PaginationConfig } from 'gridjs/dist/src/view/plugin/pagination';
 import { type ComponentChild } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 
@@ -26,10 +25,12 @@ export const tableStyle = {
 interface TableProps {
     data: TData;
     columns: OneDArray<TColumn | string | ComponentChild>;
-    pagination: PaginationConfig | boolean;
+    pageSize: number | boolean;
 }
 
-export const Table = ({ data, columns, pagination }: TableProps) => {
+export const Table = ({ data, columns, pageSize }: TableProps) => {
+    const pagination = typeof pageSize === 'number' ? { limit: pageSize } : pageSize;
+
     const wrapper = useRef(null);
 
     useEffect(() => {

--- a/components/src/preact/mutationComparison/mutation-comparison-table.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison-table.tsx
@@ -12,9 +12,14 @@ import { formatProportion } from '../shared/table/formatProportion';
 export interface MutationsTableProps {
     data: Dataset<MutationData>;
     proportionInterval: ProportionInterval;
+    pageSize: boolean | number;
 }
 
-export const MutationComparisonTable: FunctionComponent<MutationsTableProps> = ({ data, proportionInterval }) => {
+export const MutationComparisonTable: FunctionComponent<MutationsTableProps> = ({
+    data,
+    proportionInterval,
+    pageSize,
+}) => {
     const headers = [
         {
             name: 'Mutation',
@@ -37,5 +42,5 @@ export const MutationComparisonTable: FunctionComponent<MutationsTableProps> = (
 
     const tableData = getMutationComparisonTableData(data, proportionInterval).map((row) => Object.values(row));
 
-    return <Table data={tableData} columns={headers} pagination={true} />;
+    return <Table data={tableData} columns={headers} pageSize={pageSize} />;
 };

--- a/components/src/preact/mutationComparison/mutation-comparison.stories.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.stories.tsx
@@ -30,6 +30,7 @@ const meta: Meta<MutationComparisonProps> = {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        pageSize: { control: 'object' },
     },
     parameters: {
         fetchMock: {
@@ -85,6 +86,7 @@ const Template: StoryObj<MutationComparisonProps> = {
                     width={args.width}
                     height={args.height}
                     headline={args.headline}
+                    pageSize={args.pageSize}
                 />
             </ReferenceGenomeContext.Provider>
         </LapisUrlContext.Provider>
@@ -114,6 +116,7 @@ export const TwoVariants: StoryObj<MutationComparisonProps> = {
         width: '100%',
         height: '700px',
         headline: 'Mutation comparison',
+        pageSize: 10,
     },
 };
 

--- a/components/src/preact/mutationComparison/mutation-comparison.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.tsx
@@ -34,6 +34,7 @@ export interface MutationComparisonInnerProps {
     variants: NamedLapisFilter[];
     sequenceType: SequenceType;
     views: View[];
+    pageSize: boolean | number;
 }
 
 export const MutationComparison: FunctionComponent<MutationComparisonProps> = ({
@@ -43,6 +44,7 @@ export const MutationComparison: FunctionComponent<MutationComparisonProps> = ({
     width,
     height,
     headline = 'Mutation comparison',
+    pageSize,
 }) => {
     const size = { height, width };
 
@@ -50,7 +52,12 @@ export const MutationComparison: FunctionComponent<MutationComparisonProps> = ({
         <ErrorBoundary size={size} headline={headline}>
             <ResizeContainer size={size}>
                 <Headline heading={headline}>
-                    <MutationComparisonInner variants={variants} sequenceType={sequenceType} views={views} />
+                    <MutationComparisonInner
+                        variants={variants}
+                        sequenceType={sequenceType}
+                        views={views}
+                        pageSize={pageSize}
+                    />
                 </Headline>
             </ResizeContainer>
         </ErrorBoundary>
@@ -61,6 +68,7 @@ export const MutationComparisonInner: FunctionComponent<MutationComparisonInnerP
     variants,
     sequenceType,
     views,
+    pageSize,
 }) => {
     const lapis = useContext(LapisUrlContext);
 
@@ -80,16 +88,29 @@ export const MutationComparisonInner: FunctionComponent<MutationComparisonInnerP
         return <NoDataDisplay />;
     }
 
-    return <MutationComparisonTabs data={data.mutationData} sequenceType={sequenceType} views={views} />;
+    return (
+        <MutationComparisonTabs
+            data={data.mutationData}
+            sequenceType={sequenceType}
+            views={views}
+            pageSize={pageSize}
+        />
+    );
 };
 
 type MutationComparisonTabsProps = {
     data: MutationData[];
     views: View[];
     sequenceType: SequenceType;
+    pageSize: boolean | number;
 };
 
-const MutationComparisonTabs: FunctionComponent<MutationComparisonTabsProps> = ({ data, views, sequenceType }) => {
+const MutationComparisonTabs: FunctionComponent<MutationComparisonTabsProps> = ({
+    data,
+    views,
+    sequenceType,
+    pageSize,
+}) => {
     const [proportionInterval, setProportionInterval] = useState({ min: 0.5, max: 1 });
     const [displayedMutationTypes, setDisplayedMutationTypes] = useState<DisplayedMutationType[]>([
         { label: 'Substitutions', checked: true, type: 'substitution' },
@@ -111,6 +132,7 @@ const MutationComparisonTabs: FunctionComponent<MutationComparisonTabsProps> = (
                         <MutationComparisonTable
                             data={{ content: filteredData }}
                             proportionInterval={proportionInterval}
+                            pageSize={pageSize}
                         />
                     ),
                 };

--- a/components/src/preact/mutations/mutations-grid.tsx
+++ b/components/src/preact/mutations/mutations-grid.tsx
@@ -13,6 +13,7 @@ interface MutationsGridProps {
     data: SubstitutionOrDeletionEntry[];
     sequenceType: SequenceType;
     proportionInterval: ProportionInterval;
+    pageSize: boolean | number;
 }
 
 export type BaseCell = {
@@ -20,7 +21,12 @@ export type BaseCell = {
     isReference: boolean;
 };
 
-export const MutationsGrid: FunctionComponent<MutationsGridProps> = ({ data, sequenceType, proportionInterval }) => {
+export const MutationsGrid: FunctionComponent<MutationsGridProps> = ({
+    data,
+    sequenceType,
+    proportionInterval,
+    pageSize,
+}) => {
     const getHeaders = () => {
         return [
             {
@@ -80,5 +86,5 @@ export const MutationsGrid: FunctionComponent<MutationsGridProps> = ({ data, seq
 
     const tableData = getMutationsGridData(data, sequenceType, proportionInterval).map((row) => Object.values(row));
 
-    return <Table data={tableData} columns={getHeaders()} pagination={true} />;
+    return <Table data={tableData} columns={getHeaders()} pageSize={pageSize} />;
 };

--- a/components/src/preact/mutations/mutations-insertions-table.tsx
+++ b/components/src/preact/mutations/mutations-insertions-table.tsx
@@ -8,9 +8,10 @@ import { sortInsertions } from '../shared/sort/sortInsertions';
 
 export interface InsertionsTableProps {
     data: InsertionEntry[];
+    pageSize: boolean | number;
 }
 
-export const InsertionsTable: FunctionComponent<InsertionsTableProps> = ({ data }) => {
+export const InsertionsTable: FunctionComponent<InsertionsTableProps> = ({ data, pageSize }) => {
     const getHeaders = () => {
         return [
             {
@@ -31,5 +32,5 @@ export const InsertionsTable: FunctionComponent<InsertionsTableProps> = ({ data 
 
     const tableData = getInsertionsTableData(data).map((row) => Object.values(row));
 
-    return <Table data={tableData} columns={getHeaders()} pagination={true} />;
+    return <Table data={tableData} columns={getHeaders()} pageSize={pageSize} />;
 };

--- a/components/src/preact/mutations/mutations-table.tsx
+++ b/components/src/preact/mutations/mutations-table.tsx
@@ -11,9 +11,10 @@ import { formatProportion } from '../shared/table/formatProportion';
 export interface MutationsTableProps {
     data: SubstitutionOrDeletionEntry[];
     proportionInterval: ProportionInterval;
+    pageSize: boolean | number;
 }
 
-const MutationsTable: FunctionComponent<MutationsTableProps> = ({ data, proportionInterval }) => {
+const MutationsTable: FunctionComponent<MutationsTableProps> = ({ data, proportionInterval, pageSize }) => {
     const getHeaders = () => {
         return [
             {
@@ -43,7 +44,7 @@ const MutationsTable: FunctionComponent<MutationsTableProps> = ({ data, proporti
 
     const tableData = getMutationsTableData(data, proportionInterval).map((row) => Object.values(row));
 
-    return <Table data={tableData} columns={getHeaders()} pagination={true} />;
+    return <Table data={tableData} columns={getHeaders()} pageSize={pageSize} />;
 };
 
 export default MutationsTable;

--- a/components/src/preact/mutations/mutations.stories.tsx
+++ b/components/src/preact/mutations/mutations.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<MutationsProps> = {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        pageSize: { control: 'object' },
     },
 };
 
@@ -41,6 +42,7 @@ const Template = {
                     width={args.width}
                     height={args.height}
                     headline={args.headline}
+                    pageSize={args.pageSize}
                 />
             </ReferenceGenomeContext.Provider>
         </LapisUrlContext.Provider>
@@ -56,6 +58,7 @@ export const Default: StoryObj<MutationsProps> = {
         width: '100%',
         height: '700px',
         headline: 'Mutations',
+        pageSize: 10,
     },
     parameters: {
         fetchMock: {

--- a/components/src/preact/mutations/mutations.tsx
+++ b/components/src/preact/mutations/mutations.tsx
@@ -35,6 +35,7 @@ export interface MutationsInnerProps {
     variant: LapisFilter;
     sequenceType: SequenceType;
     views: View[];
+    pageSize: boolean | number;
 }
 
 export interface MutationsProps extends MutationsInnerProps {
@@ -50,6 +51,7 @@ export const Mutations: FunctionComponent<MutationsProps> = ({
     width,
     height,
     headline = 'Mutations',
+    pageSize,
 }) => {
     const size = { height, width };
 
@@ -57,14 +59,14 @@ export const Mutations: FunctionComponent<MutationsProps> = ({
         <ErrorBoundary size={size} headline={headline}>
             <ResizeContainer size={size}>
                 <Headline heading={headline}>
-                    <MutationsInner variant={variant} sequenceType={sequenceType} views={views} />
+                    <MutationsInner variant={variant} sequenceType={sequenceType} views={views} pageSize={pageSize} />
                 </Headline>
             </ResizeContainer>
         </ErrorBoundary>
     );
 };
 
-export const MutationsInner: FunctionComponent<MutationsInnerProps> = ({ variant, sequenceType, views }) => {
+export const MutationsInner: FunctionComponent<MutationsInnerProps> = ({ variant, sequenceType, views, pageSize }) => {
     const lapis = useContext(LapisUrlContext);
     const { data, error, isLoading } = useQuery(async () => {
         return queryMutationsData(variant, sequenceType, lapis);
@@ -82,16 +84,17 @@ export const MutationsInner: FunctionComponent<MutationsInnerProps> = ({ variant
         return <NoDataDisplay />;
     }
 
-    return <MutationsTabs mutationsData={data} sequenceType={sequenceType} views={views} />;
+    return <MutationsTabs mutationsData={data} sequenceType={sequenceType} views={views} pageSize={pageSize} />;
 };
 
 type MutationTabsProps = {
     mutationsData: { insertions: InsertionEntry[]; substitutionsOrDeletions: SubstitutionOrDeletionEntry[] };
     sequenceType: SequenceType;
     views: View[];
+    pageSize: boolean | number;
 };
 
-const MutationsTabs: FunctionComponent<MutationTabsProps> = ({ mutationsData, sequenceType, views }) => {
+const MutationsTabs: FunctionComponent<MutationTabsProps> = ({ mutationsData, sequenceType, views, pageSize }) => {
     const [proportionInterval, setProportionInterval] = useState({ min: 0.05, max: 1 });
 
     const [displayedSegments, setDisplayedSegments] = useDisplayedSegments(sequenceType);
@@ -107,7 +110,13 @@ const MutationsTabs: FunctionComponent<MutationTabsProps> = ({ mutationsData, se
             case 'table':
                 return {
                     title: 'Table',
-                    content: <MutationsTable data={filteredData.tableData} proportionInterval={proportionInterval} />,
+                    content: (
+                        <MutationsTable
+                            data={filteredData.tableData}
+                            proportionInterval={proportionInterval}
+                            pageSize={pageSize}
+                        />
+                    ),
                 };
             case 'grid':
                 return {
@@ -117,13 +126,14 @@ const MutationsTabs: FunctionComponent<MutationTabsProps> = ({ mutationsData, se
                             data={filteredData.gridData}
                             sequenceType={sequenceType}
                             proportionInterval={proportionInterval}
+                            pageSize={pageSize}
                         />
                     ),
                 };
             case 'insertions':
                 return {
                     title: 'Insertions',
-                    content: <InsertionsTable data={filteredData.insertions} />,
+                    content: <InsertionsTable data={filteredData.insertions} pageSize={pageSize} />,
                 };
         }
     };

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-table.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-table.tsx
@@ -7,9 +7,10 @@ import { formatProportion } from '../shared/table/formatProportion';
 interface PrevalenceOverTimeTableProps {
     data: PrevalenceOverTimeData;
     granularity: TemporalGranularity;
+    pageSize: boolean | number;
 }
 
-const PrevalenceOverTimeTable = ({ data, granularity }: PrevalenceOverTimeTableProps) => {
+const PrevalenceOverTimeTable = ({ data, granularity, pageSize }: PrevalenceOverTimeTableProps) => {
     const getSplitColumns = (data: PrevalenceOverTimeData) => {
         return data.map((dataset) => ({
             name: dataset.displayName,
@@ -40,7 +41,7 @@ const PrevalenceOverTimeTable = ({ data, granularity }: PrevalenceOverTimeTableP
         return Object.values(dataByHeader).map((row) => Object.values(row));
     };
 
-    return <Table data={getData(data, granularity)} columns={getColumns(data)} pagination={false} />;
+    return <Table data={getData(data, granularity)} columns={getColumns(data)} pageSize={pageSize} />;
 };
 
 export default PrevalenceOverTimeTable;

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
@@ -32,6 +32,7 @@ export default {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        pageSize: { control: 'object' },
     },
 };
 
@@ -49,6 +50,7 @@ const Template = {
                 height={args.height}
                 headline={args.headline}
                 lapisDateField={args.lapisDateField}
+                pageSize={args.pageSize}
             />
         </LapisUrlContext.Provider>
     ),
@@ -70,6 +72,7 @@ export const TwoVariants = {
         height: '700px',
         headline: 'Prevalence over time',
         lapisDateField: 'date',
+        pageSize: 10,
     },
     parameters: {
         fetchMock: {
@@ -142,6 +145,7 @@ export const OneVariant = {
         height: '700px',
         headline: 'Prevalence over time',
         lapisDateField: 'date',
+        pageSize: 10,
     },
     parameters: {
         fetchMock: {

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -40,6 +40,7 @@ export interface PrevalenceOverTimeInnerProps {
     views: View[];
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     lapisDateField: string;
+    pageSize: boolean | number;
 }
 
 export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
@@ -53,6 +54,7 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
     height,
     headline = 'Prevalence over time',
     lapisDateField,
+    pageSize,
 }) => {
     const size = { height, width };
 
@@ -68,6 +70,7 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
                         views={views}
                         confidenceIntervalMethods={confidenceIntervalMethods}
                         lapisDateField={lapisDateField}
+                        pageSize={pageSize}
                     />
                 </Headline>
             </ResizeContainer>
@@ -83,6 +86,7 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
     views,
     confidenceIntervalMethods,
     lapisDateField,
+    pageSize,
 }) => {
     const lapis = useContext(LapisUrlContext);
 
@@ -109,6 +113,7 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
             data={data}
             granularity={granularity}
             confidenceIntervalMethods={confidenceIntervalMethods}
+            pageSize={pageSize}
         />
     );
 };
@@ -118,6 +123,7 @@ type PrevalenceOverTimeTabsProps = {
     data: PrevalenceOverTimeData;
     granularity: TemporalGranularity;
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
+    pageSize: boolean | number;
 };
 
 const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = ({
@@ -125,6 +131,7 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
     data,
     granularity,
     confidenceIntervalMethods,
+    pageSize,
 }) => {
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
     const [confidenceIntervalMethod, setConfidenceIntervalMethod] = useState<ConfidenceIntervalMethod>(
@@ -163,7 +170,7 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
             case 'table':
                 return {
                     title: 'Table',
-                    content: <PrevalenceOverTimeTable data={data} granularity={granularity} />,
+                    content: <PrevalenceOverTimeTable data={data} granularity={granularity} pageSize={pageSize} />,
                 };
         }
     };

--- a/components/src/web-components/visualization/gs-aggregate.stories.ts
+++ b/components/src/web-components/visualization/gs-aggregate.stories.ts
@@ -19,6 +19,7 @@ const codeExample = `
     height='700px'
     initialSortField="count"
     initialSortDirection="descending"
+    pageSize="10"
 ></gs-aggregate>`;
 
 const meta: Meta<Required<AggregateProps>> = {
@@ -33,6 +34,7 @@ const meta: Meta<Required<AggregateProps>> = {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        pageSize: { control: 'object' },
         initialSortField: { control: 'text' },
         initialSortDirection: {
             options: ['ascending', 'descending'],
@@ -81,6 +83,7 @@ export const Table: StoryObj<Required<AggregateProps>> = {
                 .headline=${args.headline}
                 .initialSortField=${args.initialSortField}
                 .initialSortDirection=${args.initialSortDirection}
+                .pageSize=${args.pageSize}
             ></gs-aggregate>
         </gs-app>
     `,
@@ -95,5 +98,6 @@ export const Table: StoryObj<Required<AggregateProps>> = {
         headline: 'Aggregate',
         initialSortField: 'count',
         initialSortDirection: 'descending',
+        pageSize: 10,
     },
 };

--- a/components/src/web-components/visualization/gs-aggregate.tsx
+++ b/components/src/web-components/visualization/gs-aggregate.tsx
@@ -80,6 +80,13 @@ export class AggregateComponent extends PreactLitAdapterWithGridJsStyles {
     @property({ type: String })
     initialSortDirection: 'ascending' | 'descending' = 'descending';
 
+    /**
+     * The maximum number of rows to display in the table view.
+     * Set to `false` to disable pagination. Set to `true` to enable pagination with a default limit (10).
+     */
+    @property({ type: Object })
+    pageSize: boolean | number = false;
+
     override render() {
         return (
             <Aggregate
@@ -91,6 +98,7 @@ export class AggregateComponent extends PreactLitAdapterWithGridJsStyles {
                 headline={this.headline}
                 initialSortField={this.initialSortField}
                 initialSortDirection={this.initialSortDirection}
+                pageSize={this.pageSize}
             />
         );
     }

--- a/components/src/web-components/visualization/gs-mutation-comparison.stories.ts
+++ b/components/src/web-components/visualization/gs-mutation-comparison.stories.ts
@@ -19,6 +19,7 @@ const codeExample = String.raw`
     headline="Mutation comparison"
     width='100%'
     height='700px'
+    pageSize="10"
 ></gs-mutation-comparison>`;
 
 const meta: Meta<Required<MutationComparisonProps>> = {
@@ -37,6 +38,7 @@ const meta: Meta<Required<MutationComparisonProps>> = {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        pageSize: { control: 'object' },
     },
     parameters: withComponentDocs({
         componentDocs: {
@@ -60,6 +62,7 @@ const Template: StoryObj<Required<MutationComparisonProps>> = {
                 .width=${args.width}
                 .height=${args.height}
                 .headline=${args.headline}
+                .pageSize=${args.pageSize}
             ></gs-mutation-comparison>
         </gs-app>
     `,
@@ -91,6 +94,7 @@ export const Default: StoryObj<Required<MutationComparisonProps>> = {
         width: '100%',
         height: '700px',
         headline: 'Mutation comparison',
+        pageSize: 10,
     },
     parameters: {
         fetchMock: {

--- a/components/src/web-components/visualization/gs-mutation-comparison.tsx
+++ b/components/src/web-components/visualization/gs-mutation-comparison.tsx
@@ -82,6 +82,13 @@ export class MutationComparisonComponent extends PreactLitAdapterWithGridJsStyle
     @property({ type: String })
     headline: string = 'Mutation comparison';
 
+    /**
+     * The maximum number of rows to display in the table view.
+     * Set to `false` to disable pagination. Set to `true` to enable pagination with a default limit (10).
+     */
+    @property({ type: Object })
+    pageSize: boolean | number = false;
+
     override render() {
         return (
             <MutationComparison
@@ -91,6 +98,7 @@ export class MutationComparisonComponent extends PreactLitAdapterWithGridJsStyle
                 width={this.width}
                 height={this.height}
                 headline={this.headline}
+                pageSize={this.pageSize}
             />
         );
     }

--- a/components/src/web-components/visualization/gs-mutations.stories.ts
+++ b/components/src/web-components/visualization/gs-mutations.stories.ts
@@ -19,6 +19,7 @@ const codeExample = String.raw`
     headline="Mutations"
     width='100%'
     height='700px'
+    pageSize="10"
 ></gs-mutations>`;
 
 const meta: Meta<Required<MutationsProps>> = {
@@ -37,6 +38,7 @@ const meta: Meta<Required<MutationsProps>> = {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        pageSize: { control: 'object' },
     },
     args: {
         variant: { country: 'Switzerland', pangoLineage: 'B.1.1.7', dateTo: '2022-01-01' },
@@ -45,6 +47,7 @@ const meta: Meta<Required<MutationsProps>> = {
         width: '100%',
         height: '700px',
         headline: 'Mutations',
+        pageSize: 10,
     },
     parameters: withComponentDocs({
         componentDocs: {
@@ -68,6 +71,7 @@ const Template: StoryObj<Required<MutationsProps>> = {
                 .width=${args.width}
                 .height=${args.height}
                 .headline=${args.headline}
+                .pageSize=${args.pageSize}
             ></gs-mutations>
         </gs-app>
     `,

--- a/components/src/web-components/visualization/gs-mutations.tsx
+++ b/components/src/web-components/visualization/gs-mutations.tsx
@@ -77,6 +77,13 @@ export class MutationsComponent extends PreactLitAdapterWithGridJsStyles {
     @property({ type: String })
     headline: string = 'Mutations';
 
+    /**
+     * The maximum number of rows to display in the table view.
+     * Set to `false` to disable pagination. Set to `true` to enable pagination with a default limit (10).
+     */
+    @property({ type: Object })
+    pageSize: boolean | number = false;
+
     override render() {
         return (
             <Mutations
@@ -86,6 +93,7 @@ export class MutationsComponent extends PreactLitAdapterWithGridJsStyles {
                 width={this.width}
                 height={this.height}
                 headline={this.headline}
+                pageSize={this.pageSize}
             />
         );
     }

--- a/components/src/web-components/visualization/gs-prevalence-over-time.stories.ts
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.stories.ts
@@ -26,6 +26,7 @@ const codeExample = String.raw`
     width="100%"
     height="700px"
     lapisDateField="date"
+    pageSize="10"
 ></gs-prevalence-over-time>`;
 
 const meta: Meta<Required<PrevalenceOverTimeProps>> = {
@@ -50,6 +51,7 @@ const meta: Meta<Required<PrevalenceOverTimeProps>> = {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        pageSize: { control: 'object' },
     },
     parameters: withComponentDocs({
         componentDocs: {
@@ -77,6 +79,7 @@ const Template: StoryObj<Required<PrevalenceOverTimeProps>> = {
                 .height=${args.height}
                 .headline=${args.headline}
                 .lapisDateField=${args.lapisDateField}
+                .pageSize=${args.pageSize}
             ></gs-prevalence-over-time>
         </gs-app>
     `,
@@ -98,6 +101,7 @@ export const TwoVariants: StoryObj<Required<PrevalenceOverTimeProps>> = {
         height: '700px',
         headline: 'Prevalence over time',
         lapisDateField: 'date',
+        pageSize: 10,
     },
     parameters: {
         fetchMock: {
@@ -170,6 +174,7 @@ export const OneVariant: StoryObj<Required<PrevalenceOverTimeProps>> = {
         height: '700px',
         headline: 'Prevalence over time',
         lapisDateField: 'date',
+        pageSize: 10,
     },
     parameters: {
         fetchMock: {

--- a/components/src/web-components/visualization/gs-prevalence-over-time.tsx
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.tsx
@@ -53,16 +53,16 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
      * which will be used as the label for the variant in the views,
      * or an array of such objects.
      */
-    @property({type: Object})
+    @property({ type: Object })
     numerator:
         {
             lapisFilter: Record<string, string | number | null | boolean>;
             displayName: string;
         }
         | {
-            lapisFilter: Record<string, string | number | null | boolean>;
-            displayName: string;
-        }[] = { displayName: '', lapisFilter: {} };
+        lapisFilter: Record<string, string | number | null | boolean>;
+        displayName: string;
+    }[] = { displayName: '', lapisFilter: {} };
 
     /**
      * Required.
@@ -136,6 +136,13 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
     @property({ type: String })
     lapisDateField: string = 'date';
 
+    /**
+     * The maximum number of rows to display in the table view.
+     * Set to `false` to disable pagination. Set to `true` to enable pagination with a default limit (10).
+     */
+    @property({ type: Object })
+    pageSize: boolean | number = false;
+
     override render() {
         return (
             <PrevalenceOverTime
@@ -149,6 +156,7 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
                 height={this.height}
                 headline={this.headline}
                 lapisDateField={this.lapisDateField}
+                pageSize={this.pageSize}
             />
         );
     }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #271

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Lets the maintainer set the paginationLimit for all tables. It can either be a number, which sets the number of rows, or a boolean. A value of  `true` produces the default pagination from gridjs. A value of `false` will disable pagination.

This targets the first step of #271. The other will be done in a separate PR.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/58048b7f-f6c7-4c65-9fa0-6db312949c77)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
