### PR TITLE
160 make location fields configurable

### DIFF
--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
@@ -18,4 +18,6 @@ data class OrganismConfig(
 data class LapisConfig(
     val url: String,
     val mainDateField: String,
+    val locationFields: List<String>,
+    val lineageField: String,
 )

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
@@ -20,4 +20,9 @@ data class LapisConfig(
     val mainDateField: String,
     val locationFields: List<String>,
     val lineageField: String,
+    val hostField: String,
+    val authorsField: String?,
+    val authorAffiliationsField: String?,
+    val originatingLabField: String?,
+    val submittingLabField: String?,
 )

--- a/backend/src/main/resources/application-dashboards-dev.yaml
+++ b/backend/src/main/resources/application-dashboards-dev.yaml
@@ -4,26 +4,52 @@ dashboards:
       lapis:
         url: "https://lapis.cov-spectrum.org/open/v2"
         mainDateField: "date"
+        locationFields:
+          - "region"
+          - "country"
+          - "division"
+        lineageField: "nextcladePangoLineage"
+
     h5n1:
       lapis:
         url: "https://lapis.genspectrum.org/h5n1"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
+        lineageField: "lineage"
     mpox:
       lapis:
         url: "https://lapis.genspectrum.org/mpox"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
+        lineageField: "lineage"
     westNile:
       lapis:
         url: "https://lapis-main.loculus.org/west-nile"
-        mainDateField: "sample_collection_date"
+        mainDateField: "sampleCollectionDate"
+        locationFields:
+          - "geoLocCountry"
+          - "geoLocAdmin1"
+        lineageField: "lineage"
     rsvA:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-a"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
+        lineageField: "lineage"
     rsvB:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-b"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
+        lineageField: "lineage"
   auth:
     github:
       clientId: "Iv23li4tJm7xQ3VkM3OC"

--- a/backend/src/main/resources/application-dashboards-dev.yaml
+++ b/backend/src/main/resources/application-dashboards-dev.yaml
@@ -9,6 +9,9 @@ dashboards:
           - "country"
           - "division"
         lineageField: "nextcladePangoLineage"
+        hostField: "host"
+        originatingLabField: "originatingLab"
+        submittingLabField: "submittingLab"
 
     h5n1:
       lapis:
@@ -18,6 +21,9 @@ dashboards:
           - "geo_loc_country"
           - "geo_loc_admin_1"
         lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     mpox:
       lapis:
         url: "https://lapis.genspectrum.org/mpox"
@@ -26,6 +32,9 @@ dashboards:
           - "geo_loc_country"
           - "geo_loc_admin_1"
         lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     westNile:
       lapis:
         url: "https://lapis-main.loculus.org/west-nile"
@@ -34,6 +43,9 @@ dashboards:
           - "geoLocCountry"
           - "geoLocAdmin1"
         lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "authorAffiliations"
+        authorsField: "authors"
     rsvA:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-a"
@@ -42,6 +54,9 @@ dashboards:
           - "geo_loc_country"
           - "geo_loc_admin_1"
         lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     rsvB:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-b"
@@ -50,6 +65,9 @@ dashboards:
           - "geo_loc_country"
           - "geo_loc_admin_1"
         lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
   auth:
     github:
       clientId: "Iv23li4tJm7xQ3VkM3OC"

--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -4,26 +4,45 @@ dashboards:
       lapis:
         url: "https://lapis.cov-spectrum.org/open/v2"
         mainDateField: "date"
+        locationFields:
+          - "region"
+          - "country"
+          - "division"
     h5n1:
       lapis:
         url: "https://lapis.genspectrum.org/h5n1"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
     mpox:
       lapis:
         url: "https://lapis.genspectrum.org/mpox"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
     westNile:
       lapis:
         url: "https://lapis-main.loculus.org/west-nile"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
     rsvA:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-a"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
     rsvB:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-b"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
   auth:
     github:
       clientId: "Iv23liLcTmoYOEje50sW"

--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -8,6 +8,10 @@ dashboards:
           - "region"
           - "country"
           - "division"
+        lineageField: "nextcladePangoLineage"
+        hostField: "host"
+        originatingLabField: "originatingLab"
+        submittingLabField: "submittingLab"
     h5n1:
       lapis:
         url: "https://lapis.genspectrum.org/h5n1"
@@ -15,6 +19,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     mpox:
       lapis:
         url: "https://lapis.genspectrum.org/mpox"
@@ -22,6 +30,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     westNile:
       lapis:
         url: "https://lapis-main.loculus.org/west-nile"
@@ -29,6 +41,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "authorAffiliations"
+        authorsField: "authors"
     rsvA:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-a"
@@ -36,6 +52,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     rsvB:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-b"
@@ -43,6 +63,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
   auth:
     github:
       clientId: "Iv23liLcTmoYOEje50sW"

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -4,26 +4,45 @@ dashboards:
       lapis:
         url: "https://lapis.cov-spectrum.org/open/v2"
         mainDateField: "date"
+        locationFields:
+          - "region"
+          - "country"
+          - "division"
     h5n1:
       lapis:
         url: "https://lapis.genspectrum.org/h5n1"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
     mpox:
       lapis:
         url: "https://lapis.genspectrum.org/mpox"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
     westNile:
       lapis:
         url: "https://lapis-main.loculus.org/west-nile"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
     rsvA:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-a"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
     rsvB:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-b"
         mainDateField: "sample_collection_date"
+        locationFields:
+          - "geo_loc_country"
+          - "geo_loc_admin_1"
   auth:
     github:
       clientId: "Iv23li4tJm7xQ3VkM3OC"

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -8,6 +8,10 @@ dashboards:
           - "region"
           - "country"
           - "division"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     h5n1:
       lapis:
         url: "https://lapis.genspectrum.org/h5n1"
@@ -15,6 +19,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     mpox:
       lapis:
         url: "https://lapis.genspectrum.org/mpox"
@@ -22,6 +30,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     westNile:
       lapis:
         url: "https://lapis-main.loculus.org/west-nile"
@@ -29,6 +41,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "authorAffiliations"
+        authorsField: "authors"
     rsvA:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-a"
@@ -36,6 +52,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
     rsvB:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-b"
@@ -43,6 +63,10 @@ dashboards:
         locationFields:
           - "geo_loc_country"
           - "geo_loc_admin_1"
+        lineageField: "lineage"
+        hostField: "host_name_scientific"
+        authorAffiliationsField: "author_affiliations"
+        authorsField: "authors"
   auth:
     github:
       clientId: "Iv23li4tJm7xQ3VkM3OC"

--- a/backend/src/test/resources/application.yaml
+++ b/backend/src/test/resources/application.yaml
@@ -11,23 +11,66 @@ dashboards:
       lapis:
         url: "https://covid.lapis.dummy"
         mainDateField: "covid_date"
+        locationFields:
+          - "covid_region"
+          - "covid_country"
+          - "covid_division"
+        lineageField: "covid_lineage"
+        hostField: "covid_host"
+        originatingLabField: "covid_originating_lab"
+        submittingLabField: "covid_submitting_lab"
     h5n1:
       lapis:
         url: "https://h5n1.lapis.dummy"
         mainDateField: "h5n1_date"
+        locationFields:
+          - "h5n1_geo_loc_country"
+          - "h5n1_geo_loc_admin_1"
+        lineageField: "h5n1_lineage"
+        hostField: "h5n1_host_name_scientific"
+        authorAffiliationsField: "h5n1_author_affiliations"
+        authorsField: "h5n1_authors"
     mpox:
       lapis:
         url: "https://mpox.lapis.dummy"
         mainDateField: "mpox_date"
+        locationFields:
+          - "mpox_geo_loc_country"
+          - "mpox_geo_loc_admin_1"
+        lineageField: "mpox_lineage"
+        hostField: "mpox_host_name_scientific"
+        authorAffiliationsField: "mpox_author_affiliations"
+        authorsField: "mpox_authors"
     westNile:
       lapis:
         url: "https://westNile.lapis.dummy"
         mainDateField: "westnile_date"
+        locationFields:
+          - "westNile_geo_loc_country"
+          - "westNile_geo_loc_admin_1"
+        lineageField: "westNile_lineage"
+        hostField: "westNile_host_name_scientific"
+        authorAffiliationsField: "westNile_author_affiliations"
+        authorsField: "westNile_authors"
     rsvA:
       lapis:
         url: "https://rsvA.lapis.dummy"
         mainDateField: "rsva_date"
+        locationFields:
+          - "rsvA_geo_loc_country"
+          - "rsvA_geo_loc_admin_1"
+        lineageField: "rsvA_lineage"
+        hostField: "rsvA_host_name_scientific"
+        authorAffiliationsField: "rsvA_author_affiliations"
+        authorsField: "rsvA_authors"
     rsvB:
       lapis:
         url: "https://rsvB.lapis.dummy"
         mainDateField: "rsvb_date"
+        locationFields:
+          - "rsvB_geo_loc_country"
+          - "rsvB_geo_loc_admin_1"
+        lineageField: "rsvB_lineage"
+        hostField: "rsvB_host_name_scientific"
+        authorAffiliationsField: "rsvB_author_affiliations"
+        authorsField: "rsvB_authors"

--- a/website/src/components/VariantFilter.astro
+++ b/website/src/components/VariantFilter.astro
@@ -68,7 +68,7 @@ const { fields, initialMutations } = Astro.props;
                 const filterElement = document.getElementById(`${field.name}Filter`);
                 const eventName = field.type === 'text' ? 'gs-text-input-changed' : 'gs-lineage-filter-changed';
                 filterElement?.addEventListener(eventName, (event: CustomEvent) => {
-                    values[field.name] = event.detail[field.name];
+                    values[field.rename ?? field.name] = event.detail[field.name];
                 });
             });
 
@@ -83,6 +83,7 @@ const { fields, initialMutations } = Astro.props;
                     ...currentRoute,
                     variantFilter: values,
                 };
+
                 routing.navigateTo(newRoute);
             });
         }

--- a/website/src/components/VariantFilterTypes.ts
+++ b/website/src/components/VariantFilterTypes.ts
@@ -3,4 +3,5 @@ export type Field = {
     label: string;
     initialValue: string | undefined;
     type: 'text' | 'pango-lineage';
+    rename?: string;
 };

--- a/website/src/components/covidAnalyzeSingleVariantView/CollectionsList.tsx
+++ b/website/src/components/covidAnalyzeSingleVariantView/CollectionsList.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { Routing } from '../../routes/routing.ts';
-import { type CovidView1Route } from '../../routes/covid.ts';
+import { type CovidAnalyzeSingleVariantRoute } from '../../routes/covid.ts';
 import type { OrganismsConfig } from '../../config.ts';
 
 type CollectionVariant = {
@@ -93,8 +93,8 @@ const CollectionVariantList = ({ collection, organismsConfig }: CollectionVarian
     const routing = useMemo(() => new Routing(organismsConfig), [organismsConfig]);
 
     const selectVariant = (variant: CollectionVariant) => {
-        const currentRoute = routing.getCurrentRouteInBrowser() as CovidView1Route;
-        let newRoute: CovidView1Route;
+        const currentRoute = routing.getCurrentRouteInBrowser() as CovidAnalyzeSingleVariantRoute;
+        let newRoute: CovidAnalyzeSingleVariantRoute;
         const query = JSON.parse(variant.query);
         if ('variantQuery' in query) {
             newRoute = {
@@ -109,7 +109,7 @@ const CollectionVariantList = ({ collection, organismsConfig }: CollectionVarian
                 ...currentRoute,
                 collectionId: collection.id,
                 variantFilter: {
-                    nextcladePangoLineage: query.pangoLineage ?? query.nextcladePangoLineage,
+                    lineage: query.pangoLineage ?? query.nextcladePangoLineage,
                     nucleotideMutations: query.nucMutations,
                     aminoAcidMutations: query.aaMutations,
                     nucleotideInsertions: query.nucInsertions,

--- a/website/src/components/covidCompareVariantsView/JointFilter.astro
+++ b/website/src/components/covidCompareVariantsView/JointFilter.astro
@@ -1,6 +1,5 @@
 ---
-import type { LapisMutationQuery } from '../../routes/helpers';
-import type { LapisLocation1 } from '../../routes/helpers';
+import type { LapisLocation, LapisMutationQuery } from '../../routes/helpers';
 import type { DateRange } from '../../routes/helpers';
 import { isCustomDateRange } from '../../routes/helpers';
 import { ServerSide } from '../../routes/serverSideRouting';
@@ -8,16 +7,15 @@ import { getDashboardsConfig } from '../../config';
 
 interface Props {
     filterId: number;
-    initialLocation: LapisLocation1;
+    initialLocation: LapisLocation;
     initialDateRange: DateRange;
-    initialNextcladePangoLineage?: string;
+    initialLineage?: string;
     initialMutations: LapisMutationQuery;
 }
 
-const { filterId, initialLocation, initialNextcladePangoLineage, initialDateRange, initialMutations } = Astro.props;
+const { filterId, initialLocation, initialLineage, initialDateRange, initialMutations } = Astro.props;
 
-const { region, country, division } = initialLocation;
-const initialLocationValue = [region, country, division].filter(Boolean).join(' / ');
+const initialLocationValue = Object.values(initialLocation).filter(Boolean).join(' / ');
 const initialDateRangeValue = isCustomDateRange(initialDateRange) ? 'custom' : initialDateRange;
 const initialDateRangeFrom = isCustomDateRange(initialDateRange) ? initialDateRange.from : undefined;
 const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRange.to : undefined;
@@ -28,7 +26,7 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
         filterId,
         location: initialLocation,
         dateRange: initialDateRange,
-        nextcladePangoLineage: initialNextcladePangoLineage,
+        lineage: initialLineage,
         mutations: initialMutations,
     })}
     data-organisms-config={JSON.stringify(getDashboardsConfig().dashboards.organisms)}
@@ -39,26 +37,28 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
                 <div class='font-semibold'>Filter dataset:</div>
                 <gs-location-filter
                     id={`locationFilter${filterId}`}
-                    fields='["region", "country", "division"]'
+                    fields={JSON.stringify(ServerSide.covidAnalyzeSingleVariantView.locationFields)}
                     initialValue={initialLocationValue}
                     placeholderText='Sampling location'
                     width='100%'></gs-location-filter>
                 <gs-date-range-selector
                     id={`dateRangeSelector${filterId}`}
-                    customSelectOptions={JSON.stringify(ServerSide.covidView1.customDateRangeOptions)}
-                    earliestDate={ServerSide.covidView1.earliestDate}
+                    customSelectOptions={JSON.stringify(
+                        ServerSide.covidAnalyzeSingleVariantView.customDateRangeOptions,
+                    )}
+                    earliestDate={ServerSide.covidAnalyzeSingleVariantView.earliestDate}
                     initialValue={initialDateRangeValue}
                     initialDateFrom={initialDateRangeFrom}
                     initialDateTo={initialDateRangeTo}
-                    dateColumn='date'></gs-date-range-selector>
+                    dateColumn={ServerSide.covidAnalyzeSingleVariantView.mainDateField}></gs-date-range-selector>
             </div>
             <div class='flex flex-1 flex-col border-l-2 bg-green-50 px-2 py-4'>
                 <div class='mb-2 font-semibold'>Search variant:</div>
                 <gs-lineage-filter
                     id={`lineageFilter${filterId}`}
-                    lapisField='nextcladePangoLineage'
+                    lapisField={ServerSide.covidAnalyzeSingleVariantView.lineageField}
                     placeholderText='Pango Lineage'
-                    initialValue={initialNextcladePangoLineage}
+                    initialValue={initialLineage}
                     width='100%'
                 >
                 </gs-lineage-filter>
@@ -83,12 +83,12 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
 
 <script>
     import { Routing } from '../../routes/routing.ts';
-    import { CovidView2, type CovidView2Route } from '../../routes/covid';
+    import { CovidCompareVariantsView, type CovidCompareVariantsRoute } from '../../routes/covid';
 
     class JointFilter extends HTMLElement {
         constructor() {
             super();
-            let { filterId, location, dateRange, nextcladePangoLineage, mutations } = JSON.parse(this.dataset.message!);
+            let { filterId, location, dateRange, lineage, mutations } = JSON.parse(this.dataset.message!);
             const config = JSON.parse(this.dataset.organismsConfig!);
             const locationFilter = document.getElementById(`locationFilter${filterId}`);
             const dateRangeSelector = document.getElementById(`dateRangeSelector${filterId}`);
@@ -108,7 +108,7 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
             });
 
             lineageFilter?.addEventListener('gs-lineage-filter-changed', (event: CustomEvent) => {
-                nextcladePangoLineage = event.detail.nextcladePangoLineage;
+                lineage = event.detail.nextcladePangoLineage;
             });
 
             mutationFilter?.addEventListener('gs-mutation-filter-changed', (event: CustomEvent) => {
@@ -117,16 +117,19 @@ const initialDateRangeTo = isCustomDateRange(initialDateRange) ? initialDateRang
 
             submitButton?.addEventListener('click', () => {
                 const routing = new Routing(config);
-                const currentRoute = routing.getCurrentRouteInBrowser() as CovidView2Route;
+                const currentRoute = routing.getCurrentRouteInBrowser() as CovidCompareVariantsRoute;
                 routing.navigateTo(
-                    new CovidView2(config).setFilter(currentRoute, {
-                        id: filterId,
-                        baselineFilter: {
-                            location,
-                            dateRange,
+                    new CovidCompareVariantsView(config).setFilter(
+                        currentRoute,
+                        {
+                            baselineFilter: {
+                                location,
+                                dateRange,
+                            },
+                            variantFilter: { lineage, ...mutations },
                         },
-                        variantFilter: { nextcladePangoLineage, ...mutations },
-                    }),
+                        filterId,
+                    ),
                 );
             });
         }

--- a/website/src/components/rsv/RsvSequencingEffortsPage.astro
+++ b/website/src/components/rsv/RsvSequencingEffortsPage.astro
@@ -2,7 +2,7 @@
 import { chooseGranularityBasedOnDateRange, getLocationSubdivision } from '../../routes/helpers';
 import { organismConfig } from '../../routes/View';
 import { RsvASequencingEffortsView } from '../../routes/rsvA';
-import { RsvBView3 } from '../../routes/rsvB';
+import { RsvBSequencingEffortsView } from '../../routes/rsvB';
 import { defaultTablePageSize, type Route } from '../../routes/View';
 import { getLapisUrl } from '../../config';
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
@@ -11,7 +11,7 @@ import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 
 interface Props {
-    view: RsvASequencingEffortsView | RsvBView3;
+    view: RsvASequencingEffortsView | RsvBSequencingEffortsView;
 }
 
 const { view } = Astro.props;
@@ -74,7 +74,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             }
             <ComponentWrapper title='Hosts' height='600px'>
                 <gs-aggregate
-                    fields='["host_name_scientific"]'
+                    fields={JSON.stringify([view.hostField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -82,7 +82,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentWrapper>
             <ComponentWrapper title='Author affiliations' height='600px'>
                 <gs-aggregate
-                    fields='["author_affiliations"]'
+                    fields={JSON.stringify([view.authorAffiliationsField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -90,7 +90,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentWrapper>
             <ComponentWrapper title='Authors' height='600px'>
                 <gs-aggregate
-                    fields='["authors", "author_affiliations"]'
+                    fields={JSON.stringify([view.authorsField, view.authorAffiliationsField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/components/rsv/RsvSequencingEffortsPage.astro
+++ b/website/src/components/rsv/RsvSequencingEffortsPage.astro
@@ -1,7 +1,7 @@
 ---
-import { chooseGranularityBasedOnDateRange } from '../../routes/helpers';
+import { chooseGranularityBasedOnDateRange, getLocationSubdivision } from '../../routes/helpers';
 import { organismConfig } from '../../routes/View';
-import { RsvAView3 } from '../../routes/rsvA';
+import { RsvASequencingEffortsView } from '../../routes/rsvA';
 import { RsvBView3 } from '../../routes/rsvB';
 import { defaultTablePageSize, type Route } from '../../routes/View';
 import { getLapisUrl } from '../../config';
@@ -11,7 +11,7 @@ import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 
 interface Props {
-    view: RsvAView3 | RsvBView3;
+    view: RsvASequencingEffortsView | RsvBView3;
 }
 
 const { view } = Astro.props;
@@ -24,15 +24,10 @@ const timeGranularity = chooseGranularityBasedOnDateRange({
     from: baselineFilter[`${view.mainDateField}From`] as string,
     to: baselineFilter[`${view.mainDateField}To`] as string,
 });
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.geo_loc_country === undefined) {
-    subDivisionField = 'geo_loc_country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.geo_loc_admin_1 === undefined) {
-    subDivisionField = 'geo_loc_admin_1';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    view.locationFields,
+    routeData.baselineFilter.location,
+);
 ---
 
 <BaseLayout title={`Sequencing Efforts | ${organismConfig[view.organism].label} | GenSpectrum`}>
@@ -65,10 +60,10 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                     granularity={timeGranularity}></gs-number-sequences-over-time>
             </ComponentWrapper>
             {
-                subDivisionField && (
-                    <ComponentWrapper title={subDivisionLabel} height='600px'>
+                subdivisionField && (
+                    <ComponentWrapper title={subdivisionLabel} height='600px'>
                         <gs-aggregate
-                            fields={JSON.stringify([subDivisionField])}
+                            fields={JSON.stringify([subdivisionField])}
                             filter={JSON.stringify(baselineFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/components/rsv/RsvSingleVariantPage.astro
+++ b/website/src/components/rsv/RsvSingleVariantPage.astro
@@ -34,11 +34,6 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
 );
 
 const initialMutations = getLapisMutations(variantFilter);
-
-const lineageField =
-    view.organism === Organisms.rsvA
-        ? ServerSide.rsvAAnalyzeSingleVariantView.lineageField
-        : ServerSide.rsvBAnalyzeSingleVariantView.lineageField;
 ---
 
 <BaseLayout title={`Single Variant | ${organismConfig[view.organism].label} | GenSpectrum`}>
@@ -60,7 +55,7 @@ const lineageField =
                     <VariantFilter
                         fields={[
                             {
-                                name: lineageField,
+                                name: view.lineageField,
                                 label: 'Lineage',
                                 initialValue: variantFilter.lineage,
                                 type: 'text',
@@ -120,7 +115,7 @@ const lineageField =
                     }
                     <ComponentWrapper title='Clades and lineages'>
                         <gs-aggregate
-                            fields={JSON.stringify([lineageField])}
+                            fields={JSON.stringify([view.lineageField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'
@@ -128,7 +123,7 @@ const lineageField =
                     </ComponentWrapper>
                     <ComponentWrapper title='Hosts'>
                         <gs-aggregate
-                            fields='["host_name_scientific"]'
+                            fields={JSON.stringify([view.hostField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/components/rsv/RsvSingleVariantPage.astro
+++ b/website/src/components/rsv/RsvSingleVariantPage.astro
@@ -1,9 +1,9 @@
 ---
-import { organismConfig } from '../../routes/View';
-import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
-import type { DateRange, LapisLocation2, LapisVariantQuery1 } from '../../routes/helpers';
-import { RsvAView1 } from '../../routes/rsvA';
-import { RsvBView1 } from '../../routes/rsvB';
+import { organismConfig, Organisms } from '../../routes/View';
+import { chooseGranularityBasedOnDateRange, getLapisMutations, getLocationSubdivision } from '../../routes/helpers';
+import type { DateRange } from '../../routes/helpers';
+import { RsvAAnalyzeSingleVariantView } from '../../routes/rsvA';
+import { RsvBAnalyzeSingleVariantView } from '../../routes/rsvB';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize } from '../../routes/View';
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
@@ -11,9 +11,10 @@ import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
 import VariantFilter from '../../components/VariantFilter.astro';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import { ServerSide } from '../../routes/serverSideRouting';
 
 interface Props {
-    view: RsvAView1 | RsvBView1;
+    view: RsvAAnalyzeSingleVariantView | RsvBAnalyzeSingleVariantView;
 }
 
 const { view } = Astro.props;
@@ -27,17 +28,17 @@ const timeGranularity = chooseGranularityBasedOnDateRange({
     to: baselineFilter[`${view.mainDateField}To`] as string,
 });
 
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.geo_loc_country === undefined) {
-    subDivisionField = 'geo_loc_country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.geo_loc_admin_1 === undefined) {
-    subDivisionField = 'geo_loc_admin_1';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    view.locationFields,
+    routeData.baselineFilter.location,
+);
 
-const initialMutations = extractMutations(variantFilter);
+const initialMutations = getLapisMutations(variantFilter);
+
+const lineageField =
+    view.organism === Organisms.rsvA
+        ? ServerSide.rsvAAnalyzeSingleVariantView.lineageField
+        : ServerSide.rsvBAnalyzeSingleVariantView.lineageField;
 ---
 
 <BaseLayout title={`Single Variant | ${organismConfig[view.organism].label} | GenSpectrum`}>
@@ -58,7 +59,13 @@ const initialMutations = extractMutations(variantFilter);
                     <div class='mb-2 font-semibold'>Search variant:</div>
                     <VariantFilter
                         fields={[
-                            { name: 'lineage', label: 'Lineage', initialValue: variantFilter.lineage, type: 'text' },
+                            {
+                                name: lineageField,
+                                label: 'Lineage',
+                                initialValue: variantFilter.lineage,
+                                type: 'text',
+                                rename: 'lineage',
+                            },
                         ]}
                         initialMutations={initialMutations}
                     />
@@ -99,10 +106,10 @@ const initialMutations = extractMutations(variantFilter);
                             height='100%'></gs-mutations>
                     </ComponentWrapper>
                     {
-                        subDivisionField && (
-                            <ComponentWrapper title={subDivisionLabel}>
+                        subdivisionField && (
+                            <ComponentWrapper title={subdivisionLabel}>
                                 <gs-aggregate
-                                    fields={JSON.stringify([subDivisionField])}
+                                    fields={JSON.stringify([subdivisionField])}
                                     filter={JSON.stringify(variantFilter)}
                                     pageSize={defaultTablePageSize}
                                     width='100%'
@@ -113,7 +120,7 @@ const initialMutations = extractMutations(variantFilter);
                     }
                     <ComponentWrapper title='Clades and lineages'>
                         <gs-aggregate
-                            fields={JSON.stringify(['lineage'])}
+                            fields={JSON.stringify([lineageField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -9,6 +9,11 @@ const lapisConfigSchema = z.object({
     mainDateField: z.string(),
     locationFields: z.array(z.string()),
     lineageField: z.string(),
+    hostField: z.string(),
+    authorsField: z.optional(z.string()),
+    authorAffiliationsField: z.optional(z.string()),
+    originatingLabField: z.optional(z.string()),
+    submittingLabField: z.optional(z.string()),
 });
 
 const organismConfigSchema = z.object({ lapis: lapisConfigSchema });

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -7,6 +7,8 @@ import YAML from 'yaml';
 const lapisConfigSchema = z.object({
     url: z.string(),
     mainDateField: z.string(),
+    locationFields: z.array(z.string()),
+    lineageField: z.string(),
 });
 
 const organismConfigSchema = z.object({ lapis: lapisConfigSchema });

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -46,7 +46,7 @@ if (routeData === undefined) {
                                 filterId={id}
                                 initialLocation={baselineFilter.location}
                                 initialDateRange={baselineFilter.dateRange}
-                                initialLineage={'lineage' in variantFilter ? variantFilter.lineage : undefined}
+                                initialLineage={variantFilter.lineage ?? undefined}
                                 initialMutations={initialMutations}
                             />
                             <ComponentWrapper title='Prevalence over time'>
@@ -104,7 +104,7 @@ if (routeData === undefined) {
                             </ComponentWrapper>
                             <ComponentWrapper title='Hosts'>
                                 <gs-aggregate
-                                    fields='["host"]'
+                                    fields={JSON.stringify([ServerSide.covidSequencingEffortsView.hostField])}
                                     filter={JSON.stringify(numeratorFilter)}
                                     pageSize={defaultTablePageSize}
                                     width='100%'

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -1,13 +1,13 @@
 ---
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
-import JointFilter from '../../components/covidView2/JointFilter.astro';
-import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
+import JointFilter from '../../components/covidCompareVariantsView/JointFilter.astro';
+import { chooseGranularityBasedOnDateRange, getLapisMutations } from '../../routes/helpers';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = ServerSide.covidView2.parseUrl(Astro.url);
+const routeData = ServerSide.covidCompareVariantsView.parseUrl(Astro.url);
 if (routeData === undefined) {
     throw Error('Failed to parse URL for side-by-side comparison page');
 }
@@ -17,20 +17,27 @@ if (routeData === undefined) {
     <gs-app lapis={getLapisUrl(Organisms.covid)}>
         <div class='flex overflow-x-auto'>
             {
-                routeData.filters.map(({ id, variantFilter, baselineFilter }) => {
-                    const baselineLapisFilter = ServerSide.covidView2.baselineFilterToLapisFilter(baselineFilter);
+                Array.from(routeData.filters).map(([id, { variantFilter, baselineFilter }]) => {
+                    const baselineLapisFilter =
+                        ServerSide.covidCompareVariantsView.baselineFilterToLapisFilter(baselineFilter);
                     const timeGranularity = chooseGranularityBasedOnDateRange({
-                        from: baselineLapisFilter[`${ServerSide.covidView2.mainDateField}From`] as string,
-                        to: baselineLapisFilter[`${ServerSide.covidView2.mainDateField}To`] as string,
+                        from: baselineLapisFilter[`${ServerSide.covidCompareVariantsView.mainDateField}From`] as string,
+                        to: baselineLapisFilter[`${ServerSide.covidCompareVariantsView.mainDateField}To`] as string,
                     });
-                    const initialMutations = extractMutations(variantFilter);
+                    const initialMutations = getLapisMutations(variantFilter);
+                    const numeratorFilter = {
+                        ...ServerSide.covidCompareVariantsView.variantFilterToLapisFilter(variantFilter),
+                        ...baselineLapisFilter,
+                    };
 
                     return (
                         <div class='min-w-[700px] flex-1 border-r-2 px-2'>
-                            {routeData.filters.length > 1 && (
+                            {routeData.filters.size > 1 && (
                                 <a
                                     class='block w-full px-2 py-1 hover:bg-neutral-100'
-                                    href={ServerSide.routing.toUrl(ServerSide.covidView2.removeFilter(routeData, id))}
+                                    href={ServerSide.routing.toUrl(
+                                        ServerSide.covidCompareVariantsView.removeFilter(routeData, id),
+                                    )}
                                 >
                                     Remove column
                                 </a>
@@ -39,18 +46,14 @@ if (routeData === undefined) {
                                 filterId={id}
                                 initialLocation={baselineFilter.location}
                                 initialDateRange={baselineFilter.dateRange}
-                                initialNextcladePangoLineage={
-                                    'nextcladePangoLineage' in variantFilter
-                                        ? variantFilter.nextcladePangoLineage
-                                        : undefined
-                                }
+                                initialLineage={'lineage' in variantFilter ? variantFilter.lineage : undefined}
                                 initialMutations={initialMutations}
                             />
                             <ComponentWrapper title='Prevalence over time'>
                                 <gs-prevalence-over-time
                                     numeratorFilter={JSON.stringify({
                                         displayName: '',
-                                        lapisFilter: { ...variantFilter, ...baselineLapisFilter },
+                                        lapisFilter: numeratorFilter,
                                     })}
                                     denominatorFilter={JSON.stringify(baselineLapisFilter)}
                                     granularity={timeGranularity}
@@ -62,7 +65,7 @@ if (routeData === undefined) {
                             </ComponentWrapper>
                             <ComponentWrapper title='Relative growth advantage'>
                                 <gs-relative-growth-advantage
-                                    numeratorFilter={JSON.stringify({ ...variantFilter, ...baselineLapisFilter })}
+                                    numeratorFilter={JSON.stringify(numeratorFilter)}
                                     denominatorFilter={JSON.stringify(baselineLapisFilter)}
                                     generationTime='7'
                                     pageSize={defaultTablePageSize}
@@ -72,7 +75,7 @@ if (routeData === undefined) {
                             </ComponentWrapper>
                             <ComponentWrapper title='Nucleotide mutations'>
                                 <gs-mutations
-                                    lapisFilter={JSON.stringify(variantFilter)}
+                                    lapisFilter={JSON.stringify(numeratorFilter)}
                                     sequenceType='nucleotide'
                                     views='["grid", "table", "insertions"]'
                                     pageSize={defaultTablePageSize}
@@ -82,7 +85,7 @@ if (routeData === undefined) {
                             </ComponentWrapper>
                             <ComponentWrapper title='Amino acid mutations'>
                                 <gs-mutations
-                                    lapisFilter={JSON.stringify(variantFilter)}
+                                    lapisFilter={JSON.stringify(numeratorFilter)}
                                     sequenceType='amino acid'
                                     views='["grid", "table", "insertions"]'
                                     pageSize={defaultTablePageSize}
@@ -92,8 +95,8 @@ if (routeData === undefined) {
                             </ComponentWrapper>
                             <ComponentWrapper title='Sub-lineages'>
                                 <gs-aggregate
-                                    fields='["nextcladePangoLineage"]'
-                                    filter={JSON.stringify(variantFilter)}
+                                    fields={JSON.stringify([ServerSide.covidCompareVariantsView.lineageField])}
+                                    filter={JSON.stringify(numeratorFilter)}
                                     pageSize={defaultTablePageSize}
                                     width='100%'
                                     height='100%'
@@ -102,7 +105,7 @@ if (routeData === undefined) {
                             <ComponentWrapper title='Hosts'>
                                 <gs-aggregate
                                     fields='["host"]'
-                                    filter={JSON.stringify(variantFilter)}
+                                    filter={JSON.stringify(numeratorFilter)}
                                     pageSize={defaultTablePageSize}
                                     width='100%'
                                     height='100%'
@@ -114,7 +117,7 @@ if (routeData === undefined) {
             }
             <a
                 class='px-4 pt-8 text-left hover:bg-neutral-100'
-                href={ServerSide.routing.toUrl(ServerSide.covidView2.addEmptyFilter(routeData))}
+                href={ServerSide.routing.toUrl(ServerSide.covidCompareVariantsView.addEmptyFilter(routeData))}
                 style='writing-mode: vertical-rl;'
             >
                 Add column

--- a/website/src/pages/covid/sequencing-efforts.astro
+++ b/website/src/pages/covid/sequencing-efforts.astro
@@ -1,5 +1,5 @@
 ---
-import { chooseGranularityBasedOnDateRange } from '../../routes/helpers';
+import { chooseGranularityBasedOnDateRange, getLocationSubdivision } from '../../routes/helpers';
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
 import { getLapisUrl } from '../../config';
@@ -8,23 +8,18 @@ import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = ServerSide.covidView3.parseUrl(Astro.url);
+const routeData = ServerSide.covidSequencingEffortsView.parseUrl(Astro.url);
 
-const baselineFilter = ServerSide.covidView3.toLapisFilter(routeData);
+const baselineFilter = ServerSide.covidSequencingEffortsView.toLapisFilter(routeData);
 
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter[`${ServerSide.covidView3.mainDateField}From`] as string,
-    to: baselineFilter[`${ServerSide.covidView3.mainDateField}To`] as string,
+    from: baselineFilter[`${ServerSide.covidSequencingEffortsView.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.covidSequencingEffortsView.mainDateField}To`] as string,
 });
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.country === undefined) {
-    subDivisionField = 'country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.division === undefined) {
-    subDivisionField = 'division';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    ServerSide.covidAnalyzeSingleVariantView.locationFields,
+    routeData.baselineFilter.location,
+);
 ---
 
 <BaseLayout title='Sequencing Efforts | SARS-CoV-2 | GenSpectrum'>
@@ -33,11 +28,11 @@ if (routeData.baselineFilter.location.country === undefined) {
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
                 <LocationTimeFilter
-                    fields={ServerSide.covidView3.locationFields}
+                    fields={ServerSide.covidSequencingEffortsView.locationFields}
                     initialLocation={baselineFilter}
                     initialDateRange={routeData.baselineFilter.dateRange}
-                    earliestDate={ServerSide.covidView3.earliestDate}
-                    customDateRangeOptions={ServerSide.covidView3.customDateRangeOptions}
+                    earliestDate={ServerSide.covidSequencingEffortsView.earliestDate}
+                    customDateRangeOptions={ServerSide.covidSequencingEffortsView.customDateRangeOptions}
                 />
             </div>
         </div>
@@ -49,7 +44,7 @@ if (routeData.baselineFilter.location.country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField={ServerSide.covidView3.mainDateField}
+                    lapisDateField={ServerSide.covidSequencingEffortsView.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -57,10 +52,10 @@ if (routeData.baselineFilter.location.country === undefined) {
                     granularity={timeGranularity}></gs-number-sequences-over-time>
             </ComponentWrapper>
             {
-                subDivisionField && (
-                    <ComponentWrapper title={subDivisionLabel} height='600px'>
+                subdivisionField && (
+                    <ComponentWrapper title={subdivisionLabel} height='600px'>
                         <gs-aggregate
-                            fields={JSON.stringify([subDivisionField])}
+                            fields={JSON.stringify([subdivisionField])}
                             filter={JSON.stringify(baselineFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/pages/covid/sequencing-efforts.astro
+++ b/website/src/pages/covid/sequencing-efforts.astro
@@ -66,7 +66,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             }
             <ComponentWrapper title='Hosts' height='600px'>
                 <gs-aggregate
-                    fields='["host"]'
+                    fields={JSON.stringify([ServerSide.covidSequencingEffortsView.hostField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -74,7 +74,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentWrapper>
             <ComponentWrapper title='Originating lab' height='600px'>
                 <gs-aggregate
-                    fields='["originatingLab"]'
+                    fields={JSON.stringify([ServerSide.covidSequencingEffortsView.originatingLabField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -82,7 +82,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentWrapper>
             <ComponentWrapper title='Submitting lab' height='600px'>
                 <gs-aggregate
-                    fields='["submittingLab"]'
+                    fields={JSON.stringify([ServerSide.covidSequencingEffortsView.submittingLabField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
-import { CollectionsList } from '../../components/covidView1/CollectionsList';
-import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
+import { CollectionsList } from '../../components/covidAnalyzeSingleVariantView/CollectionsList';
+import { chooseGranularityBasedOnDateRange, getLapisMutations, getLocationSubdivision } from '../../routes/helpers';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
 import VariantFilter from '../../components/VariantFilter.astro';
 import { getDashboardsConfig, getLapisUrl } from '../../config';
@@ -10,26 +10,24 @@ import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = ServerSide.covidView1.parseUrl(Astro.url);
+const routeData = ServerSide.covidAnalyzeSingleVariantView.parseUrl(Astro.url);
 
-const variantFilter = ServerSide.covidView1.toLapisFilter(routeData);
-const baselineFilter = ServerSide.covidView1.toLapisFilterWithoutVariant(routeData);
+const variantFilter = ServerSide.covidAnalyzeSingleVariantView.toLapisFilter(routeData);
+const baselineFilter = ServerSide.covidAnalyzeSingleVariantView.toLapisFilterWithoutVariant(routeData);
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter[`${ServerSide.covidView1.mainDateField}From`] as string,
-    to: baselineFilter[`${ServerSide.covidView1.mainDateField}To`] as string,
+    from: baselineFilter[`${ServerSide.covidAnalyzeSingleVariantView.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.covidAnalyzeSingleVariantView.mainDateField}To`] as string,
 });
 
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.country === undefined) {
-    subDivisionField = 'country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.division === undefined) {
-    subDivisionField = 'division';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    ServerSide.covidAnalyzeSingleVariantView.locationFields,
+    routeData.baselineFilter.location,
+);
 
-const initialMutations = extractMutations(variantFilter);
+const initialMutations = getLapisMutations(variantFilter);
+
+console.log('variantFilter', variantFilter);
+console.log('routeData.variantFilter', routeData.variantFilter);
 ---
 
 <BaseLayout title='Single Variant | SARS-CoV-2 | GenSpectrum'>
@@ -39,11 +37,11 @@ const initialMutations = extractMutations(variantFilter);
                 <div class='bg-blue-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Filter dataset:</div>
                     <LocationTimeFilter
-                        fields={ServerSide.covidView1.locationFields}
+                        fields={ServerSide.covidAnalyzeSingleVariantView.locationFields}
                         initialLocation={baselineFilter}
                         initialDateRange={routeData.baselineFilter.dateRange}
-                        earliestDate={ServerSide.covidView1.earliestDate}
-                        customDateRangeOptions={ServerSide.covidView1.customDateRangeOptions}
+                        earliestDate={ServerSide.covidAnalyzeSingleVariantView.earliestDate}
+                        customDateRangeOptions={ServerSide.covidAnalyzeSingleVariantView.customDateRangeOptions}
                     />
                 </div>
                 <div class='border-t-2 bg-green-50 px-2 py-4'>
@@ -51,13 +49,12 @@ const initialMutations = extractMutations(variantFilter);
                     <VariantFilter
                         fields={[
                             {
-                                name: 'nextcladePangoLineage',
+                                name: ServerSide.covidAnalyzeSingleVariantView.lineageField,
                                 label: 'Pango Lineage',
                                 initialValue:
-                                    'nextcladePangoLineage' in variantFilter
-                                        ? variantFilter.nextcladePangoLineage
-                                        : undefined,
+                                    'lineage' in routeData.variantFilter ? routeData.variantFilter.lineage : undefined,
                                 type: 'pango-lineage',
+                                rename: 'lineage',
                             },
                         ]}
                         initialMutations={initialMutations}
@@ -116,17 +113,17 @@ const initialMutations = extractMutations(variantFilter);
 
                     <ComponentWrapper title='Sub-lineages'>
                         <gs-aggregate
-                            fields='["nextcladePangoLineage"]'
+                            fields={JSON.stringify([ServerSide.covidAnalyzeSingleVariantView.lineageField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'
                             height='100%'></gs-aggregate>
                     </ComponentWrapper>
                     {
-                        subDivisionField && (
-                            <ComponentWrapper title={subDivisionLabel}>
+                        subdivisionField && (
+                            <ComponentWrapper title={subdivisionLabel}>
                                 <gs-aggregate
-                                    fields={JSON.stringify([subDivisionField])}
+                                    fields={JSON.stringify([subdivisionField])}
                                     filter={JSON.stringify(variantFilter)}
                                     pageSize={defaultTablePageSize}
                                     width='100%'
@@ -154,7 +151,8 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField={ServerSide.covidView1.mainDateField}></gs-mutations-over-time>
+                        lapisDateField={ServerSide.covidAnalyzeSingleVariantView.mainDateField}
+                    ></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -165,7 +163,8 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField={ServerSide.covidView1.mainDateField}></gs-mutations-over-time>
+                        lapisDateField={ServerSide.covidAnalyzeSingleVariantView.mainDateField}
+                    ></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -1,7 +1,12 @@
 ---
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import { CollectionsList } from '../../components/covidAnalyzeSingleVariantView/CollectionsList';
-import { chooseGranularityBasedOnDateRange, getLapisMutations, getLocationSubdivision } from '../../routes/helpers';
+import {
+    chooseGranularityBasedOnDateRange,
+    getLapisMutations,
+    getLocationSubdivision,
+    lineageKey,
+} from '../../routes/helpers';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
 import VariantFilter from '../../components/VariantFilter.astro';
 import { getDashboardsConfig, getLapisUrl } from '../../config';
@@ -25,9 +30,6 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
 );
 
 const initialMutations = getLapisMutations(variantFilter);
-
-console.log('variantFilter', variantFilter);
-console.log('routeData.variantFilter', routeData.variantFilter);
 ---
 
 <BaseLayout title='Single Variant | SARS-CoV-2 | GenSpectrum'>
@@ -51,10 +53,9 @@ console.log('routeData.variantFilter', routeData.variantFilter);
                             {
                                 name: ServerSide.covidAnalyzeSingleVariantView.lineageField,
                                 label: 'Pango Lineage',
-                                initialValue:
-                                    'lineage' in routeData.variantFilter ? routeData.variantFilter.lineage : undefined,
+                                initialValue: routeData.variantFilter.lineage ?? undefined,
                                 type: 'pango-lineage',
-                                rename: 'lineage',
+                                rename: lineageKey,
                             },
                         ]}
                         initialMutations={initialMutations}
@@ -135,7 +136,7 @@ console.log('routeData.variantFilter', routeData.variantFilter);
 
                     <ComponentWrapper title='Hosts'>
                         <gs-aggregate
-                            fields='["host"]'
+                            fields={JSON.stringify([ServerSide.covidSequencingEffortsView.hostField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/pages/flu/h5n1/sequencing-efforts.astro
+++ b/website/src/pages/flu/h5n1/sequencing-efforts.astro
@@ -65,7 +65,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             }
             <ComponentsGrid title='Hosts' height='600px'>
                 <gs-aggregate
-                    fields='["host_name_scientific"]'
+                    fields={JSON.stringify([ServerSide.h5n1AnalyzeSingleVariantView.hostField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -73,7 +73,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentsGrid>
             <ComponentsGrid title='Author affiliations' height='600px'>
                 <gs-aggregate
-                    fields='["author_affiliations"]'
+                    fields={JSON.stringify([ServerSide.h5n1AnalyzeSingleVariantView.authorAffiliationsField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -81,7 +81,10 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentsGrid>
             <ComponentsGrid title='Authors' height='600px'>
                 <gs-aggregate
-                    fields='["authors", "author_affiliations"]'
+                    fields={JSON.stringify([
+                        ServerSide.h5n1AnalyzeSingleVariantView.authorsField,
+                        ServerSide.h5n1AnalyzeSingleVariantView.authorAffiliationsField,
+                    ])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/pages/flu/h5n1/sequencing-efforts.astro
+++ b/website/src/pages/flu/h5n1/sequencing-efforts.astro
@@ -1,5 +1,5 @@
 ---
-import { chooseGranularityBasedOnDateRange } from '../../../routes/helpers';
+import { chooseGranularityBasedOnDateRange, getLocationSubdivision } from '../../../routes/helpers';
 import BaseLayout from '../../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../../components/LocationTimeFilter.astro';
 import { getLapisUrl } from '../../../config';
@@ -7,23 +7,18 @@ import { defaultTablePageSize, Organisms } from '../../../routes/View';
 import ComponentsGrid from '../../../components/ComponentsGrid.astro';
 import { ServerSide } from '../../../routes/serverSideRouting';
 
-const routeData = ServerSide.h5n1View3.parseUrl(Astro.url);
+const routeData = ServerSide.h5n1SequencingEffortsView.parseUrl(Astro.url);
 
-const baselineFilter = ServerSide.h5n1View3.toLapisFilter(routeData);
+const baselineFilter = ServerSide.h5n1SequencingEffortsView.toLapisFilter(routeData);
 
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter[`${ServerSide.h5n1View3.mainDateField}From`] as string,
-    to: baselineFilter[`${ServerSide.h5n1View3.mainDateField}To`] as string,
+    from: baselineFilter[`${ServerSide.h5n1SequencingEffortsView.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.h5n1SequencingEffortsView.mainDateField}To`] as string,
 });
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.geo_loc_country === undefined) {
-    subDivisionField = 'geo_loc_country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.geo_loc_admin_1 === undefined) {
-    subDivisionField = 'geo_loc_admin_1';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    ServerSide.h5n1AnalyzeSingleVariantView.locationFields,
+    routeData.baselineFilter.location,
+);
 ---
 
 <BaseLayout title='Sequencing Efforts | H5N1 | GenSpectrum'>
@@ -32,11 +27,11 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
                 <LocationTimeFilter
-                    fields={ServerSide.h5n1View3.locationFields}
+                    fields={ServerSide.h5n1SequencingEffortsView.locationFields}
                     initialLocation={baselineFilter}
                     initialDateRange={routeData.baselineFilter.dateRange}
-                    earliestDate={ServerSide.h5n1View3.earliestDate}
-                    customDateRangeOptions={ServerSide.h5n1View3.customDateRangeOptions}
+                    earliestDate={ServerSide.h5n1SequencingEffortsView.earliestDate}
+                    customDateRangeOptions={ServerSide.h5n1SequencingEffortsView.customDateRangeOptions}
                 />
             </div>
         </div>
@@ -48,7 +43,7 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField={ServerSide.h5n1View3.mainDateField}
+                    lapisDateField={ServerSide.h5n1SequencingEffortsView.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -56,10 +51,10 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                     granularity={timeGranularity}></gs-number-sequences-over-time>
             </ComponentsGrid>
             {
-                subDivisionField && (
-                    <ComponentsGrid title={subDivisionLabel} height='600px'>
+                subdivisionField && (
+                    <ComponentsGrid title={subdivisionLabel} height='600px'>
                         <gs-aggregate
-                            fields={JSON.stringify([subDivisionField])}
+                            fields={JSON.stringify([subdivisionField])}
                             filter={JSON.stringify(baselineFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/pages/flu/h5n1/single-variant.astro
+++ b/website/src/pages/flu/h5n1/single-variant.astro
@@ -95,7 +95,7 @@ const initialMutations = getLapisMutations(variantFilter);
 
                     <ComponentWrapper title='Hosts'>
                         <gs-aggregate
-                            fields='["host_name_scientific"]'
+                            fields={JSON.stringify([ServerSide.h5n1AnalyzeSingleVariantView.hostField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/pages/flu/h5n1/single-variant.astro
+++ b/website/src/pages/flu/h5n1/single-variant.astro
@@ -2,33 +2,28 @@
 import BaseLayout from '../../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../../components/LocationTimeFilter.astro';
 import VariantFilter from '../../../components/VariantFilter.astro';
-import { chooseGranularityBasedOnDateRange, extractMutations } from '../../../routes/helpers';
+import { chooseGranularityBasedOnDateRange, getLapisMutations, getLocationSubdivision } from '../../../routes/helpers';
 import { getLapisUrl } from '../../../config';
 import { defaultTablePageSize, Organisms } from '../../../routes/View';
 import ComponentsGrid from '../../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../../components/ComponentWrapper.astro';
 import { ServerSide } from '../../../routes/serverSideRouting';
 
-const routeData = ServerSide.h5n1View1.parseUrl(Astro.url);
+const routeData = ServerSide.h5n1AnalyzeSingleVariantView.parseUrl(Astro.url);
 
-const variantFilter = ServerSide.h5n1View1.toLapisFilter(routeData);
-const baselineFilter = ServerSide.h5n1View1.toLapisFilterWithoutVariant(routeData);
+const variantFilter = ServerSide.h5n1AnalyzeSingleVariantView.toLapisFilter(routeData);
+const baselineFilter = ServerSide.h5n1AnalyzeSingleVariantView.toLapisFilterWithoutVariant(routeData);
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter[`${ServerSide.h5n1View1.mainDateField}From`] as string,
-    to: baselineFilter[`${ServerSide.h5n1View1.mainDateField}To`] as string,
+    from: baselineFilter[`${ServerSide.h5n1AnalyzeSingleVariantView.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.h5n1AnalyzeSingleVariantView.mainDateField}To`] as string,
 });
 
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.geo_loc_country === undefined) {
-    subDivisionField = 'geo_loc_country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.geo_loc_admin_1 === undefined) {
-    subDivisionField = 'geo_loc_admin_1';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    ServerSide.h5n1AnalyzeSingleVariantView.locationFields,
+    routeData.baselineFilter.location,
+);
 
-const initialMutations = extractMutations(variantFilter);
+const initialMutations = getLapisMutations(variantFilter);
 ---
 
 <BaseLayout title='Single Variant | H5N1 | GenSpectrum'>
@@ -38,11 +33,11 @@ const initialMutations = extractMutations(variantFilter);
                 <div class='bg-blue-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Filter dataset:</div>
                     <LocationTimeFilter
-                        fields={ServerSide.h5n1View1.locationFields}
+                        fields={ServerSide.h5n1AnalyzeSingleVariantView.locationFields}
                         initialLocation={baselineFilter}
                         initialDateRange={routeData.baselineFilter.dateRange}
-                        earliestDate={ServerSide.h5n1View1.earliestDate}
-                        customDateRangeOptions={ServerSide.h5n1View1.customDateRangeOptions}
+                        earliestDate={ServerSide.h5n1AnalyzeSingleVariantView.earliestDate}
+                        customDateRangeOptions={ServerSide.h5n1AnalyzeSingleVariantView.customDateRangeOptions}
                     />
                 </div>
                 <div class='border-t-2 bg-green-50 px-2 py-4'>
@@ -59,7 +54,7 @@ const initialMutations = extractMutations(variantFilter);
                                 lapisFilter: variantFilter,
                             })}
                             denominatorFilter={JSON.stringify(baselineFilter)}
-                            lapisDateField={ServerSide.h5n1View1.mainDateField}
+                            lapisDateField={ServerSide.h5n1AnalyzeSingleVariantView.mainDateField}
                             granularity={timeGranularity}
                             smoothingWindow='0'
                             pageSize={defaultTablePageSize}
@@ -85,10 +80,10 @@ const initialMutations = extractMutations(variantFilter);
                             height='100%'></gs-mutations>
                     </ComponentWrapper>
                     {
-                        subDivisionField && (
-                            <ComponentWrapper title={subDivisionLabel}>
+                        subdivisionField && (
+                            <ComponentWrapper title={subdivisionLabel}>
                                 <gs-aggregate
-                                    fields={JSON.stringify([subDivisionField])}
+                                    fields={JSON.stringify([subdivisionField])}
                                     filter={JSON.stringify(variantFilter)}
                                     pageSize={defaultTablePageSize}
                                     width='100%'
@@ -115,7 +110,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField={ServerSide.h5n1View1.mainDateField}></gs-mutations-over-time>
+                        lapisDateField={ServerSide.h5n1AnalyzeSingleVariantView.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -126,7 +121,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField={ServerSide.h5n1View1.mainDateField}></gs-mutations-over-time>
+                        lapisDateField={ServerSide.h5n1AnalyzeSingleVariantView.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/pages/mpox/sequencing-efforts.astro
+++ b/website/src/pages/mpox/sequencing-efforts.astro
@@ -1,31 +1,27 @@
 ---
-import { chooseGranularityBasedOnDateRange } from '../../routes/helpers';
+import { chooseGranularityBasedOnDateRange, getLocationSubdivision } from '../../routes/helpers';
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
-import { MpoxView1, MpoxView3 } from '../../routes/mpox';
+import { MpoxAnalyzeSingleVariantView, MpoxSequencingEffortsView } from '../../routes/mpox';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = ServerSide.mpoxView3.parseUrl(Astro.url);
+const routeData = ServerSide.mpoxSequencingEffortsView.parseUrl(Astro.url);
 
-const baselineFilter = ServerSide.mpoxView3.toLapisFilter(routeData);
+const baselineFilter = ServerSide.mpoxSequencingEffortsView.toLapisFilter(routeData);
 
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter[`${ServerSide.mpoxView3.mainDateField}From`] as string,
-    to: baselineFilter[`${ServerSide.mpoxView3.mainDateField}To`] as string,
+    from: baselineFilter[`${ServerSide.mpoxSequencingEffortsView.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.mpoxSequencingEffortsView.mainDateField}To`] as string,
 });
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.geo_loc_country === undefined) {
-    subDivisionField = 'geo_loc_country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.geo_loc_admin_1 === undefined) {
-    subDivisionField = 'geo_loc_admin_1';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    ServerSide.mpoxAnalyzeSingleVariantView.locationFields,
+    routeData.baselineFilter.location,
+);
 ---
 
 <BaseLayout title='Sequencing Efforts | Mpox | GenSpectrum'>
@@ -34,11 +30,11 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
                 <LocationTimeFilter
-                    fields={ServerSide.mpoxView3.locationFields}
+                    fields={ServerSide.mpoxSequencingEffortsView.locationFields}
                     initialLocation={baselineFilter}
                     initialDateRange={routeData.baselineFilter.dateRange}
-                    earliestDate={ServerSide.mpoxView3.earliestDate}
-                    customDateRangeOptions={ServerSide.mpoxView3.customDateRangeOptions}
+                    earliestDate={ServerSide.mpoxSequencingEffortsView.earliestDate}
+                    customDateRangeOptions={ServerSide.mpoxSequencingEffortsView.customDateRangeOptions}
                 />
             </div>
         </div>
@@ -50,7 +46,7 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField={ServerSide.mpoxView3.mainDateField}
+                    lapisDateField={ServerSide.mpoxSequencingEffortsView.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -58,10 +54,10 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                     granularity={timeGranularity}></gs-number-sequences-over-time>
             </ComponentWrapper>
             {
-                subDivisionField && (
-                    <ComponentWrapper title={subDivisionLabel} height='600px'>
+                subdivisionField && (
+                    <ComponentWrapper title={subdivisionLabel} height='600px'>
                         <gs-aggregate
-                            fields={JSON.stringify([subDivisionField])}
+                            fields={JSON.stringify([subdivisionField])}
                             filter={JSON.stringify(baselineFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/pages/mpox/sequencing-efforts.astro
+++ b/website/src/pages/mpox/sequencing-efforts.astro
@@ -68,7 +68,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             }
             <ComponentWrapper title='Hosts' height='600px'>
                 <gs-aggregate
-                    fields='["host_name_scientific"]'
+                    fields={JSON.stringify([ServerSide.mpoxAnalyzeSingleVariantView.hostField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -76,7 +76,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentWrapper>
             <ComponentWrapper title='Author affiliations' height='600px'>
                 <gs-aggregate
-                    fields='["author_affiliations"]'
+                    fields={JSON.stringify([ServerSide.mpoxAnalyzeSingleVariantView.authorAffiliationsField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -84,7 +84,10 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentWrapper>
             <ComponentWrapper title='Authors' height='600px'>
                 <gs-aggregate
-                    fields='["authors", "author_affiliations"]'
+                    fields={JSON.stringify([
+                        ServerSide.mpoxAnalyzeSingleVariantView.authorsField,
+                        ServerSide.mpoxAnalyzeSingleVariantView.authorAffiliationsField,
+                    ])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/pages/mpox/single-variant.astro
+++ b/website/src/pages/mpox/single-variant.astro
@@ -2,33 +2,28 @@
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import VariantFilter from '../../components/VariantFilter.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
-import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
+import { chooseGranularityBasedOnDateRange, getLapisMutations, getLocationSubdivision } from '../../routes/helpers';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = ServerSide.mpoxView1.parseUrl(Astro.url);
+const routeData = ServerSide.mpoxAnalyzeSingleVariantView.parseUrl(Astro.url);
 
-const variantFilter = ServerSide.mpoxView1.toLapisFilter(routeData);
-const baselineFilter = ServerSide.mpoxView1.toLapisFilterWithoutVariant(routeData);
+const variantFilter = ServerSide.mpoxAnalyzeSingleVariantView.toLapisFilter(routeData);
+const baselineFilter = ServerSide.mpoxAnalyzeSingleVariantView.toLapisFilterWithoutVariant(routeData);
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter[`${ServerSide.mpoxView1.mainDateField}From`] as string,
-    to: baselineFilter[`${ServerSide.mpoxView1.mainDateField}To`] as string,
+    from: baselineFilter[`${ServerSide.mpoxAnalyzeSingleVariantView.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.mpoxAnalyzeSingleVariantView.mainDateField}To`] as string,
 });
 
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.geo_loc_country === undefined) {
-    subDivisionField = 'geo_loc_country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.geo_loc_admin_1 === undefined) {
-    subDivisionField = 'geo_loc_admin_1';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    ServerSide.mpoxAnalyzeSingleVariantView.locationFields,
+    routeData.baselineFilter.location,
+);
 
-const initialMutations = extractMutations(variantFilter);
+const initialMutations = getLapisMutations(variantFilter);
 ---
 
 <BaseLayout title='Single Variant | Mpox | GenSpectrum'>
@@ -38,19 +33,31 @@ const initialMutations = extractMutations(variantFilter);
                 <div class='bg-blue-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Filter dataset:</div>
                     <LocationTimeFilter
-                        fields={ServerSide.mpoxView1.locationFields}
+                        fields={ServerSide.mpoxAnalyzeSingleVariantView.locationFields}
                         initialLocation={baselineFilter}
                         initialDateRange={routeData.baselineFilter.dateRange}
-                        earliestDate={ServerSide.mpoxView1.earliestDate}
-                        customDateRangeOptions={ServerSide.mpoxView1.customDateRangeOptions}
+                        earliestDate={ServerSide.mpoxAnalyzeSingleVariantView.earliestDate}
+                        customDateRangeOptions={ServerSide.mpoxAnalyzeSingleVariantView.customDateRangeOptions}
                     />
                 </div>
                 <div class='border-t-2 bg-green-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Search variant:</div>
                     <VariantFilter
                         fields={[
-                            { name: 'clade', label: 'Clade', initialValue: variantFilter.clade, type: 'text' },
-                            { name: 'lineage', label: 'Lineage', initialValue: variantFilter.lineage, type: 'text' },
+                            {
+                                name: ServerSide.mpoxAnalyzeSingleVariantView.cladeField,
+                                label: 'Clade',
+                                initialValue: variantFilter.clade,
+                                type: 'text',
+                                rename: 'clade',
+                            },
+                            {
+                                name: ServerSide.mpoxAnalyzeSingleVariantView.lineageField,
+                                label: 'Lineage',
+                                initialValue: variantFilter.lineage,
+                                type: 'text',
+                                rename: 'lineage',
+                            },
                         ]}
                         initialMutations={initialMutations}
                     />
@@ -65,7 +72,7 @@ const initialMutations = extractMutations(variantFilter);
                                 lapisFilter: variantFilter,
                             })}
                             denominatorFilter={JSON.stringify(baselineFilter)}
-                            lapisDateField={ServerSide.mpoxView1.mainDateField}
+                            lapisDateField={ServerSide.mpoxAnalyzeSingleVariantView.mainDateField}
                             granularity={timeGranularity}
                             smoothingWindow='0'
                             pageSize={defaultTablePageSize}
@@ -91,10 +98,10 @@ const initialMutations = extractMutations(variantFilter);
                             height='100%'></gs-mutations>
                     </ComponentWrapper>
                     {
-                        subDivisionField && (
-                            <ComponentWrapper title={subDivisionLabel}>
+                        subdivisionField && (
+                            <ComponentWrapper title={subdivisionLabel}>
                                 <gs-aggregate
-                                    fields={JSON.stringify([subDivisionField])}
+                                    fields={JSON.stringify([subdivisionField])}
                                     filter={JSON.stringify(variantFilter)}
                                     pageSize={defaultTablePageSize}
                                     width='100%'
@@ -105,7 +112,10 @@ const initialMutations = extractMutations(variantFilter);
                     }
                     <ComponentWrapper title='Clades and lineages'>
                         <gs-aggregate
-                            fields={JSON.stringify(['clade', 'lineage'])}
+                            fields={JSON.stringify([
+                                ServerSide.mpoxAnalyzeSingleVariantView.cladeField,
+                                ServerSide.mpoxAnalyzeSingleVariantView.lineageField,
+                            ])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'
@@ -129,7 +139,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField={ServerSide.mpoxView1.mainDateField}></gs-mutations-over-time>
+                        lapisDateField={ServerSide.mpoxAnalyzeSingleVariantView.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -140,7 +150,7 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField={ServerSide.mpoxView1.mainDateField}></gs-mutations-over-time>
+                        lapisDateField={ServerSide.mpoxAnalyzeSingleVariantView.mainDateField}></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/pages/mpox/single-variant.astro
+++ b/website/src/pages/mpox/single-variant.astro
@@ -2,7 +2,13 @@
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import VariantFilter from '../../components/VariantFilter.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
-import { chooseGranularityBasedOnDateRange, getLapisMutations, getLocationSubdivision } from '../../routes/helpers';
+import {
+    chooseGranularityBasedOnDateRange,
+    cladeKey,
+    getLapisMutations,
+    getLocationSubdivision,
+    lineageKey,
+} from '../../routes/helpers';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
@@ -49,14 +55,14 @@ const initialMutations = getLapisMutations(variantFilter);
                                 label: 'Clade',
                                 initialValue: variantFilter.clade,
                                 type: 'text',
-                                rename: 'clade',
+                                rename: cladeKey,
                             },
                             {
                                 name: ServerSide.mpoxAnalyzeSingleVariantView.lineageField,
                                 label: 'Lineage',
                                 initialValue: variantFilter.lineage,
                                 type: 'text',
-                                rename: 'lineage',
+                                rename: lineageKey,
                             },
                         ]}
                         initialMutations={initialMutations}
@@ -123,7 +129,7 @@ const initialMutations = getLapisMutations(variantFilter);
                     </ComponentWrapper>
                     <ComponentWrapper title='Hosts'>
                         <gs-aggregate
-                            fields='["host_name_scientific"]'
+                            fields={JSON.stringify([ServerSide.mpoxAnalyzeSingleVariantView.hostField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/pages/rsv-a/sequencing-efforts.astro
+++ b/website/src/pages/rsv-a/sequencing-efforts.astro
@@ -3,4 +3,4 @@ import RsvSequencingEffortsPage from '../../components/rsv/RsvSequencingEffortsP
 import { ServerSide } from '../../routes/serverSideRouting';
 ---
 
-<RsvSequencingEffortsPage view={ServerSide.rsvAView3} />
+<RsvSequencingEffortsPage view={ServerSide.rsvASequencingEffortsView} />

--- a/website/src/pages/rsv-a/single-variant.astro
+++ b/website/src/pages/rsv-a/single-variant.astro
@@ -3,4 +3,4 @@ import RsvSingleVariantPage from '../../components/rsv/RsvSingleVariantPage.astr
 import { ServerSide } from '../../routes/serverSideRouting';
 ---
 
-<RsvSingleVariantPage view={ServerSide.rsvAView1} />
+<RsvSingleVariantPage view={ServerSide.rsvAAnalyzeSingleVariantView} />

--- a/website/src/pages/rsv-b/sequencing-efforts.astro
+++ b/website/src/pages/rsv-b/sequencing-efforts.astro
@@ -3,4 +3,4 @@ import RsvSequencingEffortsPage from '../../components/rsv/RsvSequencingEffortsP
 import { ServerSide } from '../../routes/serverSideRouting';
 ---
 
-<RsvSequencingEffortsPage view={ServerSide.rsvBView3} />
+<RsvSequencingEffortsPage view={ServerSide.rsvBSequencingEffortsView} />

--- a/website/src/pages/rsv-b/single-variant.astro
+++ b/website/src/pages/rsv-b/single-variant.astro
@@ -3,4 +3,4 @@ import RsvSingleVariantPage from '../../components/rsv/RsvSingleVariantPage.astr
 import { ServerSide } from '../../routes/serverSideRouting';
 ---
 
-<RsvSingleVariantPage view={ServerSide.rsvBView1} />
+<RsvSingleVariantPage view={ServerSide.rsvBAnalyzeSingleVariantView} />

--- a/website/src/pages/west-nile/sequencing-efforts.astro
+++ b/website/src/pages/west-nile/sequencing-efforts.astro
@@ -1,5 +1,5 @@
 ---
-import { chooseGranularityBasedOnDateRange } from '../../routes/helpers';
+import { chooseGranularityBasedOnDateRange, getLocationSubdivision } from '../../routes/helpers';
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
 import { getLapisUrl } from '../../config';
@@ -8,23 +8,18 @@ import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = ServerSide.westNileView3.parseUrl(Astro.url);
+const routeData = ServerSide.westNileSequencingEffortsView.parseUrl(Astro.url);
 
-const baselineFilter = ServerSide.westNileView3.toLapisFilter(routeData);
+const baselineFilter = ServerSide.westNileSequencingEffortsView.toLapisFilter(routeData);
 
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter[`${ServerSide.westNileView3.mainDateField}From`] as string,
-    to: baselineFilter[`${ServerSide.westNileView3.mainDateField}To`] as string,
+    from: baselineFilter[`${ServerSide.westNileSequencingEffortsView.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.westNileSequencingEffortsView.mainDateField}To`] as string,
 });
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.geo_loc_country === undefined) {
-    subDivisionField = 'geo_loc_country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.geo_loc_admin_1 === undefined) {
-    subDivisionField = 'geo_loc_admin_1';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    ServerSide.westNileAnalyzeSingleVariantView.locationFields,
+    routeData.baselineFilter.location,
+);
 ---
 
 <BaseLayout title='Sequencing Efforts | WNV | GenSpectrum'>
@@ -33,11 +28,11 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
             <div class='mr-2 font-semibold'>Filter dataset:</div>
             <div class='max-w-[1000px]'>
                 <LocationTimeFilter
-                    fields={ServerSide.westNileView3.locationFields}
+                    fields={ServerSide.westNileSequencingEffortsView.locationFields}
                     initialLocation={baselineFilter}
                     initialDateRange={routeData.baselineFilter.dateRange}
-                    earliestDate={ServerSide.westNileView3.earliestDate}
-                    customDateRangeOptions={ServerSide.westNileView3.customDateRangeOptions}
+                    earliestDate={ServerSide.westNileSequencingEffortsView.earliestDate}
+                    customDateRangeOptions={ServerSide.westNileSequencingEffortsView.customDateRangeOptions}
                 />
             </div>
         </div>
@@ -49,7 +44,7 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                         displayName: '',
                         lapisFilter: baselineFilter,
                     })}
-                    lapisDateField={ServerSide.westNileView3.mainDateField}
+                    lapisDateField={ServerSide.westNileSequencingEffortsView.mainDateField}
                     views='["bar", "line", "table"]'
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -57,10 +52,10 @@ if (routeData.baselineFilter.location.geo_loc_country === undefined) {
                     granularity={timeGranularity}></gs-number-sequences-over-time>
             </ComponentWrapper>
             {
-                subDivisionField && (
-                    <ComponentWrapper title={subDivisionLabel} height='600px'>
+                subdivisionField && (
+                    <ComponentWrapper title={subdivisionLabel} height='600px'>
                         <gs-aggregate
-                            fields={JSON.stringify([subDivisionField])}
+                            fields={JSON.stringify([subdivisionField])}
                             filter={JSON.stringify(baselineFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/pages/west-nile/sequencing-efforts.astro
+++ b/website/src/pages/west-nile/sequencing-efforts.astro
@@ -66,7 +66,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             }
             <ComponentWrapper title='Hosts' height='600px'>
                 <gs-aggregate
-                    fields='["host_name_scientific"]'
+                    fields={JSON.stringify([ServerSide.westNileAnalyzeSingleVariantView.lineageField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -74,7 +74,7 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentWrapper>
             <ComponentWrapper title='Author affiliations' height='600px'>
                 <gs-aggregate
-                    fields='["author_affiliations"]'
+                    fields={JSON.stringify([ServerSide.westNileAnalyzeSingleVariantView.authorAffiliationsField])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'
@@ -82,7 +82,10 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             </ComponentWrapper>
             <ComponentWrapper title='Authors' height='600px'>
                 <gs-aggregate
-                    fields='["authors", "author_affiliations"]'
+                    fields={JSON.stringify([
+                        ServerSide.westNileAnalyzeSingleVariantView.authorsField,
+                        ServerSide.westNileAnalyzeSingleVariantView.authorAffiliationsField,
+                    ])}
                     filter={JSON.stringify(baselineFilter)}
                     pageSize={defaultTablePageSize}
                     width='100%'

--- a/website/src/pages/west-nile/single-variant.astro
+++ b/website/src/pages/west-nile/single-variant.astro
@@ -6,7 +6,7 @@ import {
     chooseGranularityBasedOnDateRange,
     getLapisMutations,
     getLocationSubdivision,
-    getTodayString,
+    lineageKey,
 } from '../../routes/helpers';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
@@ -54,7 +54,7 @@ const initialMutations = getLapisMutations(variantFilter);
                                 label: 'Lineage',
                                 initialValue: variantFilter.lineage,
                                 type: 'text',
-                                rename: 'lineage',
+                                rename: lineageKey,
                             },
                         ]}
                         initialMutations={initialMutations}
@@ -118,7 +118,7 @@ const initialMutations = getLapisMutations(variantFilter);
                     </ComponentWrapper>
                     <ComponentWrapper title='Hosts'>
                         <gs-aggregate
-                            fields='["hostNameScientific"]'
+                            fields={JSON.stringify([ServerSide.westNileAnalyzeSingleVariantView.hostField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'

--- a/website/src/pages/west-nile/single-variant.astro
+++ b/website/src/pages/west-nile/single-variant.astro
@@ -2,42 +2,33 @@
 import BaseLayout from '../../layouts/base/BaseLayout.astro';
 import LocationTimeFilter from '../../components/LocationTimeFilter.astro';
 import VariantFilter from '../../components/VariantFilter.astro';
-import { chooseGranularityBasedOnDateRange, extractMutations } from '../../routes/helpers';
+import {
+    chooseGranularityBasedOnDateRange,
+    getLapisMutations,
+    getLocationSubdivision,
+    getTodayString,
+} from '../../routes/helpers';
 import { getLapisUrl } from '../../config';
 import { defaultTablePageSize, Organisms } from '../../routes/View';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import { ServerSide } from '../../routes/serverSideRouting';
 
-const routeData = ServerSide.westNileView1.parseUrl(Astro.url);
+const routeData = ServerSide.westNileAnalyzeSingleVariantView.parseUrl(Astro.url);
 
-const variantFilter = ServerSide.westNileView1.toLapisFilter(routeData);
-const baselineFilter = ServerSide.westNileView1.toLapisFilterWithoutVariant(routeData);
+const variantFilter = ServerSide.westNileAnalyzeSingleVariantView.toLapisFilter(routeData);
+const baselineFilter = ServerSide.westNileAnalyzeSingleVariantView.toLapisFilterWithoutVariant(routeData);
 const timeGranularity = chooseGranularityBasedOnDateRange({
-    from: baselineFilter[`${ServerSide.westNileView1.mainDateField}From`] as string,
-    to: baselineFilter[`${ServerSide.westNileView1.mainDateField}To`] as string,
+    from: baselineFilter[`${ServerSide.westNileAnalyzeSingleVariantView.mainDateField}From`] as string,
+    to: baselineFilter[`${ServerSide.westNileAnalyzeSingleVariantView.mainDateField}To`] as string,
 });
 
-let subDivisionField = undefined;
-let subDivisionLabel = '';
-if (routeData.baselineFilter.location.geo_loc_country === undefined) {
-    subDivisionField = 'geo_loc_country';
-    subDivisionLabel = 'Countries';
-} else if (routeData.baselineFilter.location.geo_loc_admin_1 === undefined) {
-    subDivisionField = 'geo_loc_admin_1';
-    subDivisionLabel = 'Geographic sub-divisions';
-}
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    ServerSide.westNileAnalyzeSingleVariantView.locationFields,
+    routeData.baselineFilter.location,
+);
 
-const locationFields = ['geo_loc_country', 'geo_loc_admin_1'];
-const today = new Date().toISOString().substring(0, 10);
-const customDateRangeOptions = [
-    { label: 'Since 2020', dateFrom: '2020-01-01', dateTo: today },
-    { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
-    { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
-    { label: 'Before 2000', dateFrom: ServerSide.westNileView1.earliestDate, dateTo: '1999-12-31' },
-];
-
-const initialMutations = extractMutations(variantFilter);
+const initialMutations = getLapisMutations(variantFilter);
 ---
 
 <BaseLayout title='Single Variant | WNV | GenSpectrum'>
@@ -47,18 +38,24 @@ const initialMutations = extractMutations(variantFilter);
                 <div class='bg-blue-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Filter dataset:</div>
                     <LocationTimeFilter
-                        fields={locationFields}
+                        fields={ServerSide.westNileAnalyzeSingleVariantView.locationFields}
                         initialLocation={baselineFilter}
                         initialDateRange={routeData.baselineFilter.dateRange}
-                        earliestDate={ServerSide.westNileView1.earliestDate}
-                        customDateRangeOptions={customDateRangeOptions}
+                        earliestDate={ServerSide.westNileAnalyzeSingleVariantView.earliestDate}
+                        customDateRangeOptions={ServerSide.westNileAnalyzeSingleVariantView.customDateRangeOptions}
                     />
                 </div>
                 <div class='border-t-2 bg-green-50 px-2 py-4'>
                     <div class='mb-2 font-semibold'>Search variant:</div>
                     <VariantFilter
                         fields={[
-                            { name: 'lineage', label: 'Lineage', initialValue: variantFilter.lineage, type: 'text' },
+                            {
+                                name: ServerSide.westNileAnalyzeSingleVariantView.lineageField,
+                                label: 'Lineage',
+                                initialValue: variantFilter.lineage,
+                                type: 'text',
+                                rename: 'lineage',
+                            },
                         ]}
                         initialMutations={initialMutations}
                     />
@@ -73,7 +70,7 @@ const initialMutations = extractMutations(variantFilter);
                                 lapisFilter: variantFilter,
                             })}
                             denominatorFilter={JSON.stringify(baselineFilter)}
-                            lapisDateField={ServerSide.westNileView1.mainDateField}
+                            lapisDateField={ServerSide.westNileAnalyzeSingleVariantView.mainDateField}
                             granularity={timeGranularity}
                             smoothingWindow='0'
                             pageSize={defaultTablePageSize}
@@ -99,10 +96,10 @@ const initialMutations = extractMutations(variantFilter);
                             height='100%'></gs-mutations>
                     </ComponentWrapper>
                     {
-                        subDivisionField && (
-                            <ComponentWrapper title={subDivisionLabel}>
+                        subdivisionField && (
+                            <ComponentWrapper title={subdivisionLabel}>
                                 <gs-aggregate
-                                    fields={JSON.stringify([subDivisionField])}
+                                    fields={JSON.stringify([subdivisionField])}
                                     filter={JSON.stringify(variantFilter)}
                                     pageSize={defaultTablePageSize}
                                     width='100%'
@@ -113,7 +110,7 @@ const initialMutations = extractMutations(variantFilter);
                     }
                     <ComponentWrapper title='Clades and lineages'>
                         <gs-aggregate
-                            fields={JSON.stringify(['lineage'])}
+                            fields={JSON.stringify([ServerSide.westNileAnalyzeSingleVariantView.lineageField])}
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'
@@ -121,7 +118,7 @@ const initialMutations = extractMutations(variantFilter);
                     </ComponentWrapper>
                     <ComponentWrapper title='Hosts'>
                         <gs-aggregate
-                            fields='["host_name_scientific"]'
+                            fields='["hostNameScientific"]'
                             filter={JSON.stringify(variantFilter)}
                             pageSize={defaultTablePageSize}
                             width='100%'
@@ -137,7 +134,8 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='nucleotide'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField={ServerSide.westNileView1.mainDateField}></gs-mutations-over-time>
+                        lapisDateField={ServerSide.westNileAnalyzeSingleVariantView.mainDateField}
+                    ></gs-mutations-over-time>
                 </ComponentWrapper>
 
                 <ComponentWrapper title='Amino acid mutations over time' height='600px'>
@@ -148,7 +146,8 @@ const initialMutations = extractMutations(variantFilter);
                         sequenceType='amino acid'
                         views='["grid"]'
                         granularity={timeGranularity}
-                        lapisDateField={ServerSide.westNileView1.mainDateField}></gs-mutations-over-time>
+                        lapisDateField={ServerSide.westNileAnalyzeSingleVariantView.mainDateField}
+                    ></gs-mutations-over-time>
                 </ComponentWrapper>
             </div>
         </div>

--- a/website/src/routes/View.ts
+++ b/website/src/routes/View.ts
@@ -1,3 +1,5 @@
+import type { DateRange, LapisLocation, LapisVariantQuery } from './helpers.ts';
+
 export namespace Organisms {
     export const covid = 'covid';
     export const h5n1 = 'h5n1';
@@ -58,6 +60,21 @@ export type Route = {
     organism: Organism;
     pathname: string;
 };
+
+export type BaselineFilter = {
+    baselineFilter: {
+        location: LapisLocation;
+        dateRange: DateRange;
+    };
+};
+
+export type VariantFilter = {
+    variantFilter: LapisVariantQuery;
+};
+
+export type RouteWithBaseline = Route & BaselineFilter;
+
+export type AnalyzeSingleVariantRoute = Route & BaselineFilter & VariantFilter;
 
 export type View<R extends Route, ParseResult extends R | undefined = R> = {
     organism: Organism;

--- a/website/src/routes/covid.ts
+++ b/website/src/routes/covid.ts
@@ -28,6 +28,9 @@ class CovidConstants {
         this.mainDateField = organismsConfig.covid.lapis.mainDateField;
         this.locationFields = organismsConfig.covid.lapis.locationFields;
         this.lineageField = organismsConfig.covid.lapis.lineageField;
+        this.hostField = organismsConfig.covid.lapis.hostField;
+        this.originatingLabField = organismsConfig.covid.lapis.originatingLabField;
+        this.submittingLabField = organismsConfig.covid.lapis.submittingLabField;
     }
 
     public readonly organism = Organisms.covid as typeof Organisms.covid;
@@ -43,6 +46,9 @@ class CovidConstants {
     public readonly mainDateField: string;
     public readonly locationFields: string[];
     public readonly lineageField: string;
+    public readonly hostField: string;
+    public readonly originatingLabField: string | undefined;
+    public readonly submittingLabField: string | undefined;
 
     public variantFilterToLapisFilter = (filter: LapisCovidVariantQuery): LapisFilter => {
         const lapisFilter: LapisFilter = {};

--- a/website/src/routes/covid.ts
+++ b/website/src/routes/covid.ts
@@ -4,32 +4,33 @@ import {
     dateRangeToCustomDateRange,
     getDateRangeFromSearch,
     getIntegerFromSearch,
-    getLapisLocation1FromSearch,
-    getLapisMutationsQueryFromSearch,
-    getStringFromSearch,
+    getLapisCovidVariantQuery,
+    getLapisLocationFromSearch,
+    getTodayString,
+    type LapisCovidVariantQuery,
     type LapisFilter,
-    type LapisLocation1,
-    type LapisMutationQuery,
+    type LapisLocation,
+    type LapisVariantQuery,
     setSearchFromDateRange,
-    setSearchFromLapisLocation1,
-    setSearchFromLapisMutationsQuery,
-    setSearchFromString,
+    setSearchFromLapisCovidVariantQuery,
+    setSearchFromLocation,
 } from './helpers.ts';
-import { organismConfig, Organisms, type View } from './View.ts';
+import { type BaselineFilter, organismConfig, Organisms, type Route, type VariantFilter, type View } from './View.ts';
 import { type OrganismsConfig } from '../config.ts';
 
 const pathFragment = organismConfig[Organisms.covid].pathFragment;
 
 const earliestDate = '2020-01-06';
-const today = new Date().toISOString().substring(0, 10);
+const today = getTodayString();
 
 class CovidConstants {
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.covid.lapis.mainDateField;
+        this.locationFields = organismsConfig.covid.lapis.locationFields;
+        this.lineageField = organismsConfig.covid.lapis.lineageField;
     }
 
     public readonly organism = Organisms.covid as typeof Organisms.covid;
-    public readonly locationFields = ['region', 'country', 'division'];
     public readonly defaultDateRange: DateRange = 'last6Months';
     public readonly earliestDate = '2020-01-06';
     public readonly customDateRangeOptions: DateRangeOption[] = [
@@ -40,44 +41,30 @@ class CovidConstants {
         { label: '2020', dateFrom: earliestDate, dateTo: '2021-01-03' },
     ];
     public readonly mainDateField: string;
+    public readonly locationFields: string[];
+    public readonly lineageField: string;
+
+    public variantFilterToLapisFilter = (filter: LapisCovidVariantQuery): LapisFilter => {
+        const lapisFilter: LapisFilter = {};
+        for (const [key, value] of Object.entries(filter)) {
+            if (key === 'lineage') {
+                lapisFilter[this.lineageField] = value;
+            } else {
+                lapisFilter[key] = value;
+            }
+        }
+
+        return lapisFilter;
+    };
 }
 
-type LapisSimpleVariantQuery = LapisMutationQuery & {
-    nextcladePangoLineage?: string;
-};
-
-type LapisAdvancedVariantQuery = {
-    variantQuery?: string;
-};
-
-type LapisVariantQuery = LapisSimpleVariantQuery | LapisAdvancedVariantQuery;
-
-const isSimpleVariantQuery = (variantQuery: LapisVariantQuery): variantQuery is LapisSimpleVariantQuery => {
-    return (
-        'nucleotideMutations' in variantQuery ||
-        'aminoAcidMutations' in variantQuery ||
-        'nucleotideInsertions' in variantQuery ||
-        'aminoAcidInsertions' in variantQuery ||
-        'nextcladePangoLineage' in variantQuery
-    );
-};
-
-const isAdvancedVariantQuery = (variantQuery: LapisVariantQuery): variantQuery is LapisAdvancedVariantQuery => {
-    return 'variantQuery' in variantQuery;
-};
-
-export type CovidView1Route = {
-    organism: typeof Organisms.covid;
-    pathname: string;
-    collectionId?: number;
-    baselineFilter: {
-        location: LapisLocation1;
-        dateRange: DateRange;
+export type CovidAnalyzeSingleVariantRoute = Route &
+    BaselineFilter & {
+        variantFilter: LapisCovidVariantQuery;
+        collectionId?: number;
     };
-    variantFilter: LapisVariantQuery;
-};
 
-export class CovidView1 extends CovidConstants implements View<CovidView1Route> {
+export class CovidAnalyzeSingleVariantView extends CovidConstants implements View<CovidAnalyzeSingleVariantRoute> {
     public readonly pathname = `/${pathFragment}/single-variant` as const;
     public readonly label = 'Single variant';
     public readonly labelLong = 'Analyze a single variant';
@@ -88,60 +75,47 @@ export class CovidView1 extends CovidConstants implements View<CovidView1Route> 
             location: {},
             dateRange: this.defaultDateRange,
         },
-        variantFilter: { nextcladePangoLineage: 'JN.1*' },
+        variantFilter: { lineage: 'JN.1*' },
     };
 
-    parseUrl = (url: URL): CovidView1Route => {
+    parseUrl = (url: URL): CovidAnalyzeSingleVariantRoute => {
         const search = url.searchParams;
-        let variantFilter: LapisSimpleVariantQuery | LapisAdvancedVariantQuery = {};
-        const advancedVariantQuery = search.get('variantQuery');
-        if (advancedVariantQuery) {
-            variantFilter = { variantQuery: advancedVariantQuery };
-        } else {
-            variantFilter = {
-                ...getLapisMutationsQueryFromSearch(search),
-                nextcladePangoLineage: getStringFromSearch(search, 'nextcladePangoLineage'),
-            };
-        }
         return {
             organism: this.organism,
             pathname: this.pathname,
             baselineFilter: {
-                location: getLapisLocation1FromSearch(search),
+                location: getLapisLocationFromSearch(search, this.locationFields),
                 dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
-            variantFilter,
+            variantFilter: getLapisCovidVariantQuery(search, this.lineageField),
             collectionId: getIntegerFromSearch(search, 'collectionId'),
         };
     };
 
-    toUrl = (route: CovidView1Route): string => {
+    toUrl = (route: CovidAnalyzeSingleVariantRoute): string => {
         const search = new URLSearchParams();
-        setSearchFromLapisLocation1(search, route.baselineFilter.location);
+        setSearchFromLocation(search, route.baselineFilter.location);
+
         if (route.baselineFilter.dateRange !== this.defaultDateRange) {
             setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
-        const variantFilter = route.variantFilter;
-        if (isAdvancedVariantQuery(variantFilter)) {
-            setSearchFromString(search, 'variantQuery', variantFilter.variantQuery);
-        } else if (isSimpleVariantQuery(variantFilter)) {
-            setSearchFromString(search, 'nextcladePangoLineage', variantFilter.nextcladePangoLineage);
-            setSearchFromLapisMutationsQuery(search, variantFilter);
-        }
+
+        setSearchFromLapisCovidVariantQuery(search, route.variantFilter, this.lineageField);
+
         if (route.collectionId !== undefined) {
             search.set('collectionId', route.collectionId.toString());
         }
         return `${this.pathname}?${search}`;
     };
 
-    public toLapisFilter = (route: CovidView1Route) => {
+    public toLapisFilter = (route: CovidAnalyzeSingleVariantRoute) => {
         return {
             ...this.toLapisFilterWithoutVariant(route),
-            ...route.variantFilter,
+            ...this.variantFilterToLapisFilter(route.variantFilter),
         };
     };
 
-    public toLapisFilterWithoutVariant = (route: CovidView1Route): LapisFilter => {
+    public toLapisFilterWithoutVariant = (route: CovidAnalyzeSingleVariantRoute): LapisFilter => {
         const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(earliestDate));
         return {
             ...route.baselineFilter.location,
@@ -151,22 +125,52 @@ export class CovidView1 extends CovidConstants implements View<CovidView1Route> 
     };
 }
 
-export type CovidView2Route = {
+export type CovidCompareVariantsRoute = {
     organism: typeof Organisms.covid;
     pathname: string;
-    filters: CovidView2Filter[];
+    filters: Map<Id, CovidCompareVariantsFilter>;
 };
 
-type CovidView2Filter = {
-    id: number;
-    baselineFilter: {
-        location: LapisLocation1;
-        dateRange: DateRange;
-    };
-    variantFilter: LapisVariantQuery;
-};
+type CovidCompareVariantsFilter = BaselineFilter & VariantFilter;
 
-export class CovidView2 extends CovidConstants implements View<CovidView2Route, CovidView2Route | undefined> {
+type Id = number;
+
+function decodeMultipleFiltersFromSearch(search: URLSearchParams) {
+    const filterMap = new Map<Id, Map<string, string>>();
+
+    for (const [key, value] of search) {
+        const keySplit = key.split('$');
+        if (keySplit.length !== 2) {
+            console.error(`Invalid key in URLSearchParam: ${key}`);
+            return undefined;
+        }
+        const id = Number.parseInt(keySplit[1]);
+        if (Number.isNaN(id)) {
+            continue;
+        }
+        if (!filterMap.has(id)) {
+            filterMap.set(id, new Map<string, string>());
+        }
+        const filter = filterMap.get(id)!;
+        filter.set(keySplit[0], value);
+    }
+    return filterMap;
+}
+
+function encodeMultipleFiltersToUrlSearchParam(filters: Map<Id, Map<string, string>>) {
+    const search = new URLSearchParams();
+    for (const [id, filter] of filters) {
+        for (const [key, value] of filter) {
+            search.append(`${key}$${id}`, value);
+        }
+    }
+    return search;
+}
+
+export class CovidCompareVariantsView
+    extends CovidConstants
+    implements View<CovidCompareVariantsRoute, CovidCompareVariantsRoute | undefined>
+{
     public readonly pathname = `/${pathFragment}/compare-side-by-side` as const;
     public readonly label = 'Compare side-by-side';
     public readonly labelLong = 'Compare variants side-by-side';
@@ -174,142 +178,129 @@ export class CovidView2 extends CovidConstants implements View<CovidView2Route, 
     public readonly defaultRoute = {
         organism: this.organism,
         pathname: this.pathname,
-        filters: [
-            {
-                id: 1,
-                baselineFilter: { location: {}, dateRange: this.defaultDateRange },
-                variantFilter: { nextcladePangoLineage: 'JN.1*' },
-            },
-            {
-                id: 2,
-                baselineFilter: { location: {}, dateRange: this.defaultDateRange },
-                variantFilter: { nextcladePangoLineage: 'XBB.1*' },
-            },
-        ],
+        filters: new Map<Id, CovidCompareVariantsFilter>([
+            [
+                0,
+                {
+                    baselineFilter: {
+                        location: {},
+                        dateRange: this.defaultDateRange,
+                    },
+                    variantFilter: {
+                        lineage: 'JN.1*',
+                    },
+                },
+            ],
+            [
+                1,
+                {
+                    baselineFilter: {
+                        location: {},
+                        dateRange: this.defaultDateRange,
+                    },
+                    variantFilter: {
+                        lineage: 'XBB.1*',
+                    },
+                },
+            ],
+        ]),
     };
 
-    public parseUrl = (url: URL): CovidView2Route | undefined => {
-        const filterMap = new Map<number, CovidView2Filter>();
-        const search = url.searchParams;
-        for (const [key, value] of search) {
-            const keySplit = key.split('$');
-            if (keySplit.length !== 2) {
-                return undefined;
-            }
-            const field = keySplit[0];
-            const id = Number.parseInt(keySplit[1]);
-            if (Number.isNaN(id)) {
-                return undefined;
-            }
-            if (!filterMap.has(id)) {
-                filterMap.set(id, {
-                    id,
-                    baselineFilter: { location: {}, dateRange: this.defaultDateRange },
-                    variantFilter: {},
-                });
-            }
-            const filter = filterMap.get(id)!;
-            switch (field) {
-                case 'region':
-                case 'country':
-                case 'division':
-                    filter.baselineFilter.location[field] = value;
-                    break;
-                case this.mainDateField:
-                    filter.baselineFilter.dateRange = getDateRangeFromSearch(search, key) ?? this.defaultDateRange;
-                    break;
-                case 'variantQuery':
-                    if (isSimpleVariantQuery(filter.variantFilter)) {
-                        return undefined;
-                    }
-                    (filter.variantFilter as LapisAdvancedVariantQuery)[field] = value;
-                    break;
-                case 'nextcladePangoLineage':
-                    if (isAdvancedVariantQuery(filter.variantFilter)) {
-                        return undefined;
-                    }
-                    (filter.variantFilter as LapisSimpleVariantQuery)[field] = value;
-                    break;
-                case 'nucleotideMutations':
-                case 'aminoAcidMutations':
-                case 'nucleotideInsertions':
-                case 'aminoAcidInsertions':
-                    if (isAdvancedVariantQuery(filter.variantFilter)) {
-                        return undefined;
-                    }
-                    (filter.variantFilter as LapisSimpleVariantQuery)[field] = value.split(',');
-                    break;
-                default:
-                    return undefined;
-            }
+    private getFilter = (filterParams: Map<string, string>) => {
+        const filter: BaselineFilter & VariantFilter = {
+            baselineFilter: { location: {}, dateRange: this.defaultDateRange },
+            variantFilter: {},
+        };
+
+        filter.baselineFilter.location = getLapisLocationFromSearch(filterParams, this.locationFields);
+        filter.baselineFilter.dateRange =
+            getDateRangeFromSearch(filterParams, this.mainDateField) ?? this.defaultDateRange;
+        filter.variantFilter = getLapisCovidVariantQuery(filterParams, this.lineageField);
+
+        return filter;
+    };
+
+    public parseUrl = (url: URL): CovidCompareVariantsRoute | undefined => {
+        const filterPerColumn = decodeMultipleFiltersFromSearch(url.searchParams);
+        if (filterPerColumn === undefined) {
+            return undefined;
+        }
+
+        const filters = new Map<number, CovidCompareVariantsFilter>();
+        for (const [columnId, filterParams] of filterPerColumn) {
+            filters.set(columnId, this.getFilter(filterParams));
         }
 
         return {
             organism: this.organism,
             pathname: this.pathname,
-            filters: [...filterMap.values()].sort((a, b) => a.id - b.id),
+            filters: filters,
         };
     };
 
-    public toUrl = (route: CovidView2Route): string => {
-        const search = new URLSearchParams();
-        for (const filter of route.filters) {
-            const id = filter.id;
-            Object.entries(filter.baselineFilter.location).forEach(([key, value]) => {
-                if (value !== undefined) {
-                    search.append(`${key}$${id}`, value);
-                }
-            });
-            if (filter.baselineFilter.dateRange !== this.defaultDateRange) {
-                setSearchFromDateRange(search, `${this.mainDateField}$${id}`, filter.baselineFilter.dateRange);
-            }
-            Object.entries(filter.variantFilter).forEach(([key, value]) => {
-                if (Array.isArray(value)) {
-                    if (value.length > 0) {
-                        search.append(`${key}$${id}`, value.join(','));
-                    }
-                } else {
-                    if (value !== undefined && value.length > 0) {
-                        search.append(`${key}$${id}`, value);
-                    }
-                }
+    public toUrl = (route: CovidCompareVariantsRoute): string => {
+        const searchParameterMap = new Map<Id, Map<string, string>>();
+
+        for (const [columnId, filter] of route.filters) {
+            searchParameterMap.set(columnId, new Map<string, string>());
+
+            const searchOfFilter = new URLSearchParams();
+            setSearchFromLapisCovidVariantQuery(searchOfFilter, filter.variantFilter, this.lineageField);
+            setSearchFromLocation(searchOfFilter, filter.baselineFilter.location);
+            setSearchFromDateRange(searchOfFilter, this.mainDateField, filter.baselineFilter.dateRange);
+
+            searchOfFilter.forEach((value, key) => {
+                searchParameterMap.get(columnId)?.set(key, value);
             });
         }
+
+        const search = encodeMultipleFiltersToUrlSearchParam(searchParameterMap);
+
         return `${this.pathname}?${search}`;
     };
 
-    public setFilter = (route: CovidView2Route, newFilter: CovidView2Filter): CovidView2Route => {
-        const newRoute = {
-            ...route,
-            filters: route.filters.filter((route) => route.id !== newFilter.id),
-        };
-        newRoute.filters.push(newFilter);
-        return newRoute;
-    };
+    public setFilter = (
+        route: CovidCompareVariantsRoute,
+        newFilter: CovidCompareVariantsFilter,
+        columnId: Id,
+    ): CovidCompareVariantsRoute => {
+        const filtersPerColumn = new Map(route.filters);
 
-    public addEmptyFilter = (route: CovidView2Route): CovidView2Route => {
-        const largestId = route.filters.length > 0 ? Math.max(...route.filters.map((route) => route.id)) : 0;
-        return this.setFilter(route, {
-            id: largestId + 1,
-            // It is necessary to have at least one (non-default) filter.
-            baselineFilter: {
-                location: {
-                    region: 'Europe',
-                },
-                dateRange: this.defaultDateRange,
-            },
-            variantFilter: {},
-        });
-    };
-
-    public removeFilter(route: CovidView2Route, id: number): CovidView2Route {
+        filtersPerColumn.set(columnId, newFilter);
         return {
             ...route,
-            filters: route.filters.filter((route) => route.id !== id),
+            filters: filtersPerColumn,
+        };
+    };
+
+    public addEmptyFilter = (route: CovidCompareVariantsRoute): CovidCompareVariantsRoute => {
+        const lastId = Math.max(...Array.from(route.filters.keys()));
+
+        return this.setFilter(
+            route,
+            {
+                baselineFilter: {
+                    location: {
+                        region: 'Europe',
+                    },
+                    dateRange: this.defaultDateRange,
+                },
+                variantFilter: {},
+            },
+            lastId + 1,
+        );
+    };
+
+    public removeFilter(route: CovidCompareVariantsRoute, columnId: number): CovidCompareVariantsRoute {
+        const filters = new Map(route.filters);
+        filters.delete(columnId);
+        return {
+            ...route,
+            filters,
         };
     }
 
-    public baselineFilterToLapisFilter = (filter: CovidView2Filter['baselineFilter']): LapisFilter => {
+    public baselineFilterToLapisFilter = (filter: CovidCompareVariantsFilter['baselineFilter']): LapisFilter => {
         const dateRange = dateRangeToCustomDateRange(filter.dateRange, new Date(earliestDate));
         return {
             ...filter.location,
@@ -319,17 +310,12 @@ export class CovidView2 extends CovidConstants implements View<CovidView2Route, 
     };
 }
 
-export type CovidView3Route = {
-    organism: typeof Organisms.covid;
-    pathname: string;
-    collectionId?: number;
-    baselineFilter: {
-        location: LapisLocation1;
-        dateRange: DateRange;
+export type CovidSequencingEffortsRoute = Route &
+    BaselineFilter & {
+        collectionId?: number;
     };
-};
 
-export class CovidView3 extends CovidConstants implements View<CovidView3Route> {
+export class CovidSequencingEffortsView extends CovidConstants implements View<CovidSequencingEffortsRoute> {
     public readonly pathname = `/${pathFragment}/sequencing-efforts` as const;
     public readonly label = 'Sequencing efforts';
     public readonly labelLong = 'Sequencing efforts';
@@ -342,28 +328,23 @@ export class CovidView3 extends CovidConstants implements View<CovidView3Route> 
         },
     };
 
-    public parseUrl = (url: URL): CovidView3Route => {
+    public parseUrl = (url: URL): CovidSequencingEffortsRoute => {
         const search = url.searchParams;
         return {
             organism: this.organism,
             pathname: this.pathname,
             baselineFilter: {
-                location: {
-                    region: getStringFromSearch(search, 'region'),
-                    country: getStringFromSearch(search, 'country'),
-                    division: getStringFromSearch(search, 'division'),
-                },
+                location: getLapisLocationFromSearch(search, this.locationFields),
                 dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
             collectionId: getIntegerFromSearch(search, 'collectionId'),
         };
     };
 
-    toUrl = (route: CovidView3Route): string => {
+    toUrl = (route: CovidSequencingEffortsRoute): string => {
         const search = new URLSearchParams();
-        (['region', 'country', 'division'] as const).forEach((field) =>
-            setSearchFromString(search, field, route.baselineFilter.location[field]),
-        );
+        setSearchFromLocation(search, route.baselineFilter.location);
+
         if (route.baselineFilter.dateRange !== this.defaultDateRange) {
             setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
@@ -373,7 +354,7 @@ export class CovidView3 extends CovidConstants implements View<CovidView3Route> 
         return `${this.pathname}?${search}`;
     };
 
-    toLapisFilter = (route: CovidView3Route): LapisFilter => {
+    toLapisFilter = (route: CovidSequencingEffortsRoute): LapisFilter => {
         const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(earliestDate));
         return {
             ...route.baselineFilter.location,

--- a/website/src/routes/h5n1.ts
+++ b/website/src/routes/h5n1.ts
@@ -29,6 +29,9 @@ class H5n1Constants {
         this.mainDateField = organismsConfig.h5n1.lapis.mainDateField;
         this.locationFields = organismsConfig.h5n1.lapis.locationFields;
         this.lineageField = organismsConfig.h5n1.lapis.lineageField;
+        this.hostField = organismsConfig.h5n1.lapis.hostField;
+        this.authorsField = organismsConfig.h5n1.lapis.authorsField;
+        this.authorAffiliationsField = organismsConfig.h5n1.lapis.authorAffiliationsField;
     }
 
     public readonly organism = Organisms.h5n1 as typeof Organisms.h5n1;
@@ -44,6 +47,9 @@ class H5n1Constants {
     public readonly mainDateField: string;
     public readonly locationFields: string[];
     public readonly lineageField: string;
+    public readonly hostField: string;
+    public readonly authorsField: string | undefined;
+    public readonly authorAffiliationsField: string | undefined;
 
     public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter => {
         const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));

--- a/website/src/routes/helpers.ts
+++ b/website/src/routes/helpers.ts
@@ -174,9 +174,12 @@ export type LapisMutationQuery = {
     aminoAcidInsertions?: string[];
 };
 
+export const lineageKey = 'lineage';
+export const cladeKey = 'clade';
+
 export type LapisVariantQuery = LapisMutationQuery & {
-    lineage?: string;
-    clade?: string;
+    [lineageKey]?: string;
+    [cladeKey]?: string;
 };
 
 export type LapisCovidVariantQuery = LapisVariantQuery & {
@@ -212,8 +215,8 @@ export const getLapisVariantQuery = (
 ): LapisVariantQuery => {
     return {
         ...getLapisMutationsQueryFromSearch(search),
-        lineage: getStringFromSearch(search, lineageIdentifier),
-        clade: cladeIdentifier ? getStringFromSearch(search, cladeIdentifier) : undefined,
+        [lineageKey]: getStringFromSearch(search, lineageIdentifier),
+        [cladeKey]: cladeIdentifier ? getStringFromSearch(search, cladeIdentifier) : undefined,
     };
 };
 

--- a/website/src/routes/mpox.ts
+++ b/website/src/routes/mpox.ts
@@ -24,6 +24,9 @@ class MpoxConstants {
         this.mainDateField = organismsConfig.mpox.lapis.mainDateField;
         this.locationFields = organismsConfig.mpox.lapis.locationFields;
         this.lineageField = organismsConfig.mpox.lapis.lineageField;
+        this.hostField = organismsConfig.mpox.lapis.hostField;
+        this.authorsField = organismsConfig.mpox.lapis.authorsField;
+        this.authorAffiliationsField = organismsConfig.mpox.lapis.authorAffiliationsField;
     }
 
     public readonly organism = Organisms.mpox as typeof Organisms.mpox;
@@ -44,6 +47,9 @@ class MpoxConstants {
     public readonly locationFields: string[];
     public readonly lineageField: string;
     public readonly cladeField = 'clade';
+    public readonly hostField: string;
+    public readonly authorsField: string | undefined;
+    public readonly authorAffiliationsField: string | undefined;
 
     public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter & LapisLocation => {
         const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));

--- a/website/src/routes/routing.ts
+++ b/website/src/routes/routing.ts
@@ -1,10 +1,10 @@
-import { CovidView1, CovidView2, CovidView3 } from './covid.ts';
-import { MpoxView1, MpoxView3 } from './mpox.ts';
-import { WestNileView1, WestNileView3 } from './westNile.ts';
-import { RsvAView1, RsvAView3 } from './rsvA.ts';
-import { RsvBView1, RsvBView3 } from './rsvB.ts';
+import { CovidAnalyzeSingleVariantView, CovidCompareVariantsView, CovidSequencingEffortsView } from './covid.ts';
+import { MpoxAnalyzeSingleVariantView, MpoxSequencingEffortsView } from './mpox.ts';
+import { WestNileAnalyzeSingleVariantView, WestNileSequencingEffortsView } from './westNile.ts';
+import { RsvAAnalyzeSingleVariantView, RsvASequencingEffortsView } from './rsvA.ts';
+import { RsvBAnalyzeSingleVariantView, RsvBView3 } from './rsvB.ts';
 import { Organisms, type Route } from './View.ts';
-import { H5n1View1, H5n1View3 } from './h5n1.ts';
+import { H5n1AnalyzeSingleVariantView, H5n1SequencingEffortsView } from './h5n1.ts';
 import type { OrganismsConfig } from '../config.ts';
 
 export class Routing {
@@ -14,15 +14,27 @@ export class Routing {
     constructor(organismsConfig: OrganismsConfig) {
         this.views = {
             [Organisms.covid]: [
-                new CovidView1(organismsConfig),
-                new CovidView2(organismsConfig),
-                new CovidView3(organismsConfig),
+                new CovidAnalyzeSingleVariantView(organismsConfig),
+                new CovidCompareVariantsView(organismsConfig),
+                new CovidSequencingEffortsView(organismsConfig),
             ],
-            [Organisms.h5n1]: [new H5n1View1(organismsConfig), new H5n1View3(organismsConfig)],
-            [Organisms.mpox]: [new MpoxView1(organismsConfig), new MpoxView3(organismsConfig)],
-            [Organisms.rsvA]: [new RsvAView1(organismsConfig), new RsvAView3(organismsConfig)],
-            [Organisms.rsvB]: [new RsvBView1(organismsConfig), new RsvBView3(organismsConfig)],
-            [Organisms.westNile]: [new WestNileView1(organismsConfig), new WestNileView3(organismsConfig)],
+            [Organisms.h5n1]: [
+                new H5n1AnalyzeSingleVariantView(organismsConfig),
+                new H5n1SequencingEffortsView(organismsConfig),
+            ],
+            [Organisms.mpox]: [
+                new MpoxAnalyzeSingleVariantView(organismsConfig),
+                new MpoxSequencingEffortsView(organismsConfig),
+            ],
+            [Organisms.rsvA]: [
+                new RsvAAnalyzeSingleVariantView(organismsConfig),
+                new RsvASequencingEffortsView(organismsConfig),
+            ],
+            [Organisms.rsvB]: [new RsvBAnalyzeSingleVariantView(organismsConfig), new RsvBView3(organismsConfig)],
+            [Organisms.westNile]: [
+                new WestNileAnalyzeSingleVariantView(organismsConfig),
+                new WestNileSequencingEffortsView(organismsConfig),
+            ],
         } as const;
         this.allViews = Object.values(this.views).flat();
     }

--- a/website/src/routes/routing.ts
+++ b/website/src/routes/routing.ts
@@ -2,7 +2,7 @@ import { CovidAnalyzeSingleVariantView, CovidCompareVariantsView, CovidSequencin
 import { MpoxAnalyzeSingleVariantView, MpoxSequencingEffortsView } from './mpox.ts';
 import { WestNileAnalyzeSingleVariantView, WestNileSequencingEffortsView } from './westNile.ts';
 import { RsvAAnalyzeSingleVariantView, RsvASequencingEffortsView } from './rsvA.ts';
-import { RsvBAnalyzeSingleVariantView, RsvBView3 } from './rsvB.ts';
+import { RsvBAnalyzeSingleVariantView, RsvBSequencingEffortsView } from './rsvB.ts';
 import { Organisms, type Route } from './View.ts';
 import { H5n1AnalyzeSingleVariantView, H5n1SequencingEffortsView } from './h5n1.ts';
 import type { OrganismsConfig } from '../config.ts';
@@ -30,7 +30,10 @@ export class Routing {
                 new RsvAAnalyzeSingleVariantView(organismsConfig),
                 new RsvASequencingEffortsView(organismsConfig),
             ],
-            [Organisms.rsvB]: [new RsvBAnalyzeSingleVariantView(organismsConfig), new RsvBView3(organismsConfig)],
+            [Organisms.rsvB]: [
+                new RsvBAnalyzeSingleVariantView(organismsConfig),
+                new RsvBSequencingEffortsView(organismsConfig),
+            ],
             [Organisms.westNile]: [
                 new WestNileAnalyzeSingleVariantView(organismsConfig),
                 new WestNileSequencingEffortsView(organismsConfig),

--- a/website/src/routes/rsvA.ts
+++ b/website/src/routes/rsvA.ts
@@ -2,29 +2,36 @@ import {
     type DateRange,
     dateRangeToCustomDateRange,
     getDateRangeFromSearch,
-    getLapisLocation2FromSearch,
-    getLapisVariantQuery1FromSearch,
+    getLapisLocationFromSearch,
+    getLapisVariantQuery,
+    getTodayString,
     type LapisFilter,
-    type LapisLocation2,
-    type LapisVariantQuery1,
+    type LapisLocation,
     setSearchFromDateRange,
-    setSearchFromLapisLocation2,
-    setSearchFromLapisVariantQuery1,
+    setSearchFromLapisVariantQuery,
+    setSearchFromLocation,
 } from './helpers.ts';
-import { organismConfig, Organisms, type Route, type View } from './View.ts';
+import {
+    type AnalyzeSingleVariantRoute,
+    organismConfig,
+    Organisms,
+    type RouteWithBaseline,
+    type View,
+} from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 
 const pathFragment = organismConfig[Organisms.rsvA].pathFragment;
 
-const today = new Date().toISOString().substring(0, 10);
+const today = getTodayString();
 
 class RsvAConstants {
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.rsvA.lapis.mainDateField;
+        this.locationFields = organismsConfig.rsvA.lapis.locationFields;
+        this.lineageField = organismsConfig.rsvA.lapis.lineageField;
     }
 
     public readonly organism = Organisms.rsvA as typeof Organisms.rsvA;
-    public readonly locationFields = ['geo_loc_country', 'geo_loc_admin_1'];
     public readonly defaultDateRange: DateRange = 'allTimes';
     public readonly earliestDate = '1956-01-01';
     public readonly customDateRangeOptions = [
@@ -35,8 +42,10 @@ class RsvAConstants {
         { label: 'Before 2000', dateFrom: this.earliestDate, dateTo: '1999-12-31' },
     ];
     public readonly mainDateField: string;
+    public readonly locationFields: string[];
+    public readonly lineageField: string;
 
-    public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter & LapisLocation2 => {
+    public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter & LapisLocation => {
         const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));
         return {
             ...route.baselineFilter.location,
@@ -46,16 +55,7 @@ class RsvAConstants {
     };
 }
 
-type RouteWithBaseline = Route & {
-    baselineFilter: {
-        location: LapisLocation2;
-        dateRange: DateRange;
-    };
-};
-
-type RsvAView1Route = { variantFilter: LapisVariantQuery1 } & RouteWithBaseline;
-
-export class RsvAView1 extends RsvAConstants implements View<RsvAView1Route> {
+export class RsvAAnalyzeSingleVariantView extends RsvAConstants implements View<AnalyzeSingleVariantRoute> {
     public readonly pathname = `/${pathFragment}/single-variant`;
     public readonly label = 'Single variant';
     public readonly labelLong = 'Analyze a single variant';
@@ -69,30 +69,30 @@ export class RsvAView1 extends RsvAConstants implements View<RsvAView1Route> {
         variantFilter: {},
     };
 
-    public parseUrl = (url: URL): RsvAView1Route => {
+    public parseUrl = (url: URL): AnalyzeSingleVariantRoute => {
         const search = url.searchParams;
         return {
             organism: this.organism,
             pathname: this.pathname,
             baselineFilter: {
-                location: getLapisLocation2FromSearch(search),
+                location: getLapisLocationFromSearch(search, this.locationFields),
                 dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
-            variantFilter: getLapisVariantQuery1FromSearch(search),
+            variantFilter: getLapisVariantQuery(search, this.lineageField),
         };
     };
 
-    public toUrl = (route: RsvAView1Route): string => {
+    public toUrl = (route: AnalyzeSingleVariantRoute): string => {
         const search = new URLSearchParams();
-        setSearchFromLapisLocation2(search, route.baselineFilter.location);
+        setSearchFromLocation(search, route.baselineFilter.location);
         if (route.baselineFilter.dateRange !== this.defaultDateRange) {
             setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }
-        setSearchFromLapisVariantQuery1(search, route.variantFilter);
+        setSearchFromLapisVariantQuery(search, route.variantFilter, this.lineageField);
         return `${this.pathname}?${search}`;
     };
 
-    public toLapisFilter = (route: RsvAView1Route) => {
+    public toLapisFilter = (route: AnalyzeSingleVariantRoute) => {
         return {
             ...this.toLapisFilterWithoutVariant(route),
             ...route.variantFilter,
@@ -100,7 +100,7 @@ export class RsvAView1 extends RsvAConstants implements View<RsvAView1Route> {
     };
 }
 
-export class RsvAView3 extends RsvAConstants implements View<RouteWithBaseline> {
+export class RsvASequencingEffortsView extends RsvAConstants implements View<RouteWithBaseline> {
     public readonly pathname = `/${pathFragment}/sequencing-efforts`;
     public readonly label = 'Sequencing efforts';
     public readonly labelLong = 'Sequencing efforts';
@@ -119,7 +119,7 @@ export class RsvAView3 extends RsvAConstants implements View<RouteWithBaseline> 
             organism: this.organism,
             pathname: this.pathname,
             baselineFilter: {
-                location: getLapisLocation2FromSearch(search),
+                location: getLapisLocationFromSearch(search, this.locationFields),
                 dateRange: getDateRangeFromSearch(search, this.mainDateField) ?? this.defaultDateRange,
             },
         };
@@ -127,7 +127,7 @@ export class RsvAView3 extends RsvAConstants implements View<RouteWithBaseline> 
 
     public toUrl = (route: RouteWithBaseline): string => {
         const search = new URLSearchParams();
-        setSearchFromLapisLocation2(search, route.baselineFilter.location);
+        setSearchFromLocation(search, route.baselineFilter.location);
         if (route.baselineFilter.dateRange !== this.defaultDateRange) {
             setSearchFromDateRange(search, this.mainDateField, route.baselineFilter.dateRange);
         }

--- a/website/src/routes/rsvA.ts
+++ b/website/src/routes/rsvA.ts
@@ -29,6 +29,9 @@ class RsvAConstants {
         this.mainDateField = organismsConfig.rsvA.lapis.mainDateField;
         this.locationFields = organismsConfig.rsvA.lapis.locationFields;
         this.lineageField = organismsConfig.rsvA.lapis.lineageField;
+        this.hostField = organismsConfig.rsvA.lapis.hostField;
+        this.authorsField = organismsConfig.rsvA.lapis.authorsField;
+        this.authorAffiliationsField = organismsConfig.rsvA.lapis.authorAffiliationsField;
     }
 
     public readonly organism = Organisms.rsvA as typeof Organisms.rsvA;
@@ -44,6 +47,9 @@ class RsvAConstants {
     public readonly mainDateField: string;
     public readonly locationFields: string[];
     public readonly lineageField: string;
+    public readonly hostField: string;
+    public readonly authorsField: string | undefined;
+    public readonly authorAffiliationsField: string | undefined;
 
     public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter & LapisLocation => {
         const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));

--- a/website/src/routes/rsvB.ts
+++ b/website/src/routes/rsvB.ts
@@ -29,6 +29,9 @@ class RsvBConstants {
         this.mainDateField = organismsConfig.rsvB.lapis.mainDateField;
         this.locationFields = organismsConfig.rsvB.lapis.locationFields;
         this.lineageField = organismsConfig.rsvB.lapis.lineageField;
+        this.hostField = organismsConfig.rsvB.lapis.hostField;
+        this.authorsField = organismsConfig.rsvB.lapis.authorsField;
+        this.authorAffiliationsField = organismsConfig.rsvB.lapis.authorAffiliationsField;
     }
 
     public readonly organism = Organisms.rsvB as typeof Organisms.rsvB;
@@ -44,6 +47,9 @@ class RsvBConstants {
     public readonly mainDateField: string;
     public readonly locationFields: string[];
     public readonly lineageField: string;
+    public readonly hostField: string;
+    public readonly authorsField: string | undefined;
+    public readonly authorAffiliationsField: string | undefined;
 
     public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter & LapisLocation => {
         const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));
@@ -100,7 +106,7 @@ export class RsvBAnalyzeSingleVariantView extends RsvBConstants implements View<
     };
 }
 
-export class RsvBView3 extends RsvBConstants implements View<RouteWithBaseline> {
+export class RsvBSequencingEffortsView extends RsvBConstants implements View<RouteWithBaseline> {
     public readonly pathname = `/${pathFragment}/sequencing-efforts`;
     public readonly label = 'Sequencing efforts';
     public readonly labelLong = 'Sequencing efforts';

--- a/website/src/routes/serverSideRouting.ts
+++ b/website/src/routes/serverSideRouting.ts
@@ -10,17 +10,17 @@ export namespace ServerSide {
 
     export const routing = new Routing(organismsConfig);
 
-    export const covidView1 = routing.views.covid[0];
-    export const covidView2 = routing.views.covid[1];
-    export const covidView3 = routing.views.covid[2];
-    export const h5n1View1 = routing.views.h5n1[0];
-    export const h5n1View3 = routing.views.h5n1[1];
-    export const mpoxView1 = routing.views.mpox[0];
-    export const mpoxView3 = routing.views.mpox[1];
-    export const rsvAView1 = routing.views.rsvA[0];
-    export const rsvAView3 = routing.views.rsvA[1];
-    export const rsvBView1 = routing.views.rsvB[0];
-    export const rsvBView3 = routing.views.rsvB[1];
-    export const westNileView1 = routing.views.westNile[0];
-    export const westNileView3 = routing.views.westNile[1];
+    export const covidAnalyzeSingleVariantView = routing.views.covid[0];
+    export const covidCompareVariantsView = routing.views.covid[1];
+    export const covidSequencingEffortsView = routing.views.covid[2];
+    export const h5n1AnalyzeSingleVariantView = routing.views.h5n1[0];
+    export const h5n1SequencingEffortsView = routing.views.h5n1[1];
+    export const mpoxAnalyzeSingleVariantView = routing.views.mpox[0];
+    export const mpoxSequencingEffortsView = routing.views.mpox[1];
+    export const rsvAAnalyzeSingleVariantView = routing.views.rsvA[0];
+    export const rsvASequencingEffortsView = routing.views.rsvA[1];
+    export const rsvBAnalyzeSingleVariantView = routing.views.rsvB[0];
+    export const rsvBSequencingEffortsView = routing.views.rsvB[1];
+    export const westNileAnalyzeSingleVariantView = routing.views.westNile[0];
+    export const westNileSequencingEffortsView = routing.views.westNile[1];
 }

--- a/website/src/routes/westNile.ts
+++ b/website/src/routes/westNile.ts
@@ -29,6 +29,9 @@ class WestNileConstants {
         this.mainDateField = organismsConfig.westNile.lapis.mainDateField;
         this.locationFields = organismsConfig.westNile.lapis.locationFields;
         this.lineageField = organismsConfig.westNile.lapis.lineageField;
+        this.hostField = organismsConfig.westNile.lapis.hostField;
+        this.authorsField = organismsConfig.westNile.lapis.authorsField;
+        this.authorAffiliationsField = organismsConfig.westNile.lapis.authorAffiliationsField;
     }
 
     public readonly organism = Organisms.westNile as typeof Organisms.westNile;
@@ -44,6 +47,9 @@ class WestNileConstants {
     public readonly mainDateField: string;
     public readonly locationFields: string[];
     public readonly lineageField: string;
+    public readonly hostField: string;
+    public readonly authorsField: string | undefined;
+    public readonly authorAffiliationsField: string | undefined;
 
     public toLapisFilterWithoutVariant = (route: RouteWithBaseline): LapisFilter & LapisLocation => {
         const dateRange = dateRangeToCustomDateRange(route.baselineFilter.dateRange, new Date(this.earliestDate));


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #160

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This PR makes the location-, lineage-, host-, authors-, authorAffiliations-, submittingLab-, and originatingLab-Field configurable. This required some rework of the views, so get rid of the hard coded keys. 

Most things that changed can be found in `helpers.ts` and the views in `/routes`.

Now each organism has the concept of lineage and clade. 

In the future it might be good to configure each page from a common config. This way there is less duplication. A start can already be found in `components/rsv`.
It would also be nice to use the react components of the dashboard-components. This would make it easier to use them.


### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
