### PR TITLE
fix: config after changing the DNS entry for lapis.genspectrum.org from s1 to prod

### DIFF
--- a/backend/src/main/resources/application-dashboards-dev.yaml
+++ b/backend/src/main/resources/application-dashboards-dev.yaml
@@ -14,33 +14,33 @@ dashboards:
         submittingLabField: "submittingLab"
     h5n1:
       lapis:
-        url: "https://lapis.genspectrum.org/h5n1"
-        mainDateField: "sample_collection_date"
+        url: "https://gs-staging-1.int.genspectrum.org/h5n1"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     mpox:
       lapis:
-        url: "https://lapis.genspectrum.org/mpox"
-        mainDateField: "sample_collection_date"
+        url: "https://gs-staging-1.int.genspectrum.org/mpox"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     westNile:
       lapis:
         url: "https://lapis.pathoplexus.org/west-nile"
         mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
+          - "country"
+          - "division"
         lineageField: "lineage"
         hostField: "hostNameScientific"
         authorAffiliationsField: "authorAffiliations"
@@ -50,25 +50,25 @@ dashboards:
           isRevocation: "false"
     rsvA:
       lapis:
-        url: "https://lapis.genspectrum.org/rsv-a"
-        mainDateField: "sample_collection_date"
+        url: "https://gs-staging-1.int.genspectrum.org/rsv-a"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     rsvB:
       lapis:
-        url: "https://lapis.genspectrum.org/rsv-b"
-        mainDateField: "sample_collection_date"
+        url: "https://gs-staging-1.int.genspectrum.org/rsv-b"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
   auth:
     github:

--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -15,32 +15,32 @@ dashboards:
     h5n1:
       lapis:
         url: "https://lapis.genspectrum.org/h5n1"
-        mainDateField: "sample_collection_date"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     mpox:
       lapis:
         url: "https://lapis.genspectrum.org/mpox"
-        mainDateField: "sample_collection_date"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     westNile:
       lapis:
         url: "https://lapis.pathoplexus.org/west-nile"
         mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
+          - "country"
+          - "division"
         lineageField: "lineage"
         hostField: "hostNameScientific"
         authorAffiliationsField: "authorAffiliations"
@@ -51,24 +51,24 @@ dashboards:
     rsvA:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-a"
-        mainDateField: "sample_collection_date"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     rsvB:
       lapis:
         url: "https://lapis.genspectrum.org/rsv-b"
-        mainDateField: "sample_collection_date"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
   auth:
     github:

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -14,33 +14,33 @@ dashboards:
         submittingLabField: "submittingLab"
     h5n1:
       lapis:
-        url: "https://lapis.genspectrum.org/h5n1"
-        mainDateField: "sample_collection_date"
+        url: "https://gs-staging-1.int.genspectrum.org/h5n1"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     mpox:
       lapis:
-        url: "https://lapis.genspectrum.org/mpox"
-        mainDateField: "sample_collection_date"
+        url: "https://gs-staging-1.int.genspectrum.org/mpox"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     westNile:
       lapis:
         url: "https://lapis.pathoplexus.org/west-nile"
         mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
+          - "country"
+          - "division"
         lineageField: "lineage"
         hostField: "hostNameScientific"
         authorAffiliationsField: "authorAffiliations"
@@ -50,25 +50,25 @@ dashboards:
           isRevocation: "false"
     rsvA:
       lapis:
-        url: "https://lapis.genspectrum.org/rsv-a"
-        mainDateField: "sample_collection_date"
+        url: "https://gs-staging-1.int.genspectrum.org/rsv-a"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
     rsvB:
       lapis:
-        url: "https://lapis.genspectrum.org/rsv-b"
-        mainDateField: "sample_collection_date"
+        url: "https://gs-staging-1.int.genspectrum.org/rsv-b"
+        mainDateField: "sampleCollectionDate"
         locationFields:
-          - "geo_loc_country"
-          - "geo_loc_admin_1"
+          - "country"
+          - "division"
         lineageField: "lineage"
-        hostField: "host_name_scientific"
-        authorAffiliationsField: "author_affiliations"
+        hostField: "hostNameScientific"
+        authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
   auth:
     github:


### PR DESCRIPTION
### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

The RSV instances seem to have no lineage field yet... We will need to fix that in the deployment.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
