### PR TITLE
fix(website): fix reference error in built artifact

### DIFF
--- a/website/src/views/BaseView.ts
+++ b/website/src/views/BaseView.ts
@@ -1,0 +1,81 @@
+import type { OrganismConstants, SequencingEffortsConstants, SingleVariantConstants } from './OrganismConstants.ts';
+import { type PageStateHandler, SequencingEffortsStateHandler, SingleVariantStateHandler } from './PageStateHandler.ts';
+import type { BaselineAndVariantData, BaselineData, View } from './View.ts';
+import { sequencingEffortsViewConstants, singleVariantViewConstants, type ViewConstants } from './ViewConstants.ts';
+import { defaultBreadcrumbs } from '../layouts/Breadcrumbs.tsx';
+import { organismConfig } from '../types/Organism.ts';
+
+export abstract class BaseView<
+    PageState extends object,
+    Constants extends OrganismConstants,
+    StateHandler extends PageStateHandler<PageState>,
+> implements View<PageState, Constants, StateHandler>
+{
+    public readonly pathname;
+    public readonly viewTitle;
+    public readonly viewBreadcrumbEntries;
+
+    protected constructor(
+        public readonly organismConstants: Constants,
+        public readonly pageStateHandler: StateHandler,
+        public readonly viewConstants: ViewConstants,
+    ) {
+        this.pathname = `/${organismConfig[this.organismConstants.organism].pathFragment}/${this.viewConstants.pathFragment}`;
+        this.viewTitle = `${this.viewConstants.label} | ${organismConfig[this.organismConstants.organism].label} | GenSpectrum`;
+        this.viewBreadcrumbEntries = [
+            ...defaultBreadcrumbs,
+            { name: organismConfig[this.organismConstants.organism].label },
+            { name: this.viewConstants.label, href: this.pathname },
+        ];
+    }
+}
+
+export class GenericSingleVariantView<Constants extends SingleVariantConstants> extends BaseView<
+    BaselineAndVariantData,
+    Constants,
+    SingleVariantStateHandler
+> {
+    constructor(constants: Constants) {
+        super(
+            constants,
+            new SingleVariantStateHandler(
+                constants,
+                {
+                    baselineFilter: {
+                        location: {},
+                        dateRange: constants.defaultDateRange,
+                    },
+                    variantFilter: {
+                        mutations: {},
+                        lineages: {},
+                    },
+                },
+                organismConfig[constants.organism].pathFragment,
+            ),
+            singleVariantViewConstants,
+        );
+    }
+}
+
+export class GenericSequencingEffortsView<Constants extends SequencingEffortsConstants> extends BaseView<
+    BaselineData,
+    Constants,
+    SequencingEffortsStateHandler
+> {
+    constructor(constants: Constants) {
+        super(
+            constants,
+            new SequencingEffortsStateHandler(
+                constants,
+                {
+                    baselineFilter: {
+                        location: {},
+                        dateRange: constants.defaultDateRange,
+                    },
+                },
+                organismConfig[constants.organism].pathFragment,
+            ),
+            sequencingEffortsViewConstants,
+        );
+    }
+}

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -1,12 +1,11 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
 
-import type { OrganismConstants, SequencingEffortsConstants, SingleVariantConstants } from './OrganismConstants.ts';
-import { type PageStateHandler, SequencingEffortsStateHandler, SingleVariantStateHandler } from './PageStateHandler.ts';
-import { sequencingEffortsViewConstants, singleVariantViewConstants, type ViewConstants } from './ViewConstants';
+import type { OrganismConstants } from './OrganismConstants.ts';
+import { type PageStateHandler } from './PageStateHandler.ts';
+import { type ViewConstants } from './ViewConstants';
 import type { LapisLineageQuery, LapisLocation, LapisMutationQuery } from './helpers.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/VariantSelector.tsx';
-import { type BreadcrumbElement, defaultBreadcrumbs } from '../layouts/Breadcrumbs.tsx';
-import { organismConfig } from '../types/Organism.ts';
+import { type BreadcrumbElement } from '../layouts/Breadcrumbs.tsx';
 
 export type BaselineFilter = {
     location: LapisLocation;
@@ -57,81 +56,6 @@ export type View<
 export const defaultTablePageSize = 200;
 
 export const pathoplexusGroupNameField = 'groupName';
-
-export abstract class BaseView<
-    PageState extends object,
-    Constants extends OrganismConstants,
-    StateHandler extends PageStateHandler<PageState>,
-> implements View<PageState, Constants, StateHandler>
-{
-    public readonly pathname;
-    public readonly viewTitle;
-    public readonly viewBreadcrumbEntries;
-
-    protected constructor(
-        public readonly organismConstants: Constants,
-        public readonly pageStateHandler: StateHandler,
-        public readonly viewConstants: ViewConstants,
-    ) {
-        this.pathname = `/${organismConfig[this.organismConstants.organism].pathFragment}/${this.viewConstants.pathFragment}`;
-        this.viewTitle = `${this.viewConstants.label} | ${organismConfig[this.organismConstants.organism].label} | GenSpectrum`;
-        this.viewBreadcrumbEntries = [
-            ...defaultBreadcrumbs,
-            { name: organismConfig[this.organismConstants.organism].label },
-            { name: this.viewConstants.label, href: this.pathname },
-        ];
-    }
-}
-
-export class GenericSingleVariantView<Constants extends SingleVariantConstants> extends BaseView<
-    BaselineAndVariantData,
-    Constants,
-    SingleVariantStateHandler
-> {
-    constructor(constants: Constants) {
-        super(
-            constants,
-            new SingleVariantStateHandler(
-                constants,
-                {
-                    baselineFilter: {
-                        location: {},
-                        dateRange: constants.defaultDateRange,
-                    },
-                    variantFilter: {
-                        mutations: {},
-                        lineages: {},
-                    },
-                },
-                organismConfig[constants.organism].pathFragment,
-            ),
-            singleVariantViewConstants,
-        );
-    }
-}
-
-export class GenericSequencingEffortsView<Constants extends SequencingEffortsConstants> extends BaseView<
-    BaselineData,
-    Constants,
-    SequencingEffortsStateHandler
-> {
-    constructor(constants: Constants) {
-        super(
-            constants,
-            new SequencingEffortsStateHandler(
-                constants,
-                {
-                    baselineFilter: {
-                        location: {},
-                        dateRange: constants.defaultDateRange,
-                    },
-                },
-                organismConfig[constants.organism].pathFragment,
-            ),
-            sequencingEffortsViewConstants,
-        );
-    }
-}
 
 export function getLineageFilterFields(lineageFilters: LineageFilterConfig[]) {
     return lineageFilters.map((filter) => filter.lapisField);

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -2,7 +2,6 @@ import { type DateRangeOption, dateRangeOptionPresets } from '@genspectrum/dashb
 
 import {
     type BaselineData,
-    BaseView,
     type CompareVariantsData,
     getLineageFilterFields,
     type Id,
@@ -19,6 +18,7 @@ import {
     setSearchFromLocation,
 } from './helpers.ts';
 import { type OrganismsConfig } from '../config.ts';
+import { BaseView } from './BaseView.ts';
 import type { SingleVariantConstants } from './OrganismConstants.ts';
 import {
     CompareVariantsStateHandler,

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -1,15 +1,9 @@
 import { type DateRangeOption, dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';
 
-import {
-    type BaselineAndVariantData,
-    BaseView,
-    type CompareVariantsData,
-    GenericSequencingEffortsView,
-    GenericSingleVariantView,
-    type Id,
-} from './View.ts';
+import { type BaselineAndVariantData, type CompareVariantsData, type Id } from './View.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/VariantSelector.tsx';
 import type { OrganismsConfig } from '../config.ts';
+import { BaseView, GenericSequencingEffortsView, GenericSingleVariantView } from './BaseView.ts';
 import type { SingleVariantConstants } from './OrganismConstants.ts';
 import { GenericCompareVariantsStateHandler } from './PageStateHandler.ts';
 import { compareVariantsViewConstants } from './ViewConstants.ts';

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -1,15 +1,9 @@
 import { type DateRangeOption, dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';
 
-import {
-    type BaselineAndVariantData,
-    BaseView,
-    type CompareVariantsData,
-    GenericSequencingEffortsView,
-    GenericSingleVariantView,
-    type Id,
-} from './View.ts';
+import { type BaselineAndVariantData, type CompareVariantsData, type Id } from './View.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/VariantSelector.tsx';
 import type { OrganismsConfig } from '../config.ts';
+import { BaseView, GenericSequencingEffortsView, GenericSingleVariantView } from './BaseView.ts';
 import type { SingleVariantConstants } from './OrganismConstants.ts';
 import { GenericCompareVariantsStateHandler } from './PageStateHandler.ts';
 import { compareVariantsViewConstants } from './ViewConstants.ts';

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -1,15 +1,9 @@
 import { type DateRangeOption, dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';
 
-import {
-    type BaselineAndVariantData,
-    BaseView,
-    type CompareVariantsData,
-    GenericSequencingEffortsView,
-    GenericSingleVariantView,
-    type Id,
-} from './View.ts';
+import { type BaselineAndVariantData, type CompareVariantsData, type Id } from './View.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/VariantSelector.tsx';
 import { type OrganismsConfig } from '../config.ts';
+import { BaseView, GenericSequencingEffortsView, GenericSingleVariantView } from './BaseView.ts';
 import type { SingleVariantConstants } from './OrganismConstants.ts';
 import { GenericCompareVariantsStateHandler } from './PageStateHandler.ts';
 import { compareVariantsViewConstants } from './ViewConstants.ts';

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -1,15 +1,9 @@
 import { type DateRangeOption, dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';
 
-import {
-    type BaselineAndVariantData,
-    BaseView,
-    type CompareVariantsData,
-    GenericSequencingEffortsView,
-    GenericSingleVariantView,
-    type Id,
-} from './View.ts';
+import { type BaselineAndVariantData, type CompareVariantsData, type Id } from './View.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/VariantSelector.tsx';
 import { type OrganismsConfig } from '../config.ts';
+import { BaseView, GenericSequencingEffortsView, GenericSingleVariantView } from './BaseView.ts';
 import type { SingleVariantConstants } from './OrganismConstants.ts';
 import { GenericCompareVariantsStateHandler } from './PageStateHandler.ts';
 import { compareVariantsViewConstants } from './ViewConstants.ts';


### PR DESCRIPTION


<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->The built website would crash with "ReferenceError: can't access lexical declaration '$e' before initialization" (in Firefox) $e was one of the abstract view classes.
I guess this was due to a cyclic dependency (view requiring state handlers requiring view), but I'm not 100% sure. It works with the abstract view classes extracted to a separate file though.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
