### PR TITLE
fix: covid single variant page in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
         "@astrojs/node": "^8.3.2",
         "astro": "^4.11.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "@tanstack/react-query": "^5.50.1"
     },
     "devDependencies": {
         "@astrojs/check": "^0.7.0",
         "@astrojs/react": "^3.6.0",
         "@astrojs/tailwind": "^5.1.0",
         "@genspectrum/dashboard-components": "^0.5.1",
-        "@tanstack/react-query": "^5.50.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "prettier": "^3.3.2",


### PR DESCRIPTION
### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
When navigating to `https://staging.genspectrum.org/covid/single-variant?nextcladePangoLineage=JN.1*` a 500 error is returned. This error is caused by a missing dependency, which was moved in #1. This now moves it back.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
