### PR TITLE
feat(backend): add oauth2 for all endpoints #75

### DIFF
--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/SwaggerUiTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/SwaggerUiTest.kt
@@ -1,0 +1,51 @@
+package org.genspectrum.dashboardsbackend
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.hamcrest.core.StringContains.containsString
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SwaggerUiTest(@Autowired val mockMvc: MockMvc) {
+
+    @Test
+    fun `Swagger UI endpoint is reachable`() {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("text/html"))
+            .andExpect(content().string(containsString("Swagger UI")))
+    }
+
+    @Test
+    fun `JSON API docs are available`() {
+        mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/json"))
+            .andExpect(jsonPath("\$.openapi").exists())
+            .andExpect(jsonPath("\$.paths./subscriptions").exists())
+    }
+
+    @Test
+    fun `YAML API docs are available`() {
+        val result = mockMvc.perform(get("/v3/api-docs.yaml"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/vnd.oai.openapi"))
+            .andReturn()
+
+        val objectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
+        val yaml = objectMapper.readTree(result.response.contentAsString)
+        assertTrue(yaml.has("openapi"))
+        assertTrue(yaml.get("paths").has("/subscriptions"))
+    }
+}

--- a/website/src/auth.config.mjs
+++ b/website/src/auth.config.mjs
@@ -6,6 +6,15 @@ const authConfig = getDashboardsConfig().auth;
 const secretsConfig = getSecretsConfig();
 
 export default defineConfig({
+    callbacks: {
+        session: async ({ session, token }) => {
+            if (session?.user) {
+                session.user.id = token.sub;
+            }
+
+            return session;
+        },
+    },
     providers: [
         GitHub({
             clientId: authConfig.github.clientId,

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -29,7 +29,11 @@ const dashboardsConfigSchema = z
                 clientId: z.string(),
             }),
         }),
+        backend: z.object({
+            url: z.string(),
+        }),
     });
+
 export type DashboardsConfig = z.infer<typeof dashboardsConfigSchema>;
 
 const secretsConfigSchema = z.object({

--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -1,1 +1,5 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+// declare module 'set-cookie-parser' is added, because tsc checks our dependency auth-astro/server,
+// which uses set-cookie-parser, and it doesn't have types.
+declare module 'set-cookie-parser';

--- a/website/src/pages/api/subscriptions/[...path].ts
+++ b/website/src/pages/api/subscriptions/[...path].ts
@@ -1,0 +1,78 @@
+import { getSession } from 'auth-astro/server';
+import { getDashboardsConfig } from '../../../config.ts';
+
+const API_PATHNAME_LENGTH = '/api'.length;
+
+export async function ALL({ request }: { request: Request }) {
+    const session = await getSession(request);
+
+    if (!session || !session.user?.id) {
+        return getUnauthorizedResponse(request.url);
+    }
+
+    const backendUrl = getBackendUrl(request, session.user.id);
+
+    try {
+        const response = await fetch(backendUrl, request);
+
+        return new Response(response.body, {
+            status: response.status,
+            headers: response.headers,
+        });
+    } catch (error) {
+        console.error(error);
+        return getInternalErrorResponse(request.url);
+    }
+}
+
+function getBackendUrl(request: Request, userId: string) {
+    const backendEndpoint = new URL(request.url).pathname.slice(API_PATHNAME_LENGTH);
+    const backendUrl = new URL(backendEndpoint, getDashboardsConfig().backend.url);
+
+    new URL(request.url).searchParams.forEach((value, key) => {
+        backendUrl.searchParams.set(key, value);
+    });
+
+    backendUrl.searchParams.set('userId', userId);
+
+    return backendUrl;
+}
+
+type BackendError = {
+    title: string;
+    detail: string;
+    status: number;
+    instance: string;
+};
+
+const getUnauthorizedResponse = (requestUrl: string) => {
+    const response: BackendError = {
+        title: 'Unauthorized',
+        detail: "You're not authorized to access this resource",
+        status: 401,
+        instance: requestUrl,
+    };
+
+    return new Response(JSON.stringify({ response }), {
+        status: 401,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+};
+
+const getInternalErrorResponse = (requestUrl: string) => {
+    const response: BackendError = {
+        title: 'Internal Server Error',
+        detail: "Couldn't fetch data from the backend",
+        status: 500,
+        instance: requestUrl,
+    };
+
+    return new Response(JSON.stringify({ response }), {
+        status: 500,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+};

--- a/website/tests/config/dashboards_config.example.json
+++ b/website/tests/config/dashboards_config.example.json
@@ -21,5 +21,8 @@
         "github": {
             "clientId": "Create a GitHub App and add your client ID here: https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app"
         }
+    },
+    "backend": {
+        "url": "http://your-backend-url-here"
     }
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #75

### Summary
This adds outh2 authentification to the backend. We use the same cookies we produce on the website. It is currently not possible to add the auth to swagger. This will be done in #116

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
