### PR TITLE
feat(backend): add POST subscriptions endpoint #73

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 .idea/
 
 logs
+
+# generated types
+.astro/
+
+# dependencies
+node_modules/

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsController.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsController.kt
@@ -1,69 +1,29 @@
 package org.genspectrum.dashboardsbackend.controller
 
-import org.genspectrum.dashboardsbackend.subscriptions.CountTrigger
-import org.genspectrum.dashboardsbackend.subscriptions.DateWindow
-import org.genspectrum.dashboardsbackend.subscriptions.EvaluationInterval
-import org.genspectrum.dashboardsbackend.subscriptions.Organism
+import org.genspectrum.dashboardsbackend.model.SubscriptionModel
 import org.genspectrum.dashboardsbackend.subscriptions.Subscription
+import org.genspectrum.dashboardsbackend.subscriptions.SubscriptionRequest
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class SubscriptionsController {
+class SubscriptionsController(
+    val subscriptionModel: SubscriptionModel,
+) {
+
     @GetMapping("/subscriptions", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getSubscriptions(): List<Subscription> {
-        return DUMMY_SUBSCRIPTIONS
+        return subscriptionModel.getSubscriptions()
+    }
+
+    @PostMapping("/subscriptions")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun postSubscriptions(@RequestBody subscription: SubscriptionRequest) {
+        subscriptionModel.postSubscriptions(subscription)
     }
 }
-
-val DUMMY_SUBSCRIPTIONS =
-    listOf(
-        Subscription(
-            id = "1",
-            name = "My search",
-            filter = mapOf(
-                "country" to "Germany",
-                "dateFrom" to "2024-01-01",
-                "dateTo" to "2024-01-05",
-            ),
-            interval = EvaluationInterval.WEEKLY,
-            dateWindow = DateWindow.LAST_6_MONTHS,
-            trigger = CountTrigger(10),
-            active = true,
-            conditionsMet = true,
-            organism = Organism.COVID,
-        ),
-        Subscription(
-            id = "2",
-            name = "My other search",
-            filter =
-            mapOf(
-                "country" to "Switzerland",
-                "dateFrom" to "2024-01-01",
-                "dateTo" to "2024-01-05",
-            ),
-            interval = EvaluationInterval.DAILY,
-            dateWindow = DateWindow.LAST_6_MONTHS,
-            trigger = CountTrigger(20),
-            active = true,
-            conditionsMet = false,
-            organism = Organism.COVID,
-        ),
-        Subscription(
-            id = "3",
-            name = "My third search",
-            filter =
-            mapOf(
-                "country" to "Germany",
-                "dateFrom" to "2024-01-01",
-                "dateTo" to "2024-01-05",
-            ),
-            interval = EvaluationInterval.WEEKLY,
-            dateWindow = DateWindow.LAST_6_MONTHS,
-            trigger = CountTrigger(13),
-            active = true,
-            conditionsMet = true,
-            organism = Organism.RSV_A,
-        ),
-    )

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/SubscriptionModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/SubscriptionModel.kt
@@ -1,0 +1,32 @@
+package org.genspectrum.dashboardsbackend.model
+
+import org.genspectrum.dashboardsbackend.subscriptions.Subscription
+import org.genspectrum.dashboardsbackend.subscriptions.SubscriptionRequest
+import org.springframework.stereotype.Service
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+
+@Service
+class SubscriptionModel {
+    val inMemorySubscriptions = CopyOnWriteArrayList<Subscription>()
+
+    fun getSubscriptions(): List<Subscription> {
+        return inMemorySubscriptions
+    }
+
+    fun postSubscriptions(request: SubscriptionRequest) {
+        inMemorySubscriptions.add(
+            Subscription(
+                id = UUID.randomUUID().toString(),
+                name = request.name,
+                filter = request.filter,
+                interval = request.interval,
+                dateWindow = request.dateWindow,
+                trigger = request.trigger,
+                organism = request.organism,
+                active = true,
+                conditionsMet = false,
+            ),
+        )
+    }
+}

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsControllerTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsControllerTest.kt
@@ -1,12 +1,21 @@
 package org.genspectrum.dashboardsbackend.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.genspectrum.dashboardsbackend.subscriptions.CountTrigger
+import org.genspectrum.dashboardsbackend.subscriptions.DateWindow
+import org.genspectrum.dashboardsbackend.subscriptions.EvaluationInterval
+import org.genspectrum.dashboardsbackend.subscriptions.Organism
+import org.genspectrum.dashboardsbackend.subscriptions.Subscription
+import org.genspectrum.dashboardsbackend.subscriptions.SubscriptionRequest
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -14,12 +23,51 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @AutoConfigureMockMvc
 class SubscriptionsControllerTest(
     @Autowired val mockMvc: MockMvc,
-    @Autowired var objectMapper: ObjectMapper,
+    @Autowired val objectMapper: ObjectMapper,
 ) {
     @Test
-    fun `GET subscriptions returns a list of subscriptions`() {
-        mockMvc.perform(get("/subscriptions"))
+    fun `After a POST subscriptions it can be retrieved again through GET subscriptions`() {
+        val request = SubscriptionRequest(
+            name = "My search",
+            filter = mapOf(
+                "country" to "France",
+                "dateFrom" to "2024-01-01",
+                "dateTo" to "2024-01-05",
+            ),
+            interval = EvaluationInterval.MONTHLY,
+            dateWindow = DateWindow.LAST_6_MONTHS,
+            trigger = CountTrigger(30),
+            organism = Organism.COVID,
+        )
+
+        mockMvc.perform(
+            post("/subscriptions")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON),
+        )
+            .andExpect(status().isNoContent)
+
+        val result = mockMvc.perform(get("/subscriptions"))
             .andExpect(status().isOk)
-            .andExpect(content().json(objectMapper.writeValueAsString(DUMMY_SUBSCRIPTIONS)))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn()
+
+        val subscriptions: List<Subscription> = objectMapper.readValue(
+            result.response.contentAsString,
+            objectMapper.typeFactory.constructCollectionType(List::class.java, Subscription::class.java),
+        )
+
+        assertTrue(
+            subscriptions.any {
+                it.name == request.name &&
+                    it.interval == request.interval &&
+                    it.organism == request.organism &&
+                    it.dateWindow == request.dateWindow &&
+                    it.filter == request.filter &&
+                    it.trigger == request.trigger &&
+                    it.active &&
+                    !it.conditionsMet
+            },
+        )
     }
 }

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/subscriptions/SubscriptionTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/subscriptions/SubscriptionTest.kt
@@ -47,6 +47,7 @@ class SubscriptionTest {
                 "someOtherFilter": "value2"
               },
               "trigger": {
+                "type": "countTrigger",
                 "count": 10
               }
             }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #73

### Summary
This adds the POST endpoint /subscriptions. The posted data is persisted in memory. The GET endpoint no longer returns dummy data, but the data posted to the backend.
<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
