### PR TITLE
build: add workflow that creates a PR to update the prod branch

### DIFF
--- a/.github/workflows/rebaseProd.yml
+++ b/.github/workflows/rebaseProd.yml
@@ -1,0 +1,30 @@
+name: Create PR to Update Prod
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Create Pull Request to prod
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh pr list --base prod --head main --state open --json number | jq -e '. | length > 0'; then
+            echo "PR to update prod from main already exists - skipping creation"
+          else
+            body="This pull request updates the \`prod\` branch with the latest changes from the \`main\` branch. **Do not squash-merge** this PR."
+            gh pr create --base prod --head main --title "Update prod from main" --body "$body"
+          fi


### PR DESCRIPTION
resolves #360


### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

I tested this on a private repo. This would require allowing GitHub actions to create/approve PRs (Settings > Actions > General):
![grafik](https://github.com/user-attachments/assets/a9052d4a-f53a-43ef-a5cd-9abdcde634b3)

@chaoran-chen would it be ok if you enable this setting? Also it's probably good to add some branch protection rules for `prod` (at least restrict deletion and force pushes - maybe also add that it requires a PR to update, if we decide to keep this action).


### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
