### PR TITLE
234 show pathogen specific data source footer

### DIFF
--- a/website/src/layouts/OrganismPage/OrganismPageLayout.astro
+++ b/website/src/layouts/OrganismPage/OrganismPageLayout.astro
@@ -2,6 +2,7 @@
 import { getViewBreadcrumbEntries, getViewTitle, type View } from '../../views/View';
 import { Breadcrumbs } from '../Breadcrumbs';
 import BaseLayout from '../base/BaseLayout.astro';
+import DataInfo from '../base/footer/DataInfo.astro';
 
 interface Props<PageState extends object> {
     view: View<PageState>;
@@ -15,4 +16,5 @@ const { view } = Astro.props;
         <Breadcrumbs breadcrumbs={getViewBreadcrumbEntries(view)} />
     </div>
     <slot />
+    <DataInfo slot='secondary-footer' dataOrigins={view.dataOrigins} />
 </BaseLayout>

--- a/website/src/layouts/base/BaseLayout.astro
+++ b/website/src/layouts/base/BaseLayout.astro
@@ -2,12 +2,12 @@
 // eslint-disable-next-line import/no-deprecated -- "Parse errors in imported module '@auth/core/types': parser.parse is not a function (undefined:undefined)"
 import { ToastContainer } from 'react-toastify';
 
-import Footer from './Footer.astro';
-import Header from './header/Header.astro';
-
 import 'react-toastify/dist/ReactToastify.css';
 import '@genspectrum/dashboard-components/style.css';
 import '../../styles/tailwind.css';
+import Footer from './footer/Footer.astro';
+import FooterNavigation from './footer/FooterNavigation.astro';
+import Header from './header/Header.astro';
 
 interface Props {
     title: string;
@@ -35,6 +35,9 @@ const { title, forceLoggedOutState = false } = Astro.props;
             <Header forceLoggedOutState={forceLoggedOutState} />
             <slot />
         </div>
-        <Footer />
+        <Footer>
+            <slot slot='secondary-footer' name='secondary-footer' />
+            <FooterNavigation slot='primary-footer' />
+        </Footer>
     </body>
 </html>

--- a/website/src/layouts/base/BaseLayout.astro
+++ b/website/src/layouts/base/BaseLayout.astro
@@ -29,10 +29,12 @@ const { title, forceLoggedOutState = false } = Astro.props;
         </script>
     </head>
 
-    <body>
+    <body class='flex min-h-screen flex-col'>
         <ToastContainer client:load />
-        <Header forceLoggedOutState={forceLoggedOutState} />
-        <slot />
+        <div class='flex-grow'>
+            <Header forceLoggedOutState={forceLoggedOutState} />
+            <slot />
+        </div>
         <Footer />
     </body>
 </html>

--- a/website/src/layouts/base/Footer.astro
+++ b/website/src/layouts/base/Footer.astro
@@ -2,8 +2,8 @@
 
 ---
 
-<div class='mt-6 flex place-content-between border-t p-2'>
+<footer class='mt-auto flex place-content-between border-t p-2'>
     <div>Enabled by data from <a class='underline' href='https://www.insdc.org/'>INSDC</a></div>
     <div>Data last updated on: TODO</div>
     <div><a class='underline' href='https://github.com/GenSpectrum'>GitHub</a></div>
-</div>
+</footer>

--- a/website/src/layouts/base/Footer.astro
+++ b/website/src/layouts/base/Footer.astro
@@ -1,9 +1,0 @@
----
-
----
-
-<footer class='mt-auto flex place-content-between border-t p-2'>
-    <div>Enabled by data from <a class='underline' href='https://www.insdc.org/'>INSDC</a></div>
-    <div>Data last updated on: TODO</div>
-    <div><a class='underline' href='https://github.com/GenSpectrum'>GitHub</a></div>
-</footer>

--- a/website/src/layouts/base/footer/DataInfo.astro
+++ b/website/src/layouts/base/footer/DataInfo.astro
@@ -1,0 +1,26 @@
+---
+import DataOriginLink from './DataOriginLink.astro';
+import { type DataOrigin, dataOriginConfig } from '../../../types/dataOrigins';
+
+interface Props {
+    dataOrigins: DataOrigin[];
+}
+
+const { dataOrigins } = Astro.props;
+---
+
+<div class='flex justify-center'>
+    <div class='p-2 text-xs'>
+        Enabled by data from:
+        {
+            dataOrigins.map((dataOrigin, index) => (
+                <span>
+                    {index > 0 && (index === dataOrigins.length - 1 ? ' and ' : ', ')}
+                    <DataOriginLink href={dataOriginConfig[dataOrigin].href}>
+                        {dataOriginConfig[dataOrigin].name}
+                    </DataOriginLink>
+                </span>
+            ))
+        }
+    </div>
+</div>

--- a/website/src/layouts/base/footer/DataOriginLink.astro
+++ b/website/src/layouts/base/footer/DataOriginLink.astro
@@ -1,0 +1,11 @@
+---
+interface Props {
+    href: string;
+}
+
+const { href } = Astro.props;
+---
+
+<a class='underline after:iconify after:ml-0.5 after:mdi--external-link' href={href}>
+    <slot />
+</a>

--- a/website/src/layouts/base/footer/Footer.astro
+++ b/website/src/layouts/base/footer/Footer.astro
@@ -1,0 +1,13 @@
+---
+import PrimaryFooter from './PrimaryFooter.astro';
+import SecondaryFooter from './SecondaryFooter.astro';
+---
+
+<footer class='mt-auto'>
+    <SecondaryFooter>
+        <slot name='secondary-footer' />
+    </SecondaryFooter>
+    <PrimaryFooter>
+        <slot name='primary-footer' />
+    </PrimaryFooter>
+</footer>

--- a/website/src/layouts/base/footer/FooterNavigation.astro
+++ b/website/src/layouts/base/footer/FooterNavigation.astro
@@ -1,0 +1,10 @@
+---
+
+---
+
+<div class='flex min-h-32 items-center justify-center gap-6 p-2'>
+    <a href='/'>GenSpectrum</a>
+    <a class='flex items-center' href='https://github.com/GenSpectrum'>
+        <div class='iconify size-8 mdi--github'></div>
+    </a>
+</div>

--- a/website/src/layouts/base/footer/PrimaryFooter.astro
+++ b/website/src/layouts/base/footer/PrimaryFooter.astro
@@ -1,0 +1,7 @@
+---
+
+---
+
+<div class='border-t bg-gray-100'>
+    <slot />
+</div>

--- a/website/src/layouts/base/footer/SecondaryFooter.astro
+++ b/website/src/layouts/base/footer/SecondaryFooter.astro
@@ -1,0 +1,7 @@
+---
+
+---
+
+<div class='mt-2 border-t'>
+    <slot />
+</div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 import BaseLayout from '../layouts/base/BaseLayout.astro';
+import DataInfo from '../layouts/base/footer/DataInfo.astro';
 import { organismConfig } from '../types/Organism';
+import { dataOrigins } from '../types/dataOrigins';
 import { Page } from '../types/pages';
 import { ServerSide } from '../views/serverSideRouting';
 ---
@@ -92,4 +94,5 @@ import { ServerSide } from '../views/serverSideRouting';
             ))
         }
     </div>
+    <DataInfo slot='secondary-footer' dataOrigins={[dataOrigins.insdc, dataOrigins.pathoplexus]} />
 </BaseLayout>

--- a/website/src/types/dataOrigins.ts
+++ b/website/src/types/dataOrigins.ts
@@ -1,0 +1,13 @@
+export const dataOrigins = {
+    insdc: 'insdc' as const,
+    pathoplexus: 'pathoplexus' as const,
+    nextstrain: 'nextstrain' as const,
+};
+
+export const dataOriginConfig = {
+    [dataOrigins.insdc]: { name: 'INSDC', href: 'https://www.insdc.org/' },
+    [dataOrigins.pathoplexus]: { name: 'Pathoplexus', href: 'https://pathoplexus.org/' },
+    [dataOrigins.nextstrain]: { name: 'INSDC (curated by Nextstrain)', href: 'https://nextstrain.org/' },
+};
+
+export type DataOrigin = keyof typeof dataOriginConfig;

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -17,6 +17,7 @@ import {
 import { type OrganismsConfig } from '../config.ts';
 import { compareVariantsViewKey } from './routing.ts';
 import { organismConfig, Organisms } from '../types/Organism.ts';
+import type { DataOrigin } from '../types/dataOrigins.ts';
 import type { InstanceLogger } from '../types/logMessage.ts';
 
 const pathFragment = organismConfig[Organisms.covid].pathFragment;
@@ -41,6 +42,7 @@ class CovidConstants {
     public readonly originatingLabField: string | undefined;
     public readonly submittingLabField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
+    public readonly dataOrigins: DataOrigin[] = ['nextstrain'];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.covid.lapis.mainDateField;

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -13,6 +13,7 @@ import {
 } from './helpers.ts';
 import type { OrganismsConfig } from '../config.ts';
 import { organismConfig, Organisms } from '../types/Organism.ts';
+import type { DataOrigin } from '../types/dataOrigins.ts';
 
 const pathFragment = organismConfig[Organisms.h5n1].pathFragment;
 
@@ -37,6 +38,7 @@ class H5n1Constants {
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
+    public readonly dataOrigins: DataOrigin[] = ['insdc'];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.h5n1.lapis.mainDateField;

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -14,6 +14,7 @@ import {
 } from './helpers.ts';
 import { type OrganismsConfig } from '../config.ts';
 import { organismConfig, Organisms } from '../types/Organism.ts';
+import type { DataOrigin } from '../types/dataOrigins.ts';
 
 const pathFragment = organismConfig[Organisms.mpox].pathFragment;
 
@@ -43,6 +44,7 @@ class MpoxConstants {
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
+    public readonly dataOrigins: DataOrigin[] = ['insdc'];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.mpox.lapis.mainDateField;

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -14,6 +14,7 @@ import {
 } from './helpers.ts';
 import type { OrganismsConfig } from '../config.ts';
 import { organismConfig, Organisms } from '../types/Organism.ts';
+import type { DataOrigin } from '../types/dataOrigins.ts';
 
 const pathFragment = organismConfig[Organisms.rsvA].pathFragment;
 
@@ -37,6 +38,7 @@ class RsvAConstants {
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
+    public readonly dataOrigins: DataOrigin[] = ['insdc'];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.rsvA.lapis.mainDateField;

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -14,6 +14,7 @@ import {
 } from './helpers.ts';
 import { type OrganismsConfig } from '../config.ts';
 import { organismConfig, Organisms } from '../types/Organism.ts';
+import type { DataOrigin } from '../types/dataOrigins.ts';
 
 const pathFragment = organismConfig[Organisms.rsvB].pathFragment;
 
@@ -37,6 +38,7 @@ class RsvBConstants {
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
+    public readonly dataOrigins: DataOrigin[] = ['insdc'];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.rsvB.lapis.mainDateField;

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -13,6 +13,7 @@ import {
 } from './helpers.ts';
 import { type OrganismsConfig } from '../config.ts';
 import { organismConfig, Organisms } from '../types/Organism.ts';
+import type { DataOrigin } from '../types/dataOrigins.ts';
 
 const pathFragment = organismConfig[Organisms.westNile].pathFragment;
 
@@ -34,6 +35,7 @@ class WestNileConstants {
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
+    public readonly dataOrigins: DataOrigin[] = ['pathoplexus'];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.westNile.lapis.mainDateField;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #234 
resolves #225

### Summary

This PR changes the design of the footer. There is now a primary footer, which should be shown on every page. It is vertically centered, and a secondary footer with additional information for each single page. For now this only holds the origin of the data. 

The footer is now positioned always at the bottom of the page.

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

On home page

![grafik](https://github.com/user-attachments/assets/f21ceecd-40c9-490e-9232-e8cd48570de7)

On organism page

![grafik](https://github.com/user-attachments/assets/49789043-0a93-41f4-90e8-4bcaf546093d)

On subscription page

![grafik](https://github.com/user-attachments/assets/e6bb0493-5a7e-40c6-afb7-4f4f79352783)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
