### PR TITLE
feat(website): remove relative growth advantage chart from non-covid side-by-side views

### DIFF
--- a/website/src/components/GenericCompareSideBySidePage.astro
+++ b/website/src/components/GenericCompareSideBySidePage.astro
@@ -93,17 +93,6 @@ const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
                                     height='100%'
                                 />
                             </ComponentWrapper>
-                            <ComponentWrapper title='Relative growth advantage'>
-                                <gs-relative-growth-advantage
-                                    numeratorFilter={JSON.stringify(numeratorFilter)}
-                                    denominatorFilter={JSON.stringify(baselineLapisFilter)}
-                                    lapisDateField={view.organismConstants.mainDateField}
-                                    generationTime='7'
-                                    pageSize={defaultTablePageSize}
-                                    width='100%'
-                                    height='100%'
-                                />
-                            </ComponentWrapper>
                             <ComponentWrapper title='Nucleotide mutations'>
                                 <gs-mutations
                                     lapisFilter={JSON.stringify(numeratorFilter)}


### PR DESCRIPTION

resolves #349



### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->


### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
