### PR TITLE
feat(website): use `mainDateField` from config

### DIFF
--- a/website/src/components/LocationTimeFilter.astro
+++ b/website/src/components/LocationTimeFilter.astro
@@ -1,6 +1,7 @@
 ---
 import { isCustomDateRange } from '../routes/helpers';
 import type { DateRange } from '../routes/helpers';
+import { getDashboardsConfig } from '../config';
 
 interface Props {
     fields: string[];
@@ -25,7 +26,10 @@ const initialDateRangeFrom = isCustomDateRange(initialDateRange) ? initialDateRa
 const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRange.to : undefined;
 ---
 
-<location-time-filter data-message={JSON.stringify({ location: initialLocation, dateRange: initialDateRange })}>
+<location-time-filter
+    data-message={JSON.stringify({ location: initialLocation, dateRange: initialDateRange })}
+    data-organisms-config={JSON.stringify(getDashboardsConfig().dashboards.organisms)}
+>
     <div class='flex flex-wrap items-stretch gap-2'>
         <gs-location-filter
             id='locationFilter'
@@ -58,6 +62,7 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
         constructor() {
             super();
             let { location, dateRange } = JSON.parse(this.dataset.message!);
+            const config = JSON.parse(this.dataset.organismsConfig!);
             const locationFilter = document.getElementById('locationFilter');
             const dateRangeSelector = document.getElementById('dateRangeSelector');
             const submitButton = document.getElementById('locationTimeFilterSubmitButton');
@@ -74,9 +79,11 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
             });
 
             submitButton?.addEventListener('click', () => {
+                const routing = new Routing(config);
+
                 // TODO This component currently assumes that it is used under a route that has a baseline filter.
                 //  We should either make it more flexible or document the behavior
-                const currentRoute = Routing.getCurrentRouteInBrowser() as any;
+                const currentRoute = routing.getCurrentRouteInBrowser() as any;
                 const newRoute = {
                     ...currentRoute,
                     baselineFilter: {
@@ -85,7 +92,7 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
                         dateRange,
                     },
                 };
-                Routing.navigateTo(newRoute);
+                routing.navigateTo(newRoute);
             });
         }
     }

--- a/website/src/components/VariantFilter.astro
+++ b/website/src/components/VariantFilter.astro
@@ -1,6 +1,7 @@
 ---
 import type { LapisMutationQuery } from '../routes/helpers';
 import { type Field } from './VariantFilterTypes';
+import { getDashboardsConfig } from '../config';
 
 interface Props {
     fields: Field[];
@@ -10,7 +11,10 @@ interface Props {
 const { fields, initialMutations } = Astro.props;
 ---
 
-<variant-filter data-message={JSON.stringify({ fields })}>
+<variant-filter
+    data-message={JSON.stringify({ fields })}
+    data-organisms-config={JSON.stringify(getDashboardsConfig().dashboards.organisms)}
+>
     <div class='flex flex-col items-stretch gap-2'>
         {
             fields.map((field) =>
@@ -51,6 +55,7 @@ const { fields, initialMutations } = Astro.props;
         constructor() {
             super();
             const { fields } = JSON.parse(this.dataset.message!) as { fields: Field[] };
+            const config = JSON.parse(this.dataset.organismsConfig!);
             let values: Record<string, string | undefined> = {};
             for (const field of fields) {
                 values[field.name] = field.initialValue;
@@ -72,12 +77,13 @@ const { fields, initialMutations } = Astro.props;
             });
 
             submitButton?.addEventListener('click', () => {
-                const currentRoute = Routing.getCurrentRouteInBrowser()!;
+                const routing = new Routing(config);
+                const currentRoute = routing.getCurrentRouteInBrowser()!;
                 const newRoute = {
                     ...currentRoute,
                     variantFilter: values,
                 };
-                Routing.navigateTo(newRoute);
+                routing.navigateTo(newRoute);
             });
         }
     }

--- a/website/src/components/covidView1/CollectionsList.tsx
+++ b/website/src/components/covidView1/CollectionsList.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { Routing } from '../../routes/routing.ts';
-import { CovidView1 } from '../../routes/covid.ts';
+import { type CovidView1Route } from '../../routes/covid.ts';
+import type { OrganismsConfig } from '../../config.ts';
 
 type CollectionVariant = {
     name: string;
@@ -17,9 +18,10 @@ type Collection = {
 
 type CollectionsListProps = {
     initialCollectionId?: number;
+    organismsConfig: OrganismsConfig;
 };
 
-const CollectionsListInner = ({ initialCollectionId }: CollectionsListProps) => {
+const CollectionsListInner = ({ initialCollectionId, organismsConfig }: CollectionsListProps) => {
     const [selectedCollectionId, setSelectedCollectionId] = useState(initialCollectionId ?? 1);
 
     const query = useQuery({
@@ -45,6 +47,7 @@ const CollectionsListInner = ({ initialCollectionId }: CollectionsListProps) => 
             />
             <CollectionVariantList
                 collection={query.data.find((c) => c.id === selectedCollectionId) ?? query.data[0]}
+                organismsConfig={organismsConfig}
             />
         </>
     );
@@ -81,14 +84,17 @@ const CollectionSelector = ({ collections, selectedId, onSelect }: CollectionSel
 
 type CollectionVariantListProps = {
     collection: Collection;
+    organismsConfig: OrganismsConfig;
 };
 
-const CollectionVariantList = ({ collection }: CollectionVariantListProps) => {
+const CollectionVariantList = ({ collection, organismsConfig }: CollectionVariantListProps) => {
     const variants = collection.variants;
 
+    const routing = useMemo(() => new Routing(organismsConfig), [organismsConfig]);
+
     const selectVariant = (variant: CollectionVariant) => {
-        const currentRoute = Routing.getCurrentRouteInBrowser() as CovidView1.Route;
-        let newRoute: CovidView1.Route;
+        const currentRoute = routing.getCurrentRouteInBrowser() as CovidView1Route;
+        let newRoute: CovidView1Route;
         const query = JSON.parse(variant.query);
         if ('variantQuery' in query) {
             newRoute = {
@@ -111,7 +117,7 @@ const CollectionVariantList = ({ collection }: CollectionVariantListProps) => {
                 },
             };
         }
-        Routing.navigateTo(newRoute);
+        routing.navigateTo(newRoute);
     };
 
     return (

--- a/website/src/components/covidView2/JointFilter.astro
+++ b/website/src/components/covidView2/JointFilter.astro
@@ -2,8 +2,9 @@
 import type { LapisMutationQuery } from '../../routes/helpers';
 import type { LapisLocation1 } from '../../routes/helpers';
 import type { DateRange } from '../../routes/helpers';
-import { CovidView1 } from '../../routes/covid';
 import { isCustomDateRange } from '../../routes/helpers';
+import { ServerSide } from '../../routes/serverSideRouting';
+import { getDashboardsConfig } from '../../config';
 
 interface Props {
     filterId: number;
@@ -30,6 +31,7 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
         nextcladePangoLineage: initialNextcladePangoLineage,
         mutations: initialMutations,
     })}
+    data-organisms-config={JSON.stringify(getDashboardsConfig().dashboards.organisms)}
 >
     <div>
         <div class='flex'>
@@ -43,8 +45,8 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
                     width='100%'></gs-location-filter>
                 <gs-date-range-selector
                     id={`dateRangeSelector${filterId}`}
-                    customSelectOptions={JSON.stringify(CovidView1.view.customDateRangeOptions)}
-                    earliestDate={CovidView1.view.earliestDate}
+                    customSelectOptions={JSON.stringify(ServerSide.covidView1.customDateRangeOptions)}
+                    earliestDate={ServerSide.covidView1.earliestDate}
                     initialValue={initialDateRangeValue}
                     initialDateFrom={initialDateRangeFrom}
                     initialDateTo={initialDateRangeTo}
@@ -81,12 +83,13 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
 
 <script>
     import { Routing } from '../../routes/routing.ts';
-    import { CovidView2 } from '../../routes/covid';
+    import { CovidView2, type CovidView2Route } from '../../routes/covid';
 
     class JointFilter extends HTMLElement {
         constructor() {
             super();
             let { filterId, location, dateRange, nextcladePangoLineage, mutations } = JSON.parse(this.dataset.message!);
+            const config = JSON.parse(this.dataset.organismsConfig!);
             const locationFilter = document.getElementById(`locationFilter${filterId}`);
             const dateRangeSelector = document.getElementById(`dateRangeSelector${filterId}`);
             const lineageFilter = document.getElementById(`lineageFilter${filterId}`);
@@ -113,9 +116,10 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
             });
 
             submitButton?.addEventListener('click', () => {
-                const currentRoute = Routing.getCurrentRouteInBrowser() as CovidView2.Route;
-                Routing.navigateTo(
-                    CovidView2.setFilter(currentRoute, {
+                const routing = new Routing(config);
+                const currentRoute = routing.getCurrentRouteInBrowser() as CovidView2Route;
+                routing.navigateTo(
+                    new CovidView2(config).setFilter(currentRoute, {
                         id: filterId,
                         baselineFilter: {
                             location,

--- a/website/src/components/rsv/RsvSequencingEffortsPage.astro
+++ b/website/src/components/rsv/RsvSequencingEffortsPage.astro
@@ -1,10 +1,8 @@
 ---
 import { chooseGranularityBasedOnDateRange } from '../../routes/helpers';
-import type { Organism } from '../../routes/View';
-import type { DateRange } from '../../routes/helpers';
+import { organismConfig } from '../../routes/View';
 import { RsvAView3 } from '../../routes/rsvA';
 import { RsvBView3 } from '../../routes/rsvB';
-import type { LapisLocation2 } from '../../routes/helpers';
 import { defaultTablePageSize, type Route } from '../../routes/View';
 import { getLapisUrl } from '../../config';
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
@@ -13,24 +11,18 @@ import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 
 interface Props {
-    view: RsvAView3.RsvAView3 | RsvBView3.RsvBView3;
-    routeData: Route & {
-        baselineFilter: {
-            location: LapisLocation2;
-            dateRange: DateRange;
-        };
-    };
-    titleName: string;
-    organism: Organism;
+    view: RsvAView3 | RsvBView3;
 }
 
-const { view, routeData, titleName, organism } = Astro.props;
+const { view } = Astro.props;
 
-const baselineFilter = RsvAView3.view.toLapisFilter(routeData);
+const routeData = view.parseUrl(Astro.url);
+
+const baselineFilter = view.toLapisFilter(routeData);
 
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter.sample_collection_dateFrom,
-    to: baselineFilter.sample_collection_dateTo,
+    from: baselineFilter[`${view.mainDateField}From`] as string,
+    to: baselineFilter[`${view.mainDateField}To`] as string,
 });
 let subDivisionField = undefined;
 let subDivisionLabel = '';
@@ -43,8 +35,8 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
 }
 ---
 
-<BaseLayout title={`Sequencing Efforts | ${titleName} | GenSpectrum`}>
-    <gs-app lapis={getLapisUrl(organism)}>
+<BaseLayout title={`Sequencing Efforts | ${organismConfig[view.organism].label} | GenSpectrum`}>
+    <gs-app lapis={getLapisUrl(view.organism)}>
         <div class='mb-4 flex items-center justify-center bg-blue-50 px-2 py-1'>
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
@@ -65,7 +57,7 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField='sample_collection_date'
+                    lapisDateField={view.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/components/rsv/RsvSingleVariantPage.astro
+++ b/website/src/components/rsv/RsvSingleVariantPage.astro
@@ -1,8 +1,7 @@
 ---
-import type { Organism } from '../../routes/View';
+import { organismConfig } from '../../routes/View';
 import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
 import type { DateRange, LapisLocation2, LapisVariantQuery1 } from '../../routes/helpers';
-import type { Route } from '../../routes/View';
 import { RsvAView1 } from '../../routes/rsvA';
 import { RsvBView1 } from '../../routes/rsvB';
 import { getLapisUrl } from '../../config';
@@ -14,24 +13,18 @@ import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 
 interface Props {
-    view: RsvAView1.RsvAView1 | RsvBView1.RsvBView1;
-    routeData: { variantFilter: LapisVariantQuery1 } & Route & {
-            baselineFilter: {
-                location: LapisLocation2;
-                dateRange: DateRange;
-            };
-        };
-    titleName: string;
-    organism: Organism;
+    view: RsvAView1 | RsvBView1;
 }
 
-const { view, routeData, titleName, organism } = Astro.props;
+const { view } = Astro.props;
 
-const variantFilter = RsvBView1.view.toLapisFilter(routeData);
-const baselineFilter = RsvBView1.view.toLapisFilterWithoutVariant(routeData);
+const routeData = view.parseUrl(Astro.url);
+
+const variantFilter = view.toLapisFilter(routeData);
+const baselineFilter = view.toLapisFilterWithoutVariant(routeData);
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter.sample_collection_dateFrom,
-    to: baselineFilter.sample_collection_dateTo,
+    from: baselineFilter[`${view.mainDateField}From`] as string,
+    to: baselineFilter[`${view.mainDateField}To`] as string,
 });
 
 let subDivisionField = undefined;
@@ -47,8 +40,8 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
 const initialMutations = extractMutations(variantFilter);
 ---
 
-<BaseLayout title={`Single Variant | ${titleName} | GenSpectrum`}>
-    <gs-app lapis={getLapisUrl(organism)}>
+<BaseLayout title={`Single Variant | ${organismConfig[view.organism].label} | GenSpectrum`}>
+    <gs-app lapis={getLapisUrl(view.organism)}>
         <div class='grid-cols-[300px_1fr] gap-x-4 sm:grid'>
             <div>
                 <div class='bg-blue-50 px-2 py-4'>
@@ -80,7 +73,7 @@ const initialMutations = extractMutations(variantFilter);
                                 lapisFilter: variantFilter,
                             })}
                             denominatorFilter={JSON.stringify(baselineFilter)}
-                            lapisDateField='sample_collection_date'
+                            lapisDateField={view.mainDateField}
                             granularity={timeGranularity}
                             smoothingWindow='0'
                             pageSize={defaultTablePageSize}
@@ -144,7 +137,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='sample_collection_date'></gs-mutations-over-time>
+                        lapisDateField={view.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -155,7 +148,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='sample_collection_date'></gs-mutations-over-time>
+                        lapisDateField={view.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -10,8 +10,9 @@ const lapisConfigSchema = z.object({
 });
 
 const organismConfigSchema = z.object({ lapis: lapisConfigSchema });
+export type OrganismConfig = z.infer<typeof organismConfigSchema>;
 
-const organismsSchema = z.object(
+const organismsConfigSchema = z.object(
     allOrganisms.reduce(
         (acc, organism) => ({
             ...acc,
@@ -20,10 +21,11 @@ const organismsSchema = z.object(
         {} as { [organism in Organism]: typeof organismConfigSchema },
     ),
 );
+export type OrganismsConfig = z.infer<typeof organismsConfigSchema>;
 
 const dashboardsConfigSchema = z.object({
     dashboards: z.object({
-        organisms: organismsSchema,
+        organisms: organismsConfigSchema,
         auth: z.object({
             github: z.object({
                 /**
@@ -53,8 +55,12 @@ export function getDashboardsConfig(): DashboardsConfig {
     return dashboardsConfig;
 }
 
+export function getOrganismConfig(organism: Organism): OrganismConfig {
+    return getDashboardsConfig().dashboards.organisms[organism];
+}
+
 export function getLapisUrl(organism: Organism): string {
-    return getDashboardsConfig().dashboards.organisms[organism].lapis.url;
+    return getOrganismConfig(organism).lapis.url;
 }
 
 let backendHost: string | null = null;

--- a/website/src/layouts/base/OrganismSelector.astro
+++ b/website/src/layouts/base/OrganismSelector.astro
@@ -1,8 +1,8 @@
 ---
-import { Routing } from '../../routes/routing';
 import { organismConfig } from '../../routes/View';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const currentRoute = Routing.parseUrl(Astro.url)!;
+const currentRoute = ServerSide.routing.parseUrl(Astro.url)!;
 const currentOrganism = currentRoute?.organism;
 ---
 

--- a/website/src/layouts/base/ViewSelector.astro
+++ b/website/src/layouts/base/ViewSelector.astro
@@ -1,7 +1,7 @@
 ---
-import { Routing } from '../../routes/routing';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const currentRoute = Routing.parseUrl(Astro.url)!;
+const currentRoute = ServerSide.routing.parseUrl(Astro.url)!;
 const organism = currentRoute?.organism;
 ---
 
@@ -11,10 +11,10 @@ const organism = currentRoute?.organism;
             <label>
                 View:
                 <select id='view-selector'>
-                    {Routing.views[organism].map((view) => (
+                    {ServerSide.routing.views[organism].map((view) => (
                         <option
                             value={view.pathname}
-                            data-url={Routing.toUrl(Routing.getDefaultRoute(view.pathname)!)}
+                            data-url={ServerSide.routing.toUrl(ServerSide.routing.getDefaultRoute(view.pathname)!)}
                             selected={currentRoute.pathname === view.pathname}
                         >
                             {view.label}

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -1,14 +1,13 @@
 ---
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
-import { CovidView2 } from '../../routes/covid';
 import JointFilter from '../../components/covidView2/JointFilter.astro';
 import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
-import { Routing } from '../../routes/routing';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = CovidView2.view.parseUrl(Astro.url);
+const routeData = ServerSide.covidView2.parseUrl(Astro.url);
 if (routeData === undefined) {
     throw Error('Failed to parse URL for side-by-side comparison page');
 }
@@ -19,10 +18,10 @@ if (routeData === undefined) {
         <div class='flex overflow-x-auto'>
             {
                 routeData.filters.map(({ id, variantFilter, baselineFilter }) => {
-                    const baselineLapisFilter = CovidView2.baselineFilterToLapisFilter(baselineFilter);
+                    const baselineLapisFilter = ServerSide.covidView2.baselineFilterToLapisFilter(baselineFilter);
                     const timeGranularity = chooseGranularityBasedOnDateRange({
-                        from: baselineLapisFilter.dateFrom,
-                        to: baselineLapisFilter.dateTo,
+                        from: baselineLapisFilter[`${ServerSide.covidView2.mainDateField}From`] as string,
+                        to: baselineLapisFilter[`${ServerSide.covidView2.mainDateField}To`] as string,
                     });
                     const initialMutations = extractMutations(variantFilter);
 
@@ -31,7 +30,7 @@ if (routeData === undefined) {
                             {routeData.filters.length > 1 && (
                                 <a
                                     class='block w-full px-2 py-1 hover:bg-neutral-100'
-                                    href={Routing.toUrl(CovidView2.removeFilter(routeData, id))}
+                                    href={ServerSide.routing.toUrl(ServerSide.covidView2.removeFilter(routeData, id))}
                                 >
                                     Remove column
                                 </a>
@@ -115,7 +114,7 @@ if (routeData === undefined) {
             }
             <a
                 class='px-4 pt-8 text-left hover:bg-neutral-100'
-                href={Routing.toUrl(CovidView2.addEmptyFilter(routeData))}
+                href={ServerSide.routing.toUrl(ServerSide.covidView2.addEmptyFilter(routeData))}
                 style='writing-mode: vertical-rl;'
             >
                 Add column

--- a/website/src/pages/covid/sequencing-efforts.astro
+++ b/website/src/pages/covid/sequencing-efforts.astro
@@ -2,17 +2,20 @@
 import { chooseGranularityBasedOnDateRange } from '../../routes/helpers';
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
-import { CovidView3 } from '../../routes/covid';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = CovidView3.parseUrl(Astro.url);
+const routeData = ServerSide.covidView3.parseUrl(Astro.url);
 
-const baselineFilter = CovidView3.toLapisFilter(routeData);
+const baselineFilter = ServerSide.covidView3.toLapisFilter(routeData);
 
-const timeGranularity = chooseGranularityBasedOnDateRange({ from: baselineFilter.dateFrom, to: baselineFilter.dateTo });
+const timeGranularity = chooseGranularityBasedOnDateRange({
+    from: baselineFilter[`${ServerSide.covidView3.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.covidView3.mainDateField}To`] as string,
+});
 let subDivisionField = undefined;
 let subDivisionLabel = '';
 if (routeData.baselineFilter.location.country === undefined) {
@@ -30,11 +33,11 @@ if (routeData.baselineFilter.location.country === undefined) {
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
                 <LocationTimeFilter
-                    fields={CovidView3.view.locationFields}
+                    fields={ServerSide.covidView3.locationFields}
                     initialLocation={baselineFilter}
                     initialDateRange={routeData.baselineFilter.dateRange}
-                    earliestDate={CovidView3.view.earliestDate}
-                    customDateRangeOptions={CovidView3.view.customDateRangeOptions}
+                    earliestDate={ServerSide.covidView3.earliestDate}
+                    customDateRangeOptions={ServerSide.covidView3.customDateRangeOptions}
                 />
             </div>
         </div>
@@ -46,7 +49,7 @@ if (routeData.baselineFilter.location.country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField='date'
+                    lapisDateField={ServerSide.covidView3.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -1,20 +1,23 @@
 ---
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import { CollectionsList } from '../../components/covidView1/CollectionsList';
-import { CovidView1 } from '../../routes/covid';
 import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
 import VariantFilter from '../../components/VariantFilter.astro';
-import { getLapisUrl } from '../../config';
+import { getDashboardsConfig, getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = CovidView1.view.parseUrl(Astro.url);
+const routeData = ServerSide.covidView1.parseUrl(Astro.url);
 
-const variantFilter = CovidView1.toLapisFilter(routeData);
-const baselineFilter = CovidView1.toLapisFilterWithoutVariant(routeData);
-const timeGranularity = chooseGranularityBasedOnDateRange({ from: baselineFilter.dateFrom, to: baselineFilter.dateTo });
+const variantFilter = ServerSide.covidView1.toLapisFilter(routeData);
+const baselineFilter = ServerSide.covidView1.toLapisFilterWithoutVariant(routeData);
+const timeGranularity = chooseGranularityBasedOnDateRange({
+    from: baselineFilter[`${ServerSide.covidView1.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.covidView1.mainDateField}To`] as string,
+});
 
 let subDivisionField = undefined;
 let subDivisionLabel = '';
@@ -36,11 +39,11 @@ const initialMutations = extractMutations(variantFilter);
                 <div class='bg-blue-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Filter dataset:</div>
                     <LocationTimeFilter
-                        fields={CovidView1.view.locationFields}
+                        fields={ServerSide.covidView1.locationFields}
                         initialLocation={baselineFilter}
                         initialDateRange={routeData.baselineFilter.dateRange}
-                        earliestDate={CovidView1.view.earliestDate}
-                        customDateRangeOptions={CovidView1.view.customDateRangeOptions}
+                        earliestDate={ServerSide.covidView1.earliestDate}
+                        customDateRangeOptions={ServerSide.covidView1.customDateRangeOptions}
                     />
                 </div>
                 <div class='border-t-2 bg-green-50 px-2 py-4'>
@@ -60,7 +63,11 @@ const initialMutations = extractMutations(variantFilter);
                         initialMutations={initialMutations}
                     />
                     <div class='my-2 font-semibold'>Or select a known variant:</div>
-                    <CollectionsList initialCollectionId={routeData.collectionId} client:idle />
+                    <CollectionsList
+                        initialCollectionId={routeData.collectionId}
+                        organismsConfig={getDashboardsConfig().dashboards.organisms}
+                        client:idle
+                    />
                 </div>
             </div>
             <div>
@@ -147,7 +154,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='date'></gs-mutations-over-time>
+                        lapisDateField={ServerSide.covidView1.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -158,7 +165,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='date'></gs-mutations-over-time>
+                        lapisDateField={ServerSide.covidView1.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/pages/flu/h5n1/sequencing-efforts.astro
+++ b/website/src/pages/flu/h5n1/sequencing-efforts.astro
@@ -2,18 +2,18 @@
 import { chooseGranularityBasedOnDateRange } from '../../../routes/helpers';
 import BaseLayout from '../../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../../components/LocationTimeFilter.astro';
-import { H5n1View3 } from '../../../routes/h5n1';
 import { getLapisUrl } from '../../../config';
 import { defaultTablePageSize, Organisms } from '../../../routes/View';
 import ComponentsGrid from '../../../components/ComponentsGrid.astro';
+import { ServerSide } from '../../../routes/serverSideRouting';
 
-const routeData = H5n1View3.view.parseUrl(Astro.url);
+const routeData = ServerSide.h5n1View3.parseUrl(Astro.url);
 
-const baselineFilter = H5n1View3.view.toLapisFilter(routeData);
+const baselineFilter = ServerSide.h5n1View3.toLapisFilter(routeData);
 
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter.sample_collection_dateFrom,
-    to: baselineFilter.sample_collection_dateTo,
+    from: baselineFilter[`${ServerSide.h5n1View3.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.h5n1View3.mainDateField}To`] as string,
 });
 let subDivisionField = undefined;
 let subDivisionLabel = '';
@@ -32,11 +32,11 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
                 <LocationTimeFilter
-                    fields={H5n1View3.view.locationFields}
+                    fields={ServerSide.h5n1View3.locationFields}
                     initialLocation={baselineFilter}
                     initialDateRange={routeData.baselineFilter.dateRange}
-                    earliestDate={H5n1View3.view.earliestDate}
-                    customDateRangeOptions={H5n1View3.view.customDateRangeOptions}
+                    earliestDate={ServerSide.h5n1View3.earliestDate}
+                    customDateRangeOptions={ServerSide.h5n1View3.customDateRangeOptions}
                 />
             </div>
         </div>
@@ -48,7 +48,7 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField='sample_collection_date'
+                    lapisDateField={ServerSide.h5n1View3.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/pages/flu/h5n1/single-variant.astro
+++ b/website/src/pages/flu/h5n1/single-variant.astro
@@ -1,21 +1,21 @@
 ---
 import BaseLayout from '../../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../../components/LocationTimeFilter.astro';
-import { H5n1View1 } from '../../../routes/h5n1';
 import VariantFilter from '../../../components/VariantFilter.astro';
 import { chooseGranularityBasedOnDateRange, extractMutations } from '../../../routes/helpers';
 import { getLapisUrl } from '../../../config';
 import { defaultTablePageSize, Organisms } from '../../../routes/View';
 import ComponentsGrid from '../../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../../routes/serverSideRouting';
 
-const routeData = H5n1View1.view.parseUrl(Astro.url);
+const routeData = ServerSide.h5n1View1.parseUrl(Astro.url);
 
-const variantFilter = H5n1View1.view.toLapisFilter(routeData);
-const baselineFilter = H5n1View1.view.toLapisFilterWithoutVariant(routeData);
+const variantFilter = ServerSide.h5n1View1.toLapisFilter(routeData);
+const baselineFilter = ServerSide.h5n1View1.toLapisFilterWithoutVariant(routeData);
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter.sample_collection_dateFrom,
-    to: baselineFilter.sample_collection_dateTo,
+    from: baselineFilter[`${ServerSide.h5n1View1.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.h5n1View1.mainDateField}To`] as string,
 });
 
 let subDivisionField = undefined;
@@ -38,11 +38,11 @@ const initialMutations = extractMutations(variantFilter);
                 <div class='bg-blue-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Filter dataset:</div>
                     <LocationTimeFilter
-                        fields={H5n1View1.view.locationFields}
+                        fields={ServerSide.h5n1View1.locationFields}
                         initialLocation={baselineFilter}
                         initialDateRange={routeData.baselineFilter.dateRange}
-                        earliestDate={H5n1View1.view.earliestDate}
-                        customDateRangeOptions={H5n1View1.view.customDateRangeOptions}
+                        earliestDate={ServerSide.h5n1View1.earliestDate}
+                        customDateRangeOptions={ServerSide.h5n1View1.customDateRangeOptions}
                     />
                 </div>
                 <div class='border-t-2 bg-green-50 px-2 py-4'>
@@ -59,7 +59,7 @@ const initialMutations = extractMutations(variantFilter);
                                 lapisFilter: variantFilter,
                             })}
                             denominatorFilter={JSON.stringify(baselineFilter)}
-                            lapisDateField='sample_collection_date'
+                            lapisDateField={ServerSide.h5n1View1.mainDateField}
                             granularity={timeGranularity}
                             smoothingWindow='0'
                             pageSize={defaultTablePageSize}
@@ -115,7 +115,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='sample_collection_date'></gs-mutations-over-time>
+                        lapisDateField={ServerSide.h5n1View1.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -126,7 +126,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='sample_collection_date'></gs-mutations-over-time>
+                        lapisDateField={ServerSide.h5n1View1.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../layouts/base/BaseLayout.astro';
-import { Routing } from '../routes/routing';
 import { type Organism, organismConfig } from '../routes/View';
+import { ServerSide } from '../routes/serverSideRouting';
 ---
 
 <style>
@@ -61,11 +61,13 @@ import { type Organism, organismConfig } from '../routes/View';
                     <div class='rounded-b-md rounded-tr-md border-2 border-gray-100'>
                         <h3 class={`rounded-tr-md p-4 text-xl ${organism.backgroundColor}`}>{organism.label}</h3>
                         <ul class='mb-4 ml-6 mr-6 border-l-2 border-l-black'>
-                            {Routing.views[organism.organism as Organism].map((view) => (
+                            {ServerSide.routing.views[organism.organism as Organism].map((view) => (
                                 <li class='flex items-start pt-2'>
                                     <div class='mr-2 w-4 border-b-2 border-b-black pt-[0.8rem]' />
                                     <a
-                                        href={Routing.toUrl(Routing.getDefaultRoute(view.pathname)!)}
+                                        href={ServerSide.routing.toUrl(
+                                            ServerSide.routing.getDefaultRoute(view.pathname)!,
+                                        )}
                                         class={`hover:underline ${organism.hoverDecorationColor} hover:decoration-4`}
                                     >
                                         {view.labelLong}

--- a/website/src/pages/mpox/sequencing-efforts.astro
+++ b/website/src/pages/mpox/sequencing-efforts.astro
@@ -7,14 +7,15 @@ import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = MpoxView3.view.parseUrl(Astro.url);
+const routeData = ServerSide.mpoxView3.parseUrl(Astro.url);
 
-const baselineFilter = MpoxView3.view.toLapisFilter(routeData);
+const baselineFilter = ServerSide.mpoxView3.toLapisFilter(routeData);
 
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter.sample_collection_dateFrom,
-    to: baselineFilter.sample_collection_dateTo,
+    from: baselineFilter[`${ServerSide.mpoxView3.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.mpoxView3.mainDateField}To`] as string,
 });
 let subDivisionField = undefined;
 let subDivisionLabel = '';
@@ -33,11 +34,11 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
                 <LocationTimeFilter
-                    fields={MpoxView1.view.locationFields}
+                    fields={ServerSide.mpoxView3.locationFields}
                     initialLocation={baselineFilter}
                     initialDateRange={routeData.baselineFilter.dateRange}
-                    earliestDate={MpoxView3.view.earliestDate}
-                    customDateRangeOptions={MpoxView1.view.customDateRangeOptions}
+                    earliestDate={ServerSide.mpoxView3.earliestDate}
+                    customDateRangeOptions={ServerSide.mpoxView3.customDateRangeOptions}
                 />
             </div>
         </div>
@@ -49,7 +50,7 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField='sample_collection_date'
+                    lapisDateField={ServerSide.mpoxView3.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/pages/mpox/single-variant.astro
+++ b/website/src/pages/mpox/single-variant.astro
@@ -1,6 +1,5 @@
 ---
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
-import { MpoxView1 } from '../../routes/mpox';
 import VariantFilter from '../../components/VariantFilter.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
 import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
@@ -8,14 +7,15 @@ import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = MpoxView1.view.parseUrl(Astro.url);
+const routeData = ServerSide.mpoxView1.parseUrl(Astro.url);
 
-const variantFilter = MpoxView1.view.toLapisFilter(routeData);
-const baselineFilter = MpoxView1.view.toLapisFilterWithoutVariant(routeData);
+const variantFilter = ServerSide.mpoxView1.toLapisFilter(routeData);
+const baselineFilter = ServerSide.mpoxView1.toLapisFilterWithoutVariant(routeData);
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter.sample_collection_dateFrom,
-    to: baselineFilter.sample_collection_dateTo,
+    from: baselineFilter[`${ServerSide.mpoxView1.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.mpoxView1.mainDateField}To`] as string,
 });
 
 let subDivisionField = undefined;
@@ -38,11 +38,11 @@ const initialMutations = extractMutations(variantFilter);
                 <div class='bg-blue-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Filter dataset:</div>
                     <LocationTimeFilter
-                        fields={MpoxView1.view.locationFields}
+                        fields={ServerSide.mpoxView1.locationFields}
                         initialLocation={baselineFilter}
                         initialDateRange={routeData.baselineFilter.dateRange}
-                        earliestDate={MpoxView1.view.earliestDate}
-                        customDateRangeOptions={MpoxView1.view.customDateRangeOptions}
+                        earliestDate={ServerSide.mpoxView1.earliestDate}
+                        customDateRangeOptions={ServerSide.mpoxView1.customDateRangeOptions}
                     />
                 </div>
                 <div class='border-t-2 bg-green-50 px-2 py-4'>
@@ -65,7 +65,7 @@ const initialMutations = extractMutations(variantFilter);
                                 lapisFilter: variantFilter,
                             })}
                             denominatorFilter={JSON.stringify(baselineFilter)}
-                            lapisDateField='sample_collection_date'
+                            lapisDateField={ServerSide.mpoxView1.mainDateField}
                             granularity={timeGranularity}
                             smoothingWindow='0'
                             pageSize={defaultTablePageSize}
@@ -129,7 +129,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='sample_collection_date'></gs-mutations-over-time>
+                        lapisDateField={ServerSide.mpoxView1.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -140,7 +140,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='sample_collection_date'></gs-mutations-over-time>
+                        lapisDateField={ServerSide.mpoxView1.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/pages/rsv-a/sequencing-efforts.astro
+++ b/website/src/pages/rsv-a/sequencing-efforts.astro
@@ -1,9 +1,6 @@
 ---
-import { RsvAView3 } from '../../routes/rsvA';
-import { Organisms } from '../../routes/View';
 import RsvSequencingEffortsPage from '../../components/rsv/RsvSequencingEffortsPage.astro';
-
-const routeData = RsvAView3.view.parseUrl(Astro.url);
+import { ServerSide } from '../../routes/serverSideRouting';
 ---
 
-<RsvSequencingEffortsPage view={RsvAView3.view} routeData={routeData} titleName='RSV-A' organism={Organisms.rsvA} />
+<RsvSequencingEffortsPage view={ServerSide.rsvAView3} />

--- a/website/src/pages/rsv-a/single-variant.astro
+++ b/website/src/pages/rsv-a/single-variant.astro
@@ -1,9 +1,6 @@
 ---
-import { RsvAView1 } from '../../routes/rsvA';
 import RsvSingleVariantPage from '../../components/rsv/RsvSingleVariantPage.astro';
-import { Organisms } from '../../routes/View';
-
-const routeData = RsvAView1.view.parseUrl(Astro.url);
+import { ServerSide } from '../../routes/serverSideRouting';
 ---
 
-<RsvSingleVariantPage view={RsvAView1.view} routeData={routeData} titleName='RSV-A' organism={Organisms.rsvA} />
+<RsvSingleVariantPage view={ServerSide.rsvAView1} />

--- a/website/src/pages/rsv-b/sequencing-efforts.astro
+++ b/website/src/pages/rsv-b/sequencing-efforts.astro
@@ -1,9 +1,6 @@
 ---
-import { RsvBView3 } from '../../routes/rsvB';
-import { Organisms } from '../../routes/View';
 import RsvSequencingEffortsPage from '../../components/rsv/RsvSequencingEffortsPage.astro';
-
-const routeData = RsvBView3.view.parseUrl(Astro.url);
+import { ServerSide } from '../../routes/serverSideRouting';
 ---
 
-<RsvSequencingEffortsPage view={RsvBView3.view} routeData={routeData} titleName='RSV-B' organism={Organisms.rsvB} />
+<RsvSequencingEffortsPage view={ServerSide.rsvBView3} />

--- a/website/src/pages/rsv-b/single-variant.astro
+++ b/website/src/pages/rsv-b/single-variant.astro
@@ -1,9 +1,6 @@
 ---
-import { RsvBView1 } from '../../routes/rsvB';
 import RsvSingleVariantPage from '../../components/rsv/RsvSingleVariantPage.astro';
-import { Organisms } from '../../routes/View';
-
-const routeData = RsvBView1.view.parseUrl(Astro.url);
+import { ServerSide } from '../../routes/serverSideRouting';
 ---
 
-<RsvSingleVariantPage view={RsvBView1.view} routeData={routeData} titleName='RSV-B' organism={Organisms.rsvB} />
+<RsvSingleVariantPage view={ServerSide.rsvBView1} />

--- a/website/src/pages/west-nile/sequencing-efforts.astro
+++ b/website/src/pages/west-nile/sequencing-efforts.astro
@@ -2,19 +2,19 @@
 import { chooseGranularityBasedOnDateRange } from '../../routes/helpers';
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
-import { WestNileView3 } from '../../routes/westNile';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = WestNileView3.view.parseUrl(Astro.url);
+const routeData = ServerSide.westNileView3.parseUrl(Astro.url);
 
-const baselineFilter = WestNileView3.view.toLapisFilter(routeData);
+const baselineFilter = ServerSide.westNileView3.toLapisFilter(routeData);
 
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter.sample_collection_dateFrom,
-    to: baselineFilter.sample_collection_dateTo,
+    from: baselineFilter[`${ServerSide.westNileView3.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.westNileView3.mainDateField}To`] as string,
 });
 let subDivisionField = undefined;
 let subDivisionLabel = '';
@@ -33,11 +33,11 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
                 <LocationTimeFilter
-                    fields={WestNileView3.view.locationFields}
+                    fields={ServerSide.westNileView3.locationFields}
                     initialLocation={baselineFilter}
                     initialDateRange={routeData.baselineFilter.dateRange}
-                    earliestDate={WestNileView3.view.earliestDate}
-                    customDateRangeOptions={WestNileView3.view.customDateRangeOptions}
+                    earliestDate={ServerSide.westNileView3.earliestDate}
+                    customDateRangeOptions={ServerSide.westNileView3.customDateRangeOptions}
                 />
             </div>
         </div>
@@ -49,7 +49,7 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField='sample_collection_date'
+                    lapisDateField={ServerSide.westNileView3.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/pages/west-nile/single-variant.astro
+++ b/website/src/pages/west-nile/single-variant.astro
@@ -1,21 +1,21 @@
 ---
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
-import { WestNileView1 } from '../../routes/westNile';
 import VariantFilter from '../../components/VariantFilter.astro';
 import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = WestNileView1.view.parseUrl(Astro.url);
+const routeData = ServerSide.westNileView1.parseUrl(Astro.url);
 
-const variantFilter = WestNileView1.view.toLapisFilter(routeData);
-const baselineFilter = WestNileView1.view.toLapisFilterWithoutVariant(routeData);
+const variantFilter = ServerSide.westNileView1.toLapisFilter(routeData);
+const baselineFilter = ServerSide.westNileView1.toLapisFilterWithoutVariant(routeData);
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter.sample_collection_dateFrom,
-    to: baselineFilter.sample_collection_dateTo,
+    from: baselineFilter[`${ServerSide.westNileView1.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.westNileView1.mainDateField}To`] as string,
 });
 
 let subDivisionField = undefined;
@@ -34,7 +34,7 @@ const customDateRangeOptions = [
     { label: 'Since 2020', dateFrom: '2020-01-01', dateTo: today },
     { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
     { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
-    { label: 'Before 2000', dateFrom: WestNileView1.view.earliestDate, dateTo: '1999-12-31' },
+    { label: 'Before 2000', dateFrom: ServerSide.westNileView1.earliestDate, dateTo: '1999-12-31' },
 ];
 
 const initialMutations = extractMutations(variantFilter);
@@ -50,7 +50,7 @@ const initialMutations = extractMutations(variantFilter);
                         fields={locationFields}
                         initialLocation={baselineFilter}
                         initialDateRange={routeData.baselineFilter.dateRange}
-                        earliestDate={WestNileView1.view.earliestDate}
+                        earliestDate={ServerSide.westNileView1.earliestDate}
                         customDateRangeOptions={customDateRangeOptions}
                     />
                 </div>
@@ -73,7 +73,7 @@ const initialMutations = extractMutations(variantFilter);
                                 lapisFilter: variantFilter,
                             })}
                             denominatorFilter={JSON.stringify(baselineFilter)}
-                            lapisDateField='sample_collection_date'
+                            lapisDateField={ServerSide.westNileView1.mainDateField}
                             granularity={timeGranularity}
                             smoothingWindow='0'
                             pageSize={defaultTablePageSize}
@@ -137,7 +137,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='sample_collection_date'></gs-mutations-over-time>
+                        lapisDateField={ServerSide.westNileView1.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -148,7 +148,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField='sample_collection_date'></gs-mutations-over-time>
+                        lapisDateField={ServerSide.westNileView1.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/routes/h5n1.ts
+++ b/website/src/routes/h5n1.ts
@@ -1,41 +1,51 @@
 import {
     type DateRange,
-    type DateRangeOption,
     dateRangeToCustomDateRange,
     getDateRangeFromSearch,
     getLapisLocation2FromSearch,
     getLapisVariantQuery1FromSearch,
+    type LapisFilter,
     type LapisLocation2,
     type LapisVariantQuery1,
-    type SampleCollectionDateFromTo,
     setSearchFromDateRange,
     setSearchFromLapisLocation2,
     setSearchFromLapisVariantQuery1,
 } from './helpers.ts';
 import { organismConfig, Organisms, type Route, type View } from './View.ts';
+import type { OrganismsConfig } from '../config.ts';
 
-const organism = Organisms.h5n1 as typeof Organisms.h5n1;
-const pathFragment = organismConfig[organism].pathFragment;
-const locationFields = ['geo_loc_country', 'geo_loc_admin_1'];
+const pathFragment = organismConfig[Organisms.h5n1].pathFragment;
 
-const defaultDateRange: DateRange = 'last6Months';
 const earliestDate = '1905-01-01';
 const today = new Date().toISOString().substring(0, 10);
-const customDateRangeOptions = [
-    { label: 'Since 2020', dateFrom: '2020-01-01', dateTo: today },
-    { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
-    { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
-    { label: 'Since 2000', dateFrom: '2000-01-01', dateTo: today },
-    { label: 'Before 2000', dateFrom: earliestDate, dateTo: '1999-12-31' },
-];
 
-type Constants = {
-    earliestDate: string;
-    locationFields: string[];
-    customDateRangeOptions: DateRangeOption[];
-};
+class H5n1Constants {
+    constructor(organismsConfig: OrganismsConfig) {
+        this.mainDateField = organismsConfig.h5n1.lapis.mainDateField;
+    }
 
-const constants = { organism, earliestDate, locationFields, customDateRangeOptions };
+    public readonly organism = Organisms.h5n1 as typeof Organisms.h5n1;
+    public readonly earliestDate = '1905-01-01';
+    public readonly locationFields = ['geo_loc_country', 'geo_loc_admin_1'];
+    public readonly defaultDateRange: DateRange = 'last6Months';
+    public readonly customDateRangeOptions = [
+        { label: 'Since 2020', dateFrom: '2020-01-01', dateTo: today },
+        { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
+        { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
+        { label: 'Since 2000', dateFrom: '2000-01-01', dateTo: today },
+        { label: 'Before 2000', dateFrom: earliestDate, dateTo: '1999-12-31' },
+    ];
+    public readonly mainDateField: string;
+
+    public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter => {
+        const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));
+        return {
+            ...route.baselineFilter.location,
+            [`${this.mainDateField}From`]: dateRange.from,
+            [`${this.mainDateField}To`]: dateRange.to,
+        };
+    };
+}
 
 type RouteWithBaseline = Route & {
     baselineFilter: {
@@ -44,121 +54,88 @@ type RouteWithBaseline = Route & {
     };
 };
 
-const toLapisFilterWithoutVariant = (route: RouteWithBaseline): SampleCollectionDateFromTo & LapisLocation2 => {
-    const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(H5n1View1.view.earliestDate));
-    return {
-        ...route.baselineFilter.location,
-        sample_collection_dateFrom: dateRange.from,
-        sample_collection_dateTo: dateRange.to,
+type H5n1View1Route = { variantFilter: LapisVariantQuery1 } & RouteWithBaseline;
+
+export class H5n1View1 extends H5n1Constants implements View<H5n1View1Route> {
+    public readonly pathname = `/${pathFragment}/single-variant`;
+    public readonly label = 'Single variant';
+    public readonly labelLong = 'Analyze a single variant';
+    public readonly defaultRoute = {
+        organism: this.organism,
+        pathname: this.pathname,
+        baselineFilter: {
+            location: {},
+            dateRange: this.defaultDateRange,
+        },
+        variantFilter: {},
     };
-};
 
-export namespace H5n1View1 {
-    const pathname = `/${pathFragment}/single-variant`;
-
-    type Route = { variantFilter: LapisVariantQuery1 } & RouteWithBaseline;
-
-    const parseUrl = (url: URL): Route => {
+    public parseUrl = (url: URL): H5n1View1Route => {
         const search = url.searchParams;
         return {
-            organism,
-            pathname,
+            organism: this.organism,
+            pathname: this.pathname,
             baselineFilter: {
                 location: getLapisLocation2FromSearch(search),
-                dateRange: getDateRangeFromSearch(search, 'sample_collection_date') ?? defaultDateRange,
+                dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
             variantFilter: getLapisVariantQuery1FromSearch(search),
         };
     };
 
-    const toUrl = (route: Route): string => {
+    public toUrl = (route: H5n1View1Route): string => {
         const search = new URLSearchParams();
         setSearchFromLapisLocation2(search, route.baselineFilter.location);
-        if (route.baselineFilter.dateRange !== defaultDateRange) {
-            setSearchFromDateRange(search, 'sample_collection_date', route.baselineFilter.dateRange);
+        if (route.baselineFilter.dateRange !== this.defaultDateRange) {
+            setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
         setSearchFromLapisVariantQuery1(search, route.variantFilter);
-        return `${pathname}?${search}`;
+        return `${this.pathname}?${search}`;
     };
 
-    const toLapisFilter = (route: Route) => {
+    public toLapisFilter = (route: H5n1View1Route): LapisFilter => {
         return {
-            ...toLapisFilterWithoutVariant(route),
+            ...this.toLapisFilterWithoutVariant(route),
             ...route.variantFilter,
         };
     };
-
-    export type H5n1View1 = View<Route> &
-        Constants & {
-            toLapisFilter: (route: Route) => SampleCollectionDateFromTo & LapisLocation2 & LapisVariantQuery1;
-            toLapisFilterWithoutVariant: (route: Route) => SampleCollectionDateFromTo & LapisLocation2;
-        };
-
-    export const view: H5n1View1 = {
-        ...constants,
-        pathname,
-        label: 'Single variant',
-        labelLong: 'Analyze a single variant',
-        parseUrl,
-        toUrl,
-        defaultRoute: {
-            organism,
-            pathname,
-            baselineFilter: {
-                location: {},
-                dateRange: defaultDateRange,
-            },
-            variantFilter: {},
-        },
-        toLapisFilter,
-        toLapisFilterWithoutVariant,
-    };
 }
 
-export namespace H5n1View3 {
-    const pathname = `/${pathFragment}/sequencing-efforts`;
+export class H5n1View3 extends H5n1Constants implements View<RouteWithBaseline> {
+    public readonly pathname = `/${pathFragment}/sequencing-efforts`;
+    public readonly label = 'Sequencing efforts';
+    public readonly labelLong = 'Sequencing efforts';
+    public readonly defaultRoute = {
+        organism: this.organism,
+        pathname: this.pathname,
+        baselineFilter: {
+            location: {},
+            dateRange: this.defaultDateRange,
+        },
+    };
 
-    const parseUrl = (url: URL): RouteWithBaseline => {
+    public parseUrl = (url: URL): RouteWithBaseline => {
         const search = url.searchParams;
         return {
-            organism,
-            pathname,
+            organism: this.organism,
+            pathname: this.pathname,
             baselineFilter: {
                 location: getLapisLocation2FromSearch(search),
-                dateRange: getDateRangeFromSearch(search, 'sample_collection_date') ?? defaultDateRange,
+                dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
         };
     };
 
-    const toUrl = (route: RouteWithBaseline): string => {
+    public toUrl = (route: RouteWithBaseline): string => {
         const search = new URLSearchParams();
         setSearchFromLapisLocation2(search, route.baselineFilter.location);
-        if (route.baselineFilter.dateRange !== defaultDateRange) {
-            setSearchFromDateRange(search, 'sample_collection_date', route.baselineFilter.dateRange);
+        if (route.baselineFilter.dateRange !== this.defaultDateRange) {
+            setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
-        return `${pathname}?${search}`;
+        return `${this.pathname}?${search}`;
     };
 
-    export type H5n1View3 = View<RouteWithBaseline> &
-        Constants & {
-            toLapisFilter: (route: RouteWithBaseline) => SampleCollectionDateFromTo & LapisLocation2;
-        };
-
-    export const view: H5n1View3 = {
-        ...constants,
-        pathname,
-        label: 'Sequencing efforts',
-        labelLong: 'Sequencing efforts',
-        parseUrl,
-        toUrl,
-        defaultRoute: {
-            organism,
-            pathname,
-            baselineFilter: {
-                location: {},
-                dateRange: defaultDateRange,
-            },
-        },
-        toLapisFilter: toLapisFilterWithoutVariant,
+    public toLapisFilter = (route: RouteWithBaseline): LapisFilter => {
+        return this.toLapisFilterWithoutVariant(route);
     };
 }

--- a/website/src/routes/helpers.ts
+++ b/website/src/routes/helpers.ts
@@ -13,6 +13,8 @@ export type DateRangeOption = {
     dateTo: string;
 };
 
+export type LapisFilter = Record<string, string | number | null | boolean | string[]>;
+
 export const isCustomDateRange = (dateRange: DateRange): dateRange is CustomDateRange => {
     return typeof dateRange === 'object' && 'from' in dateRange;
 };
@@ -239,9 +241,4 @@ export const setSearchFromLapisVariantQuery1 = (search: URLSearchParams, query: 
 export const setSearchFromLapisVariantQuery2 = (search: URLSearchParams, query: LapisVariantQuery2) => {
     setSearchFromLapisVariantQuery1(search, query);
     setSearchFromString(search, 'clade', query.clade);
-};
-
-export type SampleCollectionDateFromTo = {
-    sample_collection_dateFrom: string;
-    sample_collection_dateTo: string;
 };

--- a/website/src/routes/routing.ts
+++ b/website/src/routes/routing.ts
@@ -3,36 +3,40 @@ import { MpoxView1, MpoxView3 } from './mpox.ts';
 import { WestNileView1, WestNileView3 } from './westNile.ts';
 import { RsvAView1, RsvAView3 } from './rsvA.ts';
 import { RsvBView1, RsvBView3 } from './rsvB.ts';
-import { allOrganisms, type Organism, type Route, type View } from './View.ts';
+import { Organisms, type Route } from './View.ts';
 import { H5n1View1, H5n1View3 } from './h5n1.ts';
+import type { OrganismsConfig } from '../config.ts';
 
-export namespace Routing {
-    const allViews = [
-        CovidView1.view,
-        CovidView2.view,
-        CovidView3.view,
-        H5n1View1.view,
-        H5n1View3.view,
-        MpoxView1.view,
-        MpoxView3.view,
-        RsvAView1.view,
-        RsvAView3.view,
-        RsvBView1.view,
-        RsvBView3.view,
-        WestNileView1.view,
-        WestNileView3.view,
-    ] as const;
+export class Routing {
+    private readonly allViews;
+    public readonly views;
 
-    export const getCurrentRouteInBrowser = (): Route | undefined => {
-        return parseUrl(new URL(window.location.href));
+    constructor(organismsConfig: OrganismsConfig) {
+        this.views = {
+            [Organisms.covid]: [
+                new CovidView1(organismsConfig),
+                new CovidView2(organismsConfig),
+                new CovidView3(organismsConfig),
+            ],
+            [Organisms.h5n1]: [new H5n1View1(organismsConfig), new H5n1View3(organismsConfig)],
+            [Organisms.mpox]: [new MpoxView1(organismsConfig), new MpoxView3(organismsConfig)],
+            [Organisms.rsvA]: [new RsvAView1(organismsConfig), new RsvAView3(organismsConfig)],
+            [Organisms.rsvB]: [new RsvBView1(organismsConfig), new RsvBView3(organismsConfig)],
+            [Organisms.westNile]: [new WestNileView1(organismsConfig), new WestNileView3(organismsConfig)],
+        } as const;
+        this.allViews = Object.values(this.views).flat();
+    }
+
+    getCurrentRouteInBrowser = (): Route | undefined => {
+        return this.parseUrl(new URL(window.location.href));
     };
 
-    export const navigateTo = (route: Route) => {
-        window.location.href = toUrl(route);
+    navigateTo = (route: Route) => {
+        window.location.href = this.toUrl(route);
     };
 
-    export const parseUrl = (url: URL): Route | undefined => {
-        for (const view of allViews) {
+    parseUrl = (url: URL): Route | undefined => {
+        for (const view of this.allViews) {
             if (view.pathname === url.pathname) {
                 return view.parseUrl(url);
             }
@@ -40,8 +44,8 @@ export namespace Routing {
         return undefined;
     };
 
-    export const toUrl = (route: Route): string => {
-        for (const view of allViews) {
+    toUrl = (route: Route): string => {
+        for (const view of this.allViews) {
             if (route.pathname === view.pathname) {
                 // @ts-ignore
                 return view.toUrl(route);
@@ -50,43 +54,12 @@ export namespace Routing {
         throw new Error('Unexpected route: ' + route.pathname);
     };
 
-    export const views = groupViewsByOrganism(allViews);
-
-    export const getDefaultRoute = (pathname: string): Route | undefined => {
-        for (const view of allViews) {
+    getDefaultRoute = (pathname: string): Route | undefined => {
+        for (const view of this.allViews) {
             if (view.pathname === pathname) {
                 return view.defaultRoute;
             }
         }
         return undefined;
     };
-}
-
-function groupViewsByOrganism(views: readonly View<any>[]): Record<
-    Organism,
-    {
-        label: string;
-        labelLong: string;
-        pathname: string;
-    }[]
-> {
-    const viewMap = allOrganisms.reduce(
-        (acc, organism) => ({
-            [organism]: [],
-            ...acc,
-        }),
-        {} as Record<Organism, { label: string; labelLong: string; pathname: string }[]>,
-    );
-
-    for (const view of views) {
-        if (viewMap[view.organism]) {
-            viewMap[view.organism].push({
-                label: view.label,
-                labelLong: view.labelLong,
-                pathname: view.pathname,
-            });
-        }
-    }
-
-    return viewMap;
 }

--- a/website/src/routes/rsvA.ts
+++ b/website/src/routes/rsvA.ts
@@ -1,41 +1,50 @@
 import {
     type DateRange,
-    type DateRangeOption,
     dateRangeToCustomDateRange,
     getDateRangeFromSearch,
     getLapisLocation2FromSearch,
     getLapisVariantQuery1FromSearch,
+    type LapisFilter,
     type LapisLocation2,
     type LapisVariantQuery1,
-    type SampleCollectionDateFromTo,
     setSearchFromDateRange,
     setSearchFromLapisLocation2,
     setSearchFromLapisVariantQuery1,
 } from './helpers.ts';
 import { organismConfig, Organisms, type Route, type View } from './View.ts';
+import type { OrganismsConfig } from '../config.ts';
 
-const organism = Organisms.rsvA as typeof Organisms.rsvA;
-const pathFragment = organismConfig[organism].pathFragment;
-const locationFields = ['geo_loc_country', 'geo_loc_admin_1'];
+const pathFragment = organismConfig[Organisms.rsvA].pathFragment;
 
-const defaultDateRange: DateRange = 'allTimes';
-const earliestDate = '1956-01-01';
 const today = new Date().toISOString().substring(0, 10);
-const customDateRangeOptions = [
-    { label: 'Since 2020', dateFrom: '2020-01-01', dateTo: today },
-    { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
-    { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
-    { label: 'Since 2000', dateFrom: '2000-01-01', dateTo: today },
-    { label: 'Before 2000', dateFrom: earliestDate, dateTo: '1999-12-31' },
-];
 
-type Constants = {
-    earliestDate: string;
-    locationFields: string[];
-    customDateRangeOptions: DateRangeOption[];
-};
+class RsvAConstants {
+    constructor(organismsConfig: OrganismsConfig) {
+        this.mainDateField = organismsConfig.rsvA.lapis.mainDateField;
+    }
 
-const constants = { organism, earliestDate, locationFields, customDateRangeOptions };
+    public readonly organism = Organisms.rsvA as typeof Organisms.rsvA;
+    public readonly locationFields = ['geo_loc_country', 'geo_loc_admin_1'];
+    public readonly defaultDateRange: DateRange = 'allTimes';
+    public readonly earliestDate = '1956-01-01';
+    public readonly customDateRangeOptions = [
+        { label: 'Since 2020', dateFrom: '2020-01-01', dateTo: today },
+        { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
+        { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
+        { label: 'Since 2000', dateFrom: '2000-01-01', dateTo: today },
+        { label: 'Before 2000', dateFrom: this.earliestDate, dateTo: '1999-12-31' },
+    ];
+    public readonly mainDateField: string;
+
+    public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter & LapisLocation2 => {
+        const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));
+        return {
+            ...route.baselineFilter.location,
+            [`${this.mainDateField}From`]: dateRange.from,
+            [`${this.mainDateField}To`]: dateRange.to,
+        };
+    };
+}
 
 type RouteWithBaseline = Route & {
     baselineFilter: {
@@ -44,121 +53,88 @@ type RouteWithBaseline = Route & {
     };
 };
 
-const toLapisFilterWithoutVariant = (route: RouteWithBaseline): SampleCollectionDateFromTo & LapisLocation2 => {
-    const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(RsvAView1.view.earliestDate));
-    return {
-        ...route.baselineFilter.location,
-        sample_collection_dateFrom: dateRange.from,
-        sample_collection_dateTo: dateRange.to,
+type RsvAView1Route = { variantFilter: LapisVariantQuery1 } & RouteWithBaseline;
+
+export class RsvAView1 extends RsvAConstants implements View<RsvAView1Route> {
+    public readonly pathname = `/${pathFragment}/single-variant`;
+    public readonly label = 'Single variant';
+    public readonly labelLong = 'Analyze a single variant';
+    public readonly defaultRoute = {
+        organism: this.organism,
+        pathname: this.pathname,
+        baselineFilter: {
+            location: {},
+            dateRange: this.defaultDateRange,
+        },
+        variantFilter: {},
     };
-};
 
-export namespace RsvAView1 {
-    const pathname = `/${pathFragment}/single-variant`;
-
-    type Route = { variantFilter: LapisVariantQuery1 } & RouteWithBaseline;
-
-    const parseUrl = (url: URL): Route => {
+    public parseUrl = (url: URL): RsvAView1Route => {
         const search = url.searchParams;
         return {
-            organism,
-            pathname,
+            organism: this.organism,
+            pathname: this.pathname,
             baselineFilter: {
                 location: getLapisLocation2FromSearch(search),
-                dateRange: getDateRangeFromSearch(search, 'sample_collection_date') ?? defaultDateRange,
+                dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
             variantFilter: getLapisVariantQuery1FromSearch(search),
         };
     };
 
-    const toUrl = (route: Route): string => {
+    public toUrl = (route: RsvAView1Route): string => {
         const search = new URLSearchParams();
         setSearchFromLapisLocation2(search, route.baselineFilter.location);
-        if (route.baselineFilter.dateRange !== defaultDateRange) {
-            setSearchFromDateRange(search, 'sample_collection_date', route.baselineFilter.dateRange);
+        if (route.baselineFilter.dateRange !== this.defaultDateRange) {
+            setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
         setSearchFromLapisVariantQuery1(search, route.variantFilter);
-        return `${pathname}?${search}`;
+        return `${this.pathname}?${search}`;
     };
 
-    const toLapisFilter = (route: Route) => {
+    public toLapisFilter = (route: RsvAView1Route) => {
         return {
-            ...toLapisFilterWithoutVariant(route),
+            ...this.toLapisFilterWithoutVariant(route),
             ...route.variantFilter,
         };
     };
-
-    export type RsvAView1 = View<Route> &
-        Constants & {
-            toLapisFilter: (route: Route) => SampleCollectionDateFromTo & LapisLocation2 & LapisVariantQuery1;
-            toLapisFilterWithoutVariant: (route: Route) => SampleCollectionDateFromTo & LapisLocation2;
-        };
-
-    export const view: RsvAView1 = {
-        ...constants,
-        pathname,
-        label: 'Single variant',
-        labelLong: 'Analyze a single variant',
-        parseUrl,
-        toUrl,
-        defaultRoute: {
-            organism,
-            pathname,
-            baselineFilter: {
-                location: {},
-                dateRange: defaultDateRange,
-            },
-            variantFilter: {},
-        },
-        toLapisFilter,
-        toLapisFilterWithoutVariant,
-    };
 }
 
-export namespace RsvAView3 {
-    const pathname = `/${pathFragment}/sequencing-efforts`;
+export class RsvAView3 extends RsvAConstants implements View<RouteWithBaseline> {
+    public readonly pathname = `/${pathFragment}/sequencing-efforts`;
+    public readonly label = 'Sequencing efforts';
+    public readonly labelLong = 'Sequencing efforts';
+    public readonly defaultRoute = {
+        organism: this.organism,
+        pathname: this.pathname,
+        baselineFilter: {
+            location: {},
+            dateRange: this.defaultDateRange,
+        },
+    };
 
-    const parseUrl = (url: URL): RouteWithBaseline => {
+    public parseUrl = (url: URL): RouteWithBaseline => {
         const search = url.searchParams;
         return {
-            organism,
-            pathname,
+            organism: this.organism,
+            pathname: this.pathname,
             baselineFilter: {
                 location: getLapisLocation2FromSearch(search),
-                dateRange: getDateRangeFromSearch(search, 'sample_collection_date') ?? defaultDateRange,
+                dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
         };
     };
 
-    const toUrl = (route: RouteWithBaseline): string => {
+    public toUrl = (route: RouteWithBaseline): string => {
         const search = new URLSearchParams();
         setSearchFromLapisLocation2(search, route.baselineFilter.location);
-        if (route.baselineFilter.dateRange !== defaultDateRange) {
-            setSearchFromDateRange(search, 'sample_collection_date', route.baselineFilter.dateRange);
+        if (route.baselineFilter.dateRange !== this.defaultDateRange) {
+            setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
-        return `${pathname}?${search}`;
+        return `${this.pathname}?${search}`;
     };
 
-    export type RsvAView3 = View<RouteWithBaseline> &
-        Constants & {
-            toLapisFilter: (route: RouteWithBaseline) => SampleCollectionDateFromTo & LapisLocation2;
-        };
-
-    export const view: RsvAView3 = {
-        ...constants,
-        pathname,
-        label: 'Sequencing efforts',
-        labelLong: 'Sequencing efforts',
-        parseUrl,
-        toUrl,
-        defaultRoute: {
-            organism,
-            pathname,
-            baselineFilter: {
-                location: {},
-                dateRange: defaultDateRange,
-            },
-        },
-        toLapisFilter: toLapisFilterWithoutVariant,
+    public toLapisFilter = (route: RouteWithBaseline) => {
+        return this.toLapisFilterWithoutVariant(route);
     };
 }

--- a/website/src/routes/rsvB.ts
+++ b/website/src/routes/rsvB.ts
@@ -1,41 +1,50 @@
 import {
     type DateRange,
-    type DateRangeOption,
     dateRangeToCustomDateRange,
     getDateRangeFromSearch,
     getLapisLocation2FromSearch,
     getLapisVariantQuery1FromSearch,
+    type LapisFilter,
     type LapisLocation2,
     type LapisVariantQuery1,
-    type SampleCollectionDateFromTo,
     setSearchFromDateRange,
     setSearchFromLapisLocation2,
     setSearchFromLapisVariantQuery1,
 } from './helpers.ts';
 import { organismConfig, Organisms, type Route, type View } from './View.ts';
+import { type OrganismsConfig } from '../config.ts';
 
-const organism = Organisms.rsvB as typeof Organisms.rsvB;
-const pathFragment = organismConfig[organism].pathFragment;
-const locationFields = ['geo_loc_country', 'geo_loc_admin_1'];
+const pathFragment = organismConfig[Organisms.rsvB].pathFragment;
 
-const defaultDateRange: DateRange = 'allTimes';
-const earliestDate = '1956-01-01';
 const today = new Date().toISOString().substring(0, 10);
-const customDateRangeOptions = [
-    { label: 'Since 2020', dateFrom: '2020-01-01', dateTo: today },
-    { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
-    { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
-    { label: 'Since 2000', dateFrom: '2000-01-01', dateTo: today },
-    { label: 'Before 2000', dateFrom: earliestDate, dateTo: '1999-12-31' },
-];
 
-type Constants = {
-    earliestDate: string;
-    locationFields: string[];
-    customDateRangeOptions: DateRangeOption[];
-};
+class RsvBConstants {
+    constructor(organismsConfig: OrganismsConfig) {
+        this.mainDateField = organismsConfig.rsvB.lapis.mainDateField;
+    }
 
-const constants = { organism, earliestDate, locationFields, customDateRangeOptions };
+    public readonly organism = Organisms.rsvB as typeof Organisms.rsvB;
+    public readonly locationFields = ['geo_loc_country', 'geo_loc_admin_1'];
+    public readonly defaultDateRange: DateRange = 'allTimes';
+    public readonly earliestDate = '1956-01-01';
+    public readonly customDateRangeOptions = [
+        { label: 'Since 2020', dateFrom: '2020-01-01', dateTo: today },
+        { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
+        { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
+        { label: 'Since 2000', dateFrom: '2000-01-01', dateTo: today },
+        { label: 'Before 2000', dateFrom: this.earliestDate, dateTo: '1999-12-31' },
+    ];
+    public readonly mainDateField: string;
+
+    public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter & LapisLocation2 => {
+        const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));
+        return {
+            ...route.baselineFilter.location,
+            [`${this.mainDateField}From`]: dateRange.from,
+            [`${this.mainDateField}To`]: dateRange.to,
+        };
+    };
+}
 
 type RouteWithBaseline = Route & {
     baselineFilter: {
@@ -44,121 +53,88 @@ type RouteWithBaseline = Route & {
     };
 };
 
-const toLapisFilterWithoutVariant = (route: RouteWithBaseline): SampleCollectionDateFromTo & LapisLocation2 => {
-    const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(RsvBView1.view.earliestDate));
-    return {
-        ...route.baselineFilter.location,
-        sample_collection_dateFrom: dateRange.from,
-        sample_collection_dateTo: dateRange.to,
+type RsvBView1Route = { variantFilter: LapisVariantQuery1 } & RouteWithBaseline;
+
+export class RsvBView1 extends RsvBConstants implements View<RsvBView1Route> {
+    public pathname = `/${pathFragment}/single-variant`;
+    public label = 'Single variant';
+    public labelLong = 'Analyze a single variant';
+    public defaultRoute = {
+        organism: this.organism,
+        pathname: this.pathname,
+        baselineFilter: {
+            location: {},
+            dateRange: this.defaultDateRange,
+        },
+        variantFilter: {},
     };
-};
 
-export namespace RsvBView1 {
-    const pathname = `/${pathFragment}/single-variant`;
-
-    type Route = { variantFilter: LapisVariantQuery1 } & RouteWithBaseline;
-
-    const parseUrl = (url: URL): Route => {
+    public parseUrl = (url: URL): RsvBView1Route => {
         const search = url.searchParams;
         return {
-            organism,
-            pathname,
+            organism: this.organism,
+            pathname: this.pathname,
             baselineFilter: {
                 location: getLapisLocation2FromSearch(search),
-                dateRange: getDateRangeFromSearch(search, 'sample_collection_date') ?? defaultDateRange,
+                dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
             variantFilter: getLapisVariantQuery1FromSearch(search),
         };
     };
 
-    const toUrl = (route: Route): string => {
+    public toUrl = (route: RsvBView1Route): string => {
         const search = new URLSearchParams();
         setSearchFromLapisLocation2(search, route.baselineFilter.location);
-        if (route.baselineFilter.dateRange !== defaultDateRange) {
-            setSearchFromDateRange(search, 'sample_collection_date', route.baselineFilter.dateRange);
+        if (route.baselineFilter.dateRange !== this.defaultDateRange) {
+            setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
         setSearchFromLapisVariantQuery1(search, route.variantFilter);
-        return `${pathname}?${search}`;
+        return `${this.pathname}?${search}`;
     };
 
-    const toLapisFilter = (route: Route) => {
+    public toLapisFilter = (route: RsvBView1Route) => {
         return {
-            ...toLapisFilterWithoutVariant(route),
+            ...this.toLapisFilterWithoutVariant(route),
             ...route.variantFilter,
         };
     };
-
-    export type RsvBView1 = View<Route> &
-        Constants & {
-            toLapisFilter: (route: Route) => SampleCollectionDateFromTo & LapisLocation2 & LapisVariantQuery1;
-            toLapisFilterWithoutVariant: (route: Route) => SampleCollectionDateFromTo & LapisLocation2;
-        };
-
-    export const view: RsvBView1 = {
-        ...constants,
-        pathname,
-        label: 'Single variant',
-        labelLong: 'Analyze a single variant',
-        parseUrl,
-        toUrl,
-        defaultRoute: {
-            organism,
-            pathname,
-            baselineFilter: {
-                location: {},
-                dateRange: defaultDateRange,
-            },
-            variantFilter: {},
-        },
-        toLapisFilter,
-        toLapisFilterWithoutVariant,
-    };
 }
 
-export namespace RsvBView3 {
-    const pathname = `/${pathFragment}/sequencing-efforts`;
+export class RsvBView3 extends RsvBConstants implements View<RouteWithBaseline> {
+    public readonly pathname = `/${pathFragment}/sequencing-efforts`;
+    public readonly label = 'Sequencing efforts';
+    public readonly labelLong = 'Sequencing efforts';
+    public readonly defaultRoute = {
+        organism: this.organism,
+        pathname: this.pathname,
+        baselineFilter: {
+            location: {},
+            dateRange: this.defaultDateRange,
+        },
+    };
 
-    const parseUrl = (url: URL): RouteWithBaseline => {
+    public parseUrl = (url: URL): RouteWithBaseline => {
         const search = url.searchParams;
         return {
-            organism,
-            pathname,
+            organism: this.organism,
+            pathname: this.pathname,
             baselineFilter: {
                 location: getLapisLocation2FromSearch(search),
-                dateRange: getDateRangeFromSearch(search, 'sample_collection_date') ?? defaultDateRange,
+                dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
         };
     };
 
-    const toUrl = (route: RouteWithBaseline): string => {
+    public toUrl = (route: RouteWithBaseline): string => {
         const search = new URLSearchParams();
         setSearchFromLapisLocation2(search, route.baselineFilter.location);
-        if (route.baselineFilter.dateRange !== defaultDateRange) {
-            setSearchFromDateRange(search, 'sample_collection_date', route.baselineFilter.dateRange);
+        if (route.baselineFilter.dateRange !== this.defaultDateRange) {
+            setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
-        return `${pathname}?${search}`;
+        return `${this.pathname}?${search}`;
     };
 
-    export type RsvBView3 = View<RouteWithBaseline> &
-        Constants & {
-            toLapisFilter: (route: RouteWithBaseline) => SampleCollectionDateFromTo & LapisLocation2;
-        };
-
-    export const view: RsvBView3 = {
-        ...constants,
-        pathname,
-        label: 'Sequencing efforts',
-        labelLong: 'Sequencing efforts',
-        parseUrl,
-        toUrl,
-        defaultRoute: {
-            organism,
-            pathname,
-            baselineFilter: {
-                location: {},
-                dateRange: defaultDateRange,
-            },
-        },
-        toLapisFilter: toLapisFilterWithoutVariant,
+    public toLapisFilter = (route: RouteWithBaseline) => {
+        return this.toLapisFilterWithoutVariant(route);
     };
 }

--- a/website/src/routes/serverSideRouting.ts
+++ b/website/src/routes/serverSideRouting.ts
@@ -1,0 +1,26 @@
+import { getDashboardsConfig } from '../config.ts';
+import { Routing } from './routing.ts';
+
+/**
+ * Constants for use in server-side code - for convenience.
+ * They cannot be used in client-side code, because they import node modules, which are not available in the browser.
+ */
+export namespace ServerSide {
+    const organismsConfig = getDashboardsConfig().dashboards.organisms;
+
+    export const routing = new Routing(organismsConfig);
+
+    export const covidView1 = routing.views.covid[0];
+    export const covidView2 = routing.views.covid[1];
+    export const covidView3 = routing.views.covid[2];
+    export const h5n1View1 = routing.views.h5n1[0];
+    export const h5n1View3 = routing.views.h5n1[1];
+    export const mpoxView1 = routing.views.mpox[0];
+    export const mpoxView3 = routing.views.mpox[1];
+    export const rsvAView1 = routing.views.rsvA[0];
+    export const rsvAView3 = routing.views.rsvA[1];
+    export const rsvBView1 = routing.views.rsvB[0];
+    export const rsvBView3 = routing.views.rsvB[1];
+    export const westNileView1 = routing.views.westNile[0];
+    export const westNileView3 = routing.views.westNile[1];
+}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This required a major refactoring:
Several objects are no longer available on client side, because they require reading the config. Node imports not being available in the browser made it necessary to restructure the code, such that the routing and view objects can be instantiated lazily with a given config.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
