### PR TITLE
feat(backend): for now, evaluate "denominator = 0"-proportion triggers to "condition not met"

### DIFF
--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/api/TriggerEvaluation.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/api/TriggerEvaluation.kt
@@ -29,7 +29,7 @@ sealed interface TriggerEvaluationResult {
     }
 
     data class ConditionNotMet(
-        val evaluatedValue: Number,
+        val evaluatedValue: Number?,
         val threshold: Number,
         val lapisDataVersion: String?,
     ) : TriggerEvaluationResult {

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/triggerevaluation/TriggerEvaluator.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/triggerevaluation/TriggerEvaluator.kt
@@ -175,9 +175,10 @@ private class ProportionComputation(
             )
         }
 
-        if (denominatorCount == 0 && numeratorCount == 0) {
-            return TriggerEvaluationResult.ConditionMet(
-                evaluatedValue = 0,
+        // TODO(#156): reevaluate this condition after we understand the use cases better
+        if (denominatorCount == 0) {
+            return TriggerEvaluationResult.ConditionNotMet(
+                evaluatedValue = null,
                 threshold = threshold,
                 lapisDataVersion = numeratorResponse.info.dataVersion,
             )

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/model/triggerevaluation/ProportionTriggerEvaluatorTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/model/triggerevaluation/ProportionTriggerEvaluatorTest.kt
@@ -141,8 +141,8 @@ class ProportionTriggerEvaluatorTest(
         assertThat(
             result,
             `is`(
-                TriggerEvaluationResult.ConditionMet(
-                    evaluatedValue = Double.POSITIVE_INFINITY,
+                TriggerEvaluationResult.ConditionNotMet(
+                    evaluatedValue = null,
                     threshold = 0.5,
                     lapisDataVersion = "a data version",
                 ),
@@ -171,8 +171,8 @@ class ProportionTriggerEvaluatorTest(
         assertThat(
             result,
             `is`(
-                TriggerEvaluationResult.ConditionMet(
-                    evaluatedValue = 0,
+                TriggerEvaluationResult.ConditionNotMet(
+                    evaluatedValue = null,
                     threshold = 0.5,
                     lapisDataVersion = "a data version",
                 ),


### PR DESCRIPTION
### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

To be revisited in #156 

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
