### PR TITLE
chore(website): patch auth-astro - manually import types from next-auth/react

### DIFF
--- a/website/patches/auth-astro+4.1.3.patch
+++ b/website/patches/auth-astro+4.1.3.patch
@@ -1,3 +1,68 @@
+diff --git a/node_modules/auth-astro/client.ts b/node_modules/auth-astro/client.ts
+index 8a30c9e..d853a86 100644
+--- a/node_modules/auth-astro/client.ts
++++ b/node_modules/auth-astro/client.ts
+@@ -1,11 +1,43 @@
+-import type {
+-	LiteralUnion,
+-	SignInOptions,
+-	SignInAuthorizationParams,
+-	SignOutParams,
+-} from 'next-auth/react'
+ import type { BuiltInProviderType, RedirectableProviderType } from '@auth/core/providers'
+ 
++// manually imported from next-auth/react to get the proper type without installing the dependency ourselves
++// from https://github.com/nextauthjs/next-auth/blob/9411046efb21f83218df4d7d7da6639e100adb2a/packages/next-auth/src/lib/client.ts
++export interface SignInOptions<Redirect extends boolean = true>
++	extends Record<string, unknown> {
++	/** @deprecated Use `redirectTo` instead. */
++	callbackUrl?: string
++	/**
++	 * Specify where the user should be redirected to after a successful signin.
++	 *
++	 * By default, it is the page the sign-in was initiated from.
++	 */
++	redirectTo?: string
++	/**
++	 * You might want to deal with the signin response on the same page, instead of redirecting to another page.
++	 * For example, if an error occurs (like wrong credentials given by the user), you might want to show an inline error message on the input field.
++	 *
++	 * For this purpose, you can set this to option `redirect: false`.
++	 */
++	redirect?: Redirect
++}
++export interface SignOutParams<Redirect extends boolean = true> {
++	/** @deprecated Use `redirectTo` instead. */
++	callbackUrl?: string
++	/**
++	 * If you pass `redirect: false`, the page will not reload.
++	 * The session will be deleted, and `useSession` is notified, so any indication about the user will be shown as logged out automatically.
++	 * It can give a very nice experience for the user.
++	 */
++	redirectTo?: string
++	/** [Documentation](https://next-auth.js.org/getting-started/client#using-the-redirect-false-option-1 */
++	redirect?: Redirect
++}
++export type SignInAuthorizationParams =
++	| string
++	| string[][]
++	| Record<string, string>
++	| URLSearchParams
++
+ interface AstroSignInOptions extends SignInOptions {
+ 	/** The base path for authentication (default: /api/auth) */
+ 	prefix?: string
+@@ -24,9 +56,7 @@ interface AstroSignOutParams extends SignOutParams {
+  * [Documentation](https://authjs.dev/reference/utilities/#signin)
+  */
+ export async function signIn<P extends RedirectableProviderType | undefined = undefined>(
+-	providerId?: LiteralUnion<
+-		P extends RedirectableProviderType ? P | BuiltInProviderType : BuiltInProviderType
+-	>,
++	providerId?: BuiltInProviderType,
+ 	options?: AstroSignInOptions,
+ 	authorizationParams?: SignInAuthorizationParams
+ ) {
 diff --git a/node_modules/auth-astro/src/integration.ts b/node_modules/auth-astro/src/integration.ts
 index f749024..9200d5c 100644
 --- a/node_modules/auth-astro/src/integration.ts

--- a/website/src/components/auth/LoginButton.astro
+++ b/website/src/components/auth/LoginButton.astro
@@ -10,10 +10,9 @@
         ? new URL('/', window.location.href).toString()
         : undefined;
 
-    document.getElementById('login')?.addEventListener('click', () =>
-        // @ts-expect-error -- 'callbackUrl' exists - but it's defined in SignInOptions from 'next-auth/react'.
-        // auth-astro removed the dependency on next-auth in 4.1.3, so we don't have the type anymore.
-        // I don't want to install next-auth just for the type, so I'm ignoring the error.
-        signIn('github', { callbackUrl: callbackUrlThatDoesNotImmediatelyLogoutAgain }),
-    );
+    document
+        .getElementById('login')
+        ?.addEventListener('click', () =>
+            signIn('github', { callbackUrl: callbackUrlThatDoesNotImmediatelyLogoutAgain }),
+        );
 </script>


### PR DESCRIPTION


### Summary

A copy of #322 to be merged into main instead of into another PR.

The dependency is not installed transitively - we don't want to install it ourselves We have to satisfy Typescript and the linter here. I originally fixed the build with auth-astro in #307, but this seems a better fix, since it simply removes the imports from the missing dependency.


### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
