### PR TITLE
chore: fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       - dependency-name: "@genspectrum/dashboard-components"
     commit-message:
       prefix: "chore(website)"
+    target-branch: "main"
   - package-ecosystem: npm
     directory: website/
     schedule:


### PR DESCRIPTION
### Summary

See https://github.com/GenSpectrum/dashboards/runs/28106333883
I'm not 100% sure whether this fixes the issue, but I don't know how to validate without trying it.
![grafik](https://github.com/user-attachments/assets/ca58cad7-b2f4-41b1-8588-3bf0a50a6c7c)

https://github.com/marocchino/validate-dependabot didn't work, it says the broken config is valid.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
