### PR TITLE
chore(website): add React keys to mega menu items

### DIFF
--- a/website/src/layouts/base/header/Navigation.tsx
+++ b/website/src/layouts/base/header/Navigation.tsx
@@ -38,9 +38,10 @@ export function Navigation() {
                     />
                     <MegaMenu className='hidden group-hover:block'>
                         {pathogenMegaMenuSections.map((section) => (
-                            <MegaMenuSection {...section}>
+                            <MegaMenuSection key={section.headline} {...section}>
                                 {section.navigationEntries.map((entry) => (
                                     <MegaMenuListEntry
+                                        key={entry.label}
                                         label={entry.label}
                                         href={entry.href}
                                         className={entry.underlineColor}


### PR DESCRIPTION
### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

The stdout logs of the Astro server had complaints about missing keys:
```
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <MegaMenuSection>. See https://reactjs.org/link/warning-keys for more information.
    at MegaMenuListEntry (.../dashboards/website/src/layouts/base/header/MegaMenu.tsx:48:3)
    at Tester
```
and
```
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <MegaMenu>. See https://reactjs.org/link/warning-keys for more information.
    at MegaMenuSection (.../dashboards/website/src/layouts/base/header/MegaMenu.tsx:18:3)
    at Tester
```

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
