### PR TITLE
feat(backend): provide docker image of backend

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,6 +2,9 @@ name: Backend
 
 on: [ push ]
 
+env:
+  DOCKER_IMAGE_NAME: ghcr.io/genspectrum/dashboards/backend
+
 jobs:
   tests:
     name: Check format, lint and run tests
@@ -26,3 +29,42 @@ jobs:
 
       - name: Check Format And Lint
         run: ./gradlew ktlintCheck
+
+  dockerImage:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: dockerMetadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          tags: ${{ steps.dockerMetadata.outputs.tags }}
+          cache-from: type=gha,scope=dashboards-${{ github.ref }}
+          cache-to: type=gha,mode=max,scope=dashboards-${{ github.ref }}
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -3,7 +3,7 @@ name: Website
 on: [push]
 
 env:
-  DOCKER_IMAGE_NAME: ghcr.io/genspectrum/dashboards
+  DOCKER_IMAGE_NAME: ghcr.io/genspectrum/dashboards/website
 
 jobs:
   checks:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+FROM gradle:jdk21 AS build
+
+WORKDIR /workspace
+
+COPY . ./
+
+RUN ./gradlew bootJar
+
+FROM eclipse-temurin:21-alpine
+
+WORKDIR /workspace
+
+COPY --from=build /workspace/build/libs/*.jar app.jar
+
+COPY entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["./entrypoint.sh"]
+
+LABEL org.opencontainers.image.source="https://github.com/GenSpectrum/dashboards/backend"

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Takes JVM_OPTS as environment variable and passes it to the JVM
+JVM_OPTS=${JVM_OPTS:-}
+ARGS="${*}"
+
+GENERAL_OPTS="-jar app.jar \
+    $ARGS"
+
+if [ -n "$JVM_OPTS" ]; then
+    CMD="java $JVM_OPTS $GENERAL_OPTS"
+else
+    CMD="java $GENERAL_OPTS"
+fi
+echo Running application with command:
+echo "$CMD"
+$CMD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  website:
+    image: ghcr.io/genspectrum/dashboards/website:${WEBSITE_TAG}
+    ports:
+      - "9020:4321"
+    volumes:
+      - type: bind
+        source: ./website/tests/config
+        target: /config
+        read_only: true
+  
+  backend:
+    image: ghcr.io/genspectrum/dashboards/backend:${BACKEND_TAG}
+    ports:
+      - "9021:8080"


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
Runs the backend in docker and. This uses an entrypoint script to be able to pass jvm options to the execution of the backend. 

This adds a docker-compose file to run both the website and the backend docker containers.

The docker container is build in ci and pushed on ghcr.

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
