### PR TITLE
fix(website): Show correct proportion percentage on subscription overview

### DIFF
--- a/website/src/components/subscriptions/overview/SubscriptionDisplay.tsx
+++ b/website/src/components/subscriptions/overview/SubscriptionDisplay.tsx
@@ -101,7 +101,7 @@ function ProportionTriggerDisplay({ trigger }: { trigger: ProportionTrigger }) {
     return (
         <div className='flex flex-col gap-2'>
             <div className='font-bold text-gray-500'>
-                Proportion {'>'} {trigger.proportion}%
+                Proportion {'>'} {trigger.proportion * 100}%
             </div>
             <div className='flex flex-1 flex-wrap gap-4'>
                 <div className='flex-1'>


### PR DESCRIPTION
### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The value proportion is not in percent, so it should be multiplied by 100 to get the percent value.

### Screenshot
![grafik](https://github.com/user-attachments/assets/2c6f9372-678a-4552-9b24-f2cb7abb2d2b)

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
