### PR TITLE
refactor(website): make the "Apply filters" button a link

### DIFF
--- a/website/src/components/GenericCompareVariantsPage.astro
+++ b/website/src/components/GenericCompareVariantsPage.astro
@@ -47,7 +47,6 @@ const numeratorFilters = view.pageStateHandler.variantFiltersToNamedLapisFilters
         }}
         variantFilterConfigs={variantFilterConfigs}
         emptyVariantFilterConfig={view.pageStateHandler.getEmptyVariantFilterConfig()}
-        pageState={pageState}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'

--- a/website/src/components/pageStateSelectors/ApplyFilterButton.tsx
+++ b/website/src/components/pageStateSelectors/ApplyFilterButton.tsx
@@ -1,16 +1,17 @@
-import type { JSX } from 'react';
-
 import type { WithClassName } from '../../types/WithClassName.ts';
+import type { PageStateHandler } from '../../views/PageStateHandler.ts';
 
-export function ApplyFilterButton({
-    onClick,
+export function ApplyFilterButton<PageState extends object, StateHandler extends PageStateHandler<PageState>>({
+    pageStateHandler,
+    newPageState,
     className,
 }: WithClassName<{
-    onClick: JSX.IntrinsicElements['button']['onClick'];
+    pageStateHandler: StateHandler;
+    newPageState: PageState;
 }>) {
     return (
-        <button className={`btn btn-primary ${className}`} onClick={onClick}>
+        <a className={`btn btn-primary ${className}`} href={pageStateHandler.toUrl(newPageState)}>
             Apply filters
-        </button>
+        </a>
     );
 }

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -41,7 +41,7 @@ export function CompareSideBySidePageStateSelector({
     );
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
 
-    const routeToNewPage = () => {
+    const newPageState = useMemo(() => {
         pageState.filters.set(filterId, {
             baselineFilter: {
                 location,
@@ -53,8 +53,8 @@ export function CompareSideBySidePageStateSelector({
             },
         });
 
-        window.location.href = view.pageStateHandler.toUrl(pageState);
-    };
+        return pageState;
+    }, [location, dateRange, mutation, lineages, filterId, pageState]);
 
     return (
         <div className='flex flex-col gap-4 bg-gray-50 p-2'>
@@ -84,7 +84,7 @@ export function CompareSideBySidePageStateSelector({
                 </div>
             </div>
             <div className='flex justify-end'>
-                <ApplyFilterButton onClick={routeToNewPage} className='btn-sm max-w-64' />
+                <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
             </div>
         </div>
     );

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -6,7 +6,7 @@ import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig
 import type { LineageFilterConfig } from './LineageFilterInput.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
-import type { CompareVariantsData, Id, VariantFilter } from '../../views/View.ts';
+import type { Id, VariantFilter } from '../../views/View.ts';
 import { type LapisLocation, type LapisMutationQuery } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { compareVariantsViewKey } from '../../views/viewKeys.ts';
@@ -32,7 +32,6 @@ export function CompareVariantsPageStateSelector({
     emptyVariantFilterConfig,
     organismViewKey,
     organismsConfig,
-    pageState,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
@@ -40,7 +39,6 @@ export function CompareVariantsPageStateSelector({
     emptyVariantFilterConfig: VariantFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareVariantsViewKey}`;
     organismsConfig: OrganismsConfig;
-    pageState: CompareVariantsData;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
@@ -52,24 +50,21 @@ export function CompareVariantsPageStateSelector({
         [organismsConfig, organismViewKey],
     );
 
-    const routeToNewPage = () => {
+    const newPageState = useMemo(() => {
         const variants = new Map(
             Array.from(variantConfigs).map(([id, variantFilterConfig]) => {
                 return [id, toVariantFilter(variantFilterConfig)];
             }),
         );
 
-        const newPageState: CompareVariantsData = {
-            ...pageState,
+        return {
             baselineFilter: {
                 location,
                 dateRange,
             },
             variants,
         };
-
-        window.location.href = view.pageStateHandler.toUrl(newPageState);
-    };
+    }, [location, dateRange, variantConfigs]);
 
     return (
         <div className='flex flex-col gap-6 bg-gray-50 p-2'>
@@ -84,7 +79,7 @@ export function CompareVariantsPageStateSelector({
                 setVariantFilterConfigs={setVariantConfigs}
                 emptyVariantFilterConfig={emptyVariantFilterConfig}
             />
-            <ApplyFilterButton onClick={routeToNewPage} />
+            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from 'react';
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
-import type { BaselineData } from '../../views/View.ts';
 import type { LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { sequencingEffortsViewKey } from '../../views/viewKeys.ts';
@@ -12,13 +11,11 @@ import type { sequencingEffortsViewKey } from '../../views/viewKeys.ts';
 export function SequencingEffortsPageStateSelector({
     locationFilterConfig,
     dateRangeFilterConfig,
-    pageState,
     organismViewKey,
     organismsConfig,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
-    pageState: BaselineData;
     organismViewKey: OrganismViewKey & `${string}.${typeof sequencingEffortsViewKey}`;
     organismsConfig: OrganismsConfig;
 }) {
@@ -26,17 +23,15 @@ export function SequencingEffortsPageStateSelector({
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
 
-    const routeToNewPage = () => {
-        const newPageState: BaselineData = {
-            ...pageState,
+    const newPageState = useMemo(
+        () => ({
             baselineFilter: {
                 location,
                 dateRange,
             },
-        };
-
-        window.location.href = view.pageStateHandler.toUrl(newPageState);
-    };
+        }),
+        [location, dateRange],
+    );
 
     return (
         <div className='flex flex-col gap-6 bg-gray-50 p-2'>
@@ -46,7 +41,7 @@ export function SequencingEffortsPageStateSelector({
                 onDateRangeChange={(dateRange) => setDateRange(dateRange)}
                 dateRangeFilterConfig={dateRangeFilterConfig}
             />
-            <ApplyFilterButton onClick={routeToNewPage} />
+            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -6,7 +6,6 @@ import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig
 import type { LineageFilterConfig } from './LineageFilterInput.tsx';
 import { type MutationFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
-import type { BaselineAndVariantData } from '../../views/View.ts';
 import { type LapisLocation, type LapisMutationQuery } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { singleVariantViewKey } from '../../views/viewKeys.ts';
@@ -18,7 +17,6 @@ export function SingleVariantPageStateSelector({
     lineageFilterConfigs,
     organismViewKey,
     organismsConfig,
-    pageState,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
@@ -26,7 +24,6 @@ export function SingleVariantPageStateSelector({
     lineageFilterConfigs: LineageFilterConfig[];
     organismViewKey: OrganismViewKey & `${string}.${typeof singleVariantViewKey}`;
     organismsConfig: OrganismsConfig;
-    pageState: BaselineAndVariantData;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
@@ -41,9 +38,8 @@ export function SingleVariantPageStateSelector({
 
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
 
-    const routeToNewPage = () => {
-        const newPageState: BaselineAndVariantData = {
-            ...pageState,
+    const newPageState = useMemo(
+        () => ({
             baselineFilter: {
                 location,
                 dateRange,
@@ -52,9 +48,9 @@ export function SingleVariantPageStateSelector({
                 mutations: { ...mutation },
                 lineages: { ...lineages },
             },
-        };
-        window.location.href = view.pageStateHandler.toUrl(newPageState);
-    };
+        }),
+        [location, dateRange, mutation, lineages],
+    );
 
     return (
         <div className='flex flex-col gap-6 bg-gray-50 p-2'>
@@ -77,7 +73,7 @@ export function SingleVariantPageStateSelector({
                     },
                 }))}
             />
-            <ApplyFilterButton onClick={routeToNewPage} />
+            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/rsv/RsvSequencingEffortsPage.astro
+++ b/website/src/components/rsv/RsvSequencingEffortsPage.astro
@@ -50,7 +50,6 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             earliestDate: view.organismConstants.earliestDate,
             dateColumn: view.organismConstants.mainDateField,
         }}
-        pageState={pageState}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -60,7 +60,6 @@ const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
         }}
         mutationFilterConfig={{ initialMutations: pageState.variantFilter.mutations }}
         lineageFilterConfigs={lineageFilterConfigs}
-        pageState={pageState}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'

--- a/website/src/pages/covid/sequencing-efforts.astro
+++ b/website/src/pages/covid/sequencing-efforts.astro
@@ -40,7 +40,6 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             earliestDate: view.organismConstants.earliestDate,
             dateColumn: view.organismConstants.mainDateField,
         }}
-        pageState={pageState}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -54,7 +54,6 @@ const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
             }}
             mutationFilterConfig={{ initialMutations: pageState.variantFilter.mutations }}
             lineageFilterConfigs={lineageFilterConfigs}
-            pageState={pageState}
             organismViewKey={organismViewKey}
             organismsConfig={getDashboardsConfig().dashboards.organisms}
             client:only='react'

--- a/website/src/pages/flu/h5n1/sequencing-efforts.astro
+++ b/website/src/pages/flu/h5n1/sequencing-efforts.astro
@@ -40,7 +40,6 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             earliestDate: view.organismConstants.earliestDate,
             dateColumn: view.organismConstants.mainDateField,
         }}
-        pageState={pageState}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'

--- a/website/src/pages/west-nile/sequencing-efforts.astro
+++ b/website/src/pages/west-nile/sequencing-efforts.astro
@@ -40,7 +40,6 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
             earliestDate: view.organismConstants.earliestDate,
             dateColumn: view.organismConstants.mainDateField,
         }}
-        pageState={pageState}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'


### PR DESCRIPTION

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
So that the browser displays a preview where it's going when hovering it. And previously the button was essentially a link, because onChange just set `window.location.href`. We can let the `<a>` tag do that.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/user-attachments/assets/b5a7289e-2a10-4d68-9042-26d0c2979ee0)
