### PR TITLE
feat(website): hide login button on prod

### DIFF
--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -32,6 +32,12 @@ const organismsConfigSchema = z.object(
 );
 export type OrganismsConfig = z.infer<typeof organismsConfigSchema>;
 
+const environmentSchema = z.union([
+    z.literal('dashboards-dev'),
+    z.literal('dashboards-staging'),
+    z.literal('dashboards-prod'),
+]);
+
 const dashboardsConfigSchema = z.object({
     dashboards: z.object({
         organisms: organismsConfigSchema,
@@ -47,12 +53,6 @@ const dashboardsConfigSchema = z.object({
     }),
 });
 export type DashboardsConfig = z.infer<typeof dashboardsConfigSchema>;
-
-const environmentSchema = z.union([
-    z.literal('dashboards-dev'),
-    z.literal('dashboards-staging'),
-    z.literal('dashboards-prod'),
-]);
 
 let dashboardsConfig: DashboardsConfig | null = null;
 
@@ -100,7 +100,7 @@ function getConfigDir(): string {
     return configDir;
 }
 
-function getEnvironment() {
+export function getEnvironment() {
     return processEnvOrMetaEnv('DASHBOARDS_ENVIRONMENT', environmentSchema);
 }
 

--- a/website/src/layouts/base/header/CallToAction.astro
+++ b/website/src/layouts/base/header/CallToAction.astro
@@ -1,13 +1,17 @@
 ---
 import LoginState from '../../../components/auth/LoginState.astro';
+import { getEnvironment } from '../../../config';
 
 interface Props {
     forceLoggedOutState?: boolean;
 }
 
 const { forceLoggedOutState = false } = Astro.props;
+const dashboardsEnvironment = getEnvironment();
 ---
 
 <div class='mr-2 flex w-32 justify-end'>
-    <LoginState forceLoggedOutState={forceLoggedOutState} />
+    <div class={`${dashboardsEnvironment === 'dashboards-prod' ? 'hidden' : 'visible'}`}>
+        <LoginState forceLoggedOutState={forceLoggedOutState} />
+    </div>
 </div>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #283

### Summary
The environment variable `DASHBOARDS_ENVIRONMENT` now toggles also, if the login button should be shown or not. We remove this condition, once we have the subscription feature ready.

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
The button no longer shows on prod. The layout is the same as before.
![grafik](https://github.com/user-attachments/assets/3c807d5d-80a2-42e0-b32f-dce979782a62)

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
