### PR TITLE
feat(website): confirm deletion of subscription #207

### DIFF
--- a/website/src/components/subscriptions/overview/SubscriptionEntry.tsx
+++ b/website/src/components/subscriptions/overview/SubscriptionEntry.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { type JSX } from 'react';
+import { type JSX, type RefObject, useRef } from 'react';
 import { toast } from 'react-toastify';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -7,6 +7,9 @@ import { SubscriptionDisplay } from './SubscriptionDisplay.tsx';
 import { getClientLogger } from '../../../clientLogger.ts';
 import { BorderedCard } from '../../../styles/containers/BorderedCard.tsx';
 import { CardDescription } from '../../../styles/containers/CardDescription.tsx';
+import { ModalBox } from '../../../styles/containers/ModalBox.tsx';
+import { ModalContent } from '../../../styles/containers/ModalContent.tsx';
+import { ModalHeader } from '../../../styles/containers/ModalHeader.tsx';
 import { organismConfig } from '../../../types/Organism.ts';
 import type { Subscription } from '../../../types/Subscription.ts';
 import { getErrorLogMessage } from '../../../util/getErrorLogMessage.ts';
@@ -128,6 +131,17 @@ function MoreDropdown({
         },
     });
 
+    const deleteSubscriptionDialog = useRef<HTMLDialogElement>(null);
+
+    const toggleConfirmDeletionDialog = () => {
+        deleteSubscriptionDialog.current?.showModal();
+        deleteSubscriptionDialog.current?.focus();
+    };
+
+    const handleDelete = async () => {
+        deleteSubscription.mutate();
+    };
+
     // TODO: #171 Activate/Deactivate subscription
     // const activateSubscription = useMutation({
     //     mutationFn: () =>
@@ -142,33 +156,32 @@ function MoreDropdown({
     //     },
     // });
 
-    const handleDelete = async () => {
-        deleteSubscription.mutate();
-    };
-
     // TODO: #171 Activate/Deactivate subscription
     // const handleActivate = async () => {
     //     activateSubscription.mutate();
     // };
     return (
-        <div className='dropdown dropdown-end'>
-            <div tabIndex={0} role='button' className='btn btn-xs'>
-                ...
+        <>
+            <div className='dropdown dropdown-end'>
+                <div tabIndex={0} role='button' className='btn btn-xs'>
+                    ...
+                </div>
+                <ul tabIndex={0} className='menu dropdown-content z-[10] w-52 rounded-box bg-base-100 p-2 shadow'>
+                    {/* TODO: #170 Page to edit subscription*/}
+                    {/* <li>*/}
+                    {/*    <EditButton />*/}
+                    {/* </li>*/}
+                    {/* TODO: #171 Activate/Deactivate subscription*/}
+                    {/* <li>*/}
+                    {/*    <ActivateButton isActive={subscription.active} onClick={handleActivate} />*/}
+                    {/* </li>*/}
+                    <li>
+                        <DeleteButton onClick={toggleConfirmDeletionDialog} />
+                    </li>
+                </ul>
             </div>
-            <ul tabIndex={0} className='menu dropdown-content z-[10] w-52 rounded-box bg-base-100 p-2 shadow'>
-                {/* TODO: #170 Page to edit subscription*/}
-                {/* <li>*/}
-                {/*    <EditButton />*/}
-                {/* </li>*/}
-                {/* TODO: #171 Activate/Deactivate subscription*/}
-                {/* <li>*/}
-                {/*    <ActivateButton isActive={subscription.active} onClick={handleActivate} />*/}
-                {/* </li>*/}
-                <li>
-                    <DeleteButton onClick={handleDelete} />
-                </li>
-            </ul>
-        </div>
+            <ConfirmDeletionModal modalRef={deleteSubscriptionDialog} onDelete={handleDelete} />
+        </>
     );
 }
 
@@ -207,5 +220,44 @@ function DeleteButton({ onClick }: { onClick: JSX.IntrinsicElements['button']['o
             <div className='iconify mdi--delete'></div>
             Delete
         </button>
+    );
+}
+
+function ConfirmDeletionModal({
+    onDelete,
+    modalRef,
+}: {
+    onDelete: JSX.IntrinsicElements['button']['onClick'];
+    modalRef: RefObject<HTMLDialogElement>;
+}) {
+    return (
+        <dialog className='modal' ref={modalRef}>
+            <ModalBox>
+                <ModalHeader title='Delete subscription' icon='mdi--delete' />
+                <ModalContent>
+                    <p>Are you sure you want to delete this subscription?</p>
+                    <div className='divider' />
+                    <div className='modal-action'>
+                        <form method='dialog'>
+                            <button
+                                type='submit'
+                                className='btn btn-outline float-right w-24'
+                                onClick={() => modalRef.current?.close()}
+                            >
+                                Cancel
+                            </button>
+                        </form>
+                        <form method='dialog'>
+                            <button type='submit' className='btn btn-error float-right w-24' onClick={onDelete}>
+                                Delete
+                            </button>
+                        </form>
+                    </div>
+                </ModalContent>
+            </ModalBox>
+            <form method='dialog' className='modal-backdrop'>
+                <button>close on clicking outside of modal</button>
+            </form>
+        </dialog>
     );
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #207

### Summary
When clicking the delete subscription button, the user is now shown a modal. The modal can be closed by clicking outside, pressing the escape button, or by clicking the discard button. When clicking the delete button the subscription is deleted. 
The user can also use the tab button to go through the selection. When pressing enter the selected action is performed.

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

![grafik](https://github.com/user-attachments/assets/8f984bd8-ce36-4d3b-ad1e-cc3376dd0972)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
