### PR TITLE
feat(website): round trigger evaluation results (#211)

### DIFF
--- a/website/src/components/subscriptions/overview/SubscriptionDisplay.tsx
+++ b/website/src/components/subscriptions/overview/SubscriptionDisplay.tsx
@@ -56,6 +56,26 @@ function DateWindowDisplay({ dateWindow }: { dateWindow: DateWindow }) {
     );
 }
 
+function roundToPrecision({
+    val,
+    precision = 3,
+    lowerBound = 0.001,
+}: {
+    val: number;
+    precision?: number;
+    lowerBound?: number;
+}): string {
+    if (val < lowerBound) {
+        return `<${lowerBound}`;
+    }
+
+    if (Number.isInteger(val)) {
+        return val.toString();
+    }
+
+    return val.toFixed(precision);
+}
+
 function TriggerEvaluationResult({ result }: { result: Subscription['triggerEvaluationResult'] }) {
     if (result.type === 'EvaluationError') {
         return (
@@ -73,7 +93,7 @@ function TriggerEvaluationResult({ result }: { result: Subscription['triggerEval
                     {result.type === 'ConditionMet' ? 'met' : 'not met'}
                 </span>
             </div>
-            <div className='text-gray-500'>Evaluated value: {result.evaluatedValue}</div>
+            <div className='text-gray-500'>Evaluated value: {roundToPrecision({ val: result.evaluatedValue })}</div>
             <div className='text-gray-500'>Threshold: {result.threshold}</div>
         </div>
     );

--- a/website/src/util/proportionAsPercent.ts
+++ b/website/src/util/proportionAsPercent.ts
@@ -1,0 +1,3 @@
+export function proportionAsPercent(proportion: number) {
+    return `${proportion * 100}%`;
+}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves https://github.com/GenSpectrum/dashboards/issues/211

### Summary

Round to precision 3 decimal points:
<img width="446" alt="image" src="https://github.com/user-attachments/assets/a26d28c9-ea58-4c8b-b9b8-696bf0b66877">
 otherwise for evaluated values below threshold: 
<img width="474" alt="image" src="https://github.com/user-attachments/assets/13b6c879-cc85-4646-96db-e506dbe2817f">
keep integers as they are:
<img width="446" alt="image" src="https://github.com/user-attachments/assets/9552c335-0f86-4b7c-93a5-0b28573d4c60">



<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
