### PR TITLE
feat(website): show more useful error messages to the user

### DIFF
--- a/website/src/components/subscriptions/backendApi/backendService.spec.ts
+++ b/website/src/components/subscriptions/backendApi/backendService.spec.ts
@@ -173,7 +173,7 @@ describe('backendService', () => {
         backendRequestMocks.getSubscriptionsBackendError(errorResponse, 400);
 
         await expect(backendService.getSubscriptions({ userId: '123' })).rejects.to.deep.equal(
-            new BackendError('Bad Request', 400, errorResponse, '/subscriptions', undefined),
+            new BackendError('Some error detail', 400, errorResponse, '/subscriptions', undefined),
         );
     });
 

--- a/website/src/components/subscriptions/backendApi/backendService.ts
+++ b/website/src/components/subscriptions/backendApi/backendService.ts
@@ -8,6 +8,7 @@ import {
     subscriptionResponseSchema,
     triggerEvaluationResponseSchema,
 } from '../../../types/Subscription.ts';
+import { UserFacingError } from '../../ErrorReportInstruction.tsx';
 
 const X_REQUEST_ID_HEADER = 'x-request-id';
 
@@ -75,7 +76,7 @@ class ApiService {
             const backendError = problemDetailSchema.safeParse(response.data);
             if (backendError.success) {
                 throw new BackendError(
-                    response.statusText,
+                    backendError.data.detail ?? '(no detail)',
                     response.status,
                     backendError.data,
                     response.config.url ?? '',
@@ -90,7 +91,7 @@ class ApiService {
 
 const axiosNotFoundError = 'ENOTFOUND';
 
-export class BackendError extends Error {
+export class BackendError extends UserFacingError {
     constructor(
         message: string,
         public readonly status: number,
@@ -114,7 +115,7 @@ export class UnknownBackendError extends Error {
     }
 }
 
-export class BackendNotAvailable extends Error {
+export class BackendNotAvailable extends UserFacingError {
     constructor(url: string) {
         super(`Backend not available under ${url}`);
         this.name = 'BackendNotAvailable';

--- a/website/src/components/subscriptions/create/SubscriptionsCreate.tsx
+++ b/website/src/components/subscriptions/create/SubscriptionsCreate.tsx
@@ -56,7 +56,7 @@ export function SubscriptionsCreateInner({
             toast.error(
                 <>
                     <p className='mb-2'>We could not create your subscription. Please try again later.</p>
-                    <ErrorReportToastModal errorId={errorId} />
+                    <ErrorReportToastModal errorId={errorId} error={error} />
                 </>,
                 {
                     position: 'bottom-left',

--- a/website/src/components/subscriptions/overview/SubscriptionEntry.tsx
+++ b/website/src/components/subscriptions/overview/SubscriptionEntry.tsx
@@ -121,7 +121,7 @@ function MoreDropdown({
                     <p className='mb-2'>
                         We could not delete your subscription "{subscription.name}". Please try again later.
                     </p>
-                    <ErrorReportToastModal errorId={errorId} />
+                    <ErrorReportToastModal errorId={errorId} error={error} />
                 </>,
                 {
                     position: 'bottom-left',

--- a/website/src/pages/500.astro
+++ b/website/src/pages/500.astro
@@ -2,10 +2,10 @@
 // eslint-disable-next-line import/no-deprecated -- "Parse errors in imported module 'uuid': parser.parse is not a function (undefined:undefined)"
 import { v4 as uuidv4 } from 'uuid';
 
-import { ErrorReportInstruction } from '../components/ErrorReportInstruction';
-import BaseLayout from '../layouts/base/BaseLayout.astro';
+import { ErrorReportInstruction, UserFacingError } from '../components/ErrorReportInstruction';
+import { defaultBreadcrumbs } from '../layouts/Breadcrumbs';
+import ContaineredPageLayout from '../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { getInstanceLogger } from '../logger';
-import { PageContainer } from '../styles/containers/PageContainer';
 import { PageHeadline } from '../styles/containers/PageHeadline';
 import { getErrorLogMessage } from '../util/getErrorLogMessage';
 
@@ -19,16 +19,20 @@ const errorId = uuidv4();
 getInstanceLogger('500ErrorPage').error(`An error occurred: ${getErrorLogMessage(error)}`, { errorId });
 ---
 
-<BaseLayout title='GenSpectrum Dashboards'>
-    <PageContainer>
-        <PageHeadline>Oops! Something went wrong...</PageHeadline>
-        <div class='mb-2'>We are sorry for the inconvenience. Please try again later.</div>
+<ContaineredPageLayout title='GenSpectrum Dashboards' breadcrumbs={defaultBreadcrumbs}>
+    <PageHeadline>Oops! Something went wrong...</PageHeadline>
+    {error instanceof UserFacingError && <div class='mb-2'>{error.message}</div>}
+    <div class='mb-2'>We are sorry for the inconvenience. Please try again later.</div>
 
-        <details class='collapse'>
-            <summary class='collapse-title link'> The problem persists? Learn how to report an issue.</summary>
-            <div class='collapse-content'>
-                <ErrorReportInstruction errorId={errorId} currentUrl={Astro.url.toString()} client:load />
-            </div>
-        </details>
-    </PageContainer>
-</BaseLayout>
+    <details class='collapse'>
+        <summary class='collapse-title link'> The problem persists? Learn how to report an issue.</summary>
+        <div class='collapse-content'>
+            <ErrorReportInstruction
+                errorId={errorId}
+                currentUrl={Astro.url.toString()}
+                error={error instanceof UserFacingError ? { message: error.message } : undefined}
+                client:load
+            />
+        </div>
+    </details>
+</ContaineredPageLayout>

--- a/website/src/pages/api/subscriptions/[...path].ts
+++ b/website/src/pages/api/subscriptions/[...path].ts
@@ -2,6 +2,7 @@ import { getSession } from 'auth-astro/server';
 
 import { getBackendHost } from '../../../config.ts';
 import { getInstanceLogger } from '../../../logger.ts';
+import type { ProblemDetail } from '../../../types/ProblemDetail.ts';
 import { getErrorLogMessage } from '../../../util/getErrorLogMessage.ts';
 
 const API_PATHNAME_LENGTH = '/api'.length;
@@ -43,22 +44,15 @@ function getBackendUrl(request: Request, userId: string) {
     return backendUrl;
 }
 
-type BackendError = {
-    title: string;
-    detail: string;
-    status: number;
-    instance: string;
-};
-
 const getUnauthorizedResponse = (requestUrl: string) => {
-    const response: BackendError = {
+    const response: ProblemDetail = {
         title: 'Unauthorized',
         detail: "You're not authorized to access this resource",
         status: 401,
         instance: requestUrl,
     };
 
-    return new Response(JSON.stringify({ response }), {
+    return Response.json(response, {
         status: 401,
         headers: {
             // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -68,14 +62,14 @@ const getUnauthorizedResponse = (requestUrl: string) => {
 };
 
 const getInternalErrorResponse = (requestUrl: string) => {
-    const response: BackendError = {
+    const response: ProblemDetail = {
         title: 'Internal Server Error',
-        detail: "Couldn't fetch data from the backend",
+        detail: 'Failed to connect the backend service',
         status: 500,
         instance: requestUrl,
     };
 
-    return new Response(JSON.stringify({ response }), {
+    return Response.json(response, {
         status: 500,
         headers: {
             // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/website/src/views/PageStateHandler.ts
+++ b/website/src/views/PageStateHandler.ts
@@ -23,7 +23,8 @@ import {
     setSearchFromLocation,
 } from './helpers.ts';
 import { compareVariantsViewKey } from './routing.ts';
-import { Organisms } from '../types/Organism.ts';
+import { UserFacingError } from '../components/ErrorReportInstruction.tsx';
+import { organismConfig } from '../types/Organism.ts';
 
 export interface PageStateHandler<PageState extends object> {
     parsePageStateFromUrl(url: URL): PageState;
@@ -143,6 +144,8 @@ function toLapisFilterWithoutVariant(
     };
 }
 
+const $ = '$';
+
 export abstract class CompareVariantsStateHandler<ColumnData extends BaselineAndVariantData = BaselineAndVariantData>
     implements PageStateHandler<CompareVariantsData<ColumnData>>
 {
@@ -227,10 +230,10 @@ export abstract class CompareVariantsStateHandler<ColumnData extends BaselineAnd
         const filterMap = new Map<Id, Map<string, string>>();
 
         for (const [key, value] of search) {
-            const keySplit = key.split('$');
+            const keySplit = key.split($);
             if (keySplit.length !== 2) {
-                throw Error(
-                    `Failed parsing query parameters on ${Organisms.covid} ${compareVariantsViewKey}: Invalid key in URLSearchParam: ${key}`,
+                throw new UserFacingError(
+                    `Failed parsing query parameters on ${organismConfig[this.constants.organism].label} ${compareVariantsViewKey}: Invalid key in URLSearchParam: '${key}'. Expected key of the form <parameter>${$}<id>`,
                 );
             }
             const id = Number.parseInt(keySplit[1], 10);
@@ -250,7 +253,7 @@ export abstract class CompareVariantsStateHandler<ColumnData extends BaselineAnd
         const search = new URLSearchParams();
         for (const [id, filter] of filters) {
             for (const [key, value] of filter) {
-                search.append(`${key}$${id}`, value);
+                search.append(`${key}${$}${id}`, value);
             }
         }
         return search;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #256

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
On client side (where the error can be seen in console and network tab anyway): Now shows the error message 
* in the error information that's supposed to be copied to our GitHub issues
* in the error toast, if it should be user facing
 
![grafik](https://github.com/user-attachments/assets/ec6a2c81-5757-4d8a-b821-659bfe82cef1)

On server side: Shows the error message
* in the error information,  if it should be user facing
* in the error toast, if it should be user facing
![grafik](https://github.com/user-attachments/assets/9eec55de-6f55-45a1-bfee-ce3aa08dba4c)

