### PR TITLE
feat(website): remove unused onBlur value from GsMutationFilter as removed in https://github.com/GenSpectrum/dashboard-components/pull/511

### DIFF
--- a/website/src/components/genspectrum/GsMutationFilter.tsx
+++ b/website/src/components/genspectrum/GsMutationFilter.tsx
@@ -11,13 +11,11 @@ export type MutationFilter = {
 export function GsMutationFilter({
     initialValue,
     width,
-    onBlur = () => {},
     onMutationChange = () => {},
 }: {
     width?: string;
     initialValue?: MutationFilter | string[] | undefined;
     onMutationChange: (mutationFilter: MutationFilter | undefined) => void;
-    onBlur?: (mutationFilter: MutationFilter | undefined) => void;
 }) {
     const mutationFilterRef = useRef<HTMLElement>();
 
@@ -26,23 +24,17 @@ export function GsMutationFilter({
             onMutationChange(event.detail);
         };
 
-        const handleMutationFilterBlur = (event: CustomEvent) => {
-            onBlur(event.detail);
-        };
-
         const currentMutationFilterRef = mutationFilterRef.current;
         if (currentMutationFilterRef) {
             currentMutationFilterRef.addEventListener('gs-mutation-filter-changed', handleMutationFilterChange);
-            currentMutationFilterRef.addEventListener('gs-mutation-filter-on-blur', handleMutationFilterBlur);
         }
 
         return () => {
             if (currentMutationFilterRef) {
                 currentMutationFilterRef.removeEventListener('gs-mutation-filter-changed', handleMutationFilterChange);
-                currentMutationFilterRef.removeEventListener('gs-mutation-filter-on-blur', handleMutationFilterBlur);
             }
         };
-    }, [onMutationChange, onBlur]);
+    }, [onMutationChange]);
 
     return (
         <gs-mutation-filter


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

In https://github.com/GenSpectrum/dashboard-components/pull/511 we removed the blur dispatch event from the mutation filter component, this PR reflects this change in genspectrum dashboards. 

The dispatch event was unused and was not accurate (e.g. it did not fire if a user moved outside of the component if they moved outside after deleting mutations)
### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
