### PR TITLE
feat(website): add fallback element for filters

### DIFF
--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -52,7 +52,7 @@ export function CompareVariantsPageStateSelector({
     }, [location, dateRange, variantConfigs]);
 
     return (
-        <div className='flex flex-col gap-6 bg-gray-50 p-2'>
+        <div className='flex flex-col gap-6'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <BaselineSelector

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -58,7 +58,7 @@ export function CompareVariantsToBaselineStateSelector({
     }, [variantConfigs, location, dateRange, baselineFilterConfigState]);
 
     return (
-        <div className='flex flex-col gap-6 bg-gray-50 p-2'>
+        <div className='flex flex-col gap-6'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <BaselineSelector

--- a/website/src/components/pageStateSelectors/FallbackElement.tsx
+++ b/website/src/components/pageStateSelectors/FallbackElement.tsx
@@ -1,0 +1,38 @@
+export function SequencingEffortsSelectorFallback() {
+    return <div className='h-[208px] lg:h-auto'></div>;
+}
+
+export function AnalyzeSingleVariantSelectorFallback() {
+    return <div className='h-[372px] lg:h-auto'></div>;
+}
+
+export function CompareSideBySideSelectorFallback({ numFilters }: { numFilters: number }) {
+    return (
+        <div>
+            {numFilters > 2 && <div className='h-[264px]' />}
+            {numFilters <= 2 && <div className='h-[220px]' />}
+        </div>
+    );
+}
+
+export function CompareToBaselineSelectorFallback({ numFilters }: { numFilters: number }) {
+    return (
+        <>
+            <div className='h-[460px] lg:h-auto'></div>
+            {Array.from({ length: numFilters }).map((_, index) => (
+                <div key={index} className='h-[156px] lg:h-auto'></div>
+            ))}
+        </>
+    );
+}
+
+export function CompareVariantsSelectorFallback({ numFilters }: { numFilters: number }) {
+    return (
+        <>
+            <div className='h-[296px] lg:h-auto'></div>
+            {Array.from({ length: numFilters }).map((_, index) => (
+                <div key={index} className='h-[156px] lg:h-auto'></div>
+            ))}
+        </>
+    );
+}

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -35,7 +35,7 @@ export function SequencingEffortsPageStateSelector({
     );
 
     return (
-        <div className='flex flex-col gap-6 bg-gray-50 p-2'>
+        <div className='flex flex-col gap-6'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <BaselineSelector

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -43,7 +43,7 @@ export function SingleVariantPageStateSelector({
     );
 
     return (
-        <div className='flex flex-col gap-6 bg-gray-50 p-2'>
+        <div className='flex flex-col gap-6'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <BaselineSelector

--- a/website/src/components/rsv/RsvSequencingEffortsPage.astro
+++ b/website/src/components/rsv/RsvSequencingEffortsPage.astro
@@ -10,6 +10,7 @@ import { getLocationSubdivision } from '../../views/helpers';
 import type { OrganismViewKey } from '../../views/routing';
 import { ServerSide } from '../../views/serverSideRouting';
 import { sequencingEffortsViewKey } from '../../views/viewKeys';
+import { SequencingEffortsSelectorFallback } from '../pageStateSelectors/FallbackElement';
 import { SequencingEffortsPageStateSelector } from '../pageStateSelectors/SequencingEffortsPageStateSelector';
 
 interface Props {
@@ -51,7 +52,9 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-    />
+    >
+        <SequencingEffortsSelectorFallback slot='fallback' />
+    </SequencingEffortsPageStateSelector>
 
     <ComponentsGrid slot='dataDisplay'>
         <ComponentWrapper title='Number sequences' height='600px'>

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -13,6 +13,7 @@ import { singleVariantViewKey } from '../../../views/viewKeys';
 import ComponentHeadline from '../../ComponentHeadline.astro';
 import ComponentWrapper from '../../ComponentWrapper.astro';
 import ComponentsGrid from '../../ComponentsGrid.astro';
+import { AnalyzeSingleVariantSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 import { SingleVariantPageStateSelector } from '../../pageStateSelectors/SingleVariantPageStateSelector';
 
 interface Props {
@@ -66,7 +67,9 @@ const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-    />
+    >
+        <AnalyzeSingleVariantSelectorFallback slot='fallback' />
+    </SingleVariantPageStateSelector>
 
     {
         noVariantSelected ? (

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -9,6 +9,7 @@ import { ServerSide } from '../../../views/serverSideRouting';
 import { compareSideBySideViewKey } from '../../../views/viewKeys';
 import ComponentWrapper from '../../ComponentWrapper.astro';
 import { CompareSideBySidePageStateSelector } from '../../pageStateSelectors/CompareSideBySidePageStateSelector';
+import { CompareSideBySideSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 
 interface Props {
     organism: Organism;
@@ -75,7 +76,12 @@ const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
                                     client:only='react'
-                                />
+                                >
+                                    <CompareSideBySideSelectorFallback
+                                        slot='fallback'
+                                        numFilters={pageState.filters.size}
+                                    />
+                                </CompareSideBySidePageStateSelector>
                             </div>
 
                             <ComponentWrapper title='Prevalence over time'>

--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
@@ -10,6 +10,7 @@ import { compareToBaselineViewKey } from '../../../views/viewKeys';
 import ComponentWrapper from '../../ComponentWrapper.astro';
 import ComponentsGrid from '../../ComponentsGrid.astro';
 import { CompareVariantsToBaselineStateSelector } from '../../pageStateSelectors/CompareVariantsToBaselineStateSelector';
+import { CompareToBaselineSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 
 interface Props {
     organism: Organism;
@@ -52,7 +53,9 @@ const numeratorLapisFilters = view.pageStateHandler.variantFiltersToNamedLapisFi
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-    />
+    >
+        <CompareToBaselineSelectorFallback slot='fallback' numFilters={numeratorLapisFilters.length} />
+    </CompareVariantsToBaselineStateSelector>
     <ComponentsGrid slot='dataDisplay'>
         <ComponentWrapper title='Prevalence over time'>
             <gs-prevalence-over-time

--- a/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
+++ b/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
@@ -11,6 +11,7 @@ import { compareVariantsViewKey } from '../../../views/viewKeys';
 import ComponentWrapper from '../../ComponentWrapper.astro';
 import ComponentsGrid from '../../ComponentsGrid.astro';
 import { CompareVariantsPageStateSelector } from '../../pageStateSelectors/CompareVariantsPageStateSelector';
+import { CompareVariantsSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 
 interface Props {
     organism: Organism;
@@ -53,7 +54,9 @@ const notEnoughVariantsSelected = pageState.variants.size < 2;
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-    />
+    >
+        <CompareVariantsSelectorFallback slot='fallback' numFilters={numeratorLapisFilters.length} />
+    </CompareVariantsPageStateSelector>
     {
         notEnoughVariantsSelected ? (
             <SelectVariants slot='dataDisplay' />

--- a/website/src/layouts/OrganismPage/SingleVariantOrganismPageLayout.astro
+++ b/website/src/layouts/OrganismPage/SingleVariantOrganismPageLayout.astro
@@ -13,7 +13,9 @@ const { view } = Astro.props;
 <OrganismPageLayout view={view}>
     <gs-app lapis={getLapisUrl(view.organismConstants.organism)}>
         <div class='grid-cols-[300px_1fr] gap-x-4 lg:grid'>
-            <slot name='filters' />
+            <div class='h-fit bg-gray-50 p-2'>
+                <slot name='filters' />
+            </div>
             <slot name='dataDisplay' />
         </div>
     </gs-app>

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -1,6 +1,7 @@
 ---
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import { CompareSideBySidePageStateSelector } from '../../components/pageStateSelectors/CompareSideBySidePageStateSelector';
+import { CompareSideBySideSelectorFallback } from '../../components/pageStateSelectors/FallbackElement';
 import { getDashboardsConfig, getLapisUrl } from '../../config';
 import OrganismPageLayout from '../../layouts/OrganismPage/OrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
@@ -69,7 +70,12 @@ const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
                                     client:only='react'
-                                />
+                                >
+                                    <CompareSideBySideSelectorFallback
+                                        slot='fallback'
+                                        numFilters={pageState.filters.size}
+                                    />
+                                </CompareSideBySidePageStateSelector>
                             </div>
 
                             <ComponentWrapper title='Prevalence over time'>

--- a/website/src/pages/covid/sequencing-efforts.astro
+++ b/website/src/pages/covid/sequencing-efforts.astro
@@ -1,6 +1,7 @@
 ---
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
+import { SequencingEffortsSelectorFallback } from '../../components/pageStateSelectors/FallbackElement';
 import { SequencingEffortsPageStateSelector } from '../../components/pageStateSelectors/SequencingEffortsPageStateSelector';
 import { getDashboardsConfig } from '../../config';
 import SingleVariantOrganismPageLayout from '../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
@@ -43,7 +44,9 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-    />
+    >
+        <SequencingEffortsSelectorFallback slot='fallback' />
+    </SequencingEffortsPageStateSelector>
 
     <ComponentsGrid slot='dataDisplay'>
         <ComponentWrapper title='Number sequences' height='600px'>

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -2,6 +2,7 @@
 import ComponentHeadline from '../../components/ComponentHeadline.astro';
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
+import { AnalyzeSingleVariantSelectorFallback } from '../../components/pageStateSelectors/FallbackElement';
 import { SingleVariantPageStateSelector } from '../../components/pageStateSelectors/SingleVariantPageStateSelector';
 import { CollectionsList } from '../../components/views/analyzeSingleVariant/CollectionsList';
 import SelectVariant from '../../components/views/analyzeSingleVariant/SelectVariant.astro';
@@ -39,7 +40,7 @@ const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
 ---
 
 <SingleVariantOrganismPageLayout view={view}>
-    <div class='bg-gray-50' slot='filters'>
+    <div slot='filters'>
         <SingleVariantPageStateSelector
             locationFilterConfig={{
                 locationFields: view.organismConstants.locationFields,
@@ -59,7 +60,9 @@ const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
             organismViewKey={organismViewKey}
             organismsConfig={getDashboardsConfig().dashboards.organisms}
             client:only='react'
-        />
+        >
+            <AnalyzeSingleVariantSelectorFallback slot='fallback' />
+        </SingleVariantPageStateSelector>
         <div class='p-2'>
             <h2 class='my-2'>Or select a known variant:</h2>
             <CollectionsList

--- a/website/src/pages/flu/h5n1/sequencing-efforts.astro
+++ b/website/src/pages/flu/h5n1/sequencing-efforts.astro
@@ -1,6 +1,7 @@
 ---
 import ComponentWrapper from '../../../components/ComponentWrapper.astro';
 import ComponentsGrid from '../../../components/ComponentsGrid.astro';
+import { SequencingEffortsSelectorFallback } from '../../../components/pageStateSelectors/FallbackElement';
 import { SequencingEffortsPageStateSelector } from '../../../components/pageStateSelectors/SequencingEffortsPageStateSelector';
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
@@ -43,7 +44,9 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-    />
+    >
+        <SequencingEffortsSelectorFallback slot='fallback' />
+    </SequencingEffortsPageStateSelector>
 
     <ComponentsGrid slot='dataDisplay'>
         <ComponentWrapper title='Number sequences' height='600px'>

--- a/website/src/pages/west-nile/sequencing-efforts.astro
+++ b/website/src/pages/west-nile/sequencing-efforts.astro
@@ -1,6 +1,7 @@
 ---
 import ComponentWrapper from '../../components/ComponentWrapper.astro';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
+import { SequencingEffortsSelectorFallback } from '../../components/pageStateSelectors/FallbackElement';
 import { SequencingEffortsPageStateSelector } from '../../components/pageStateSelectors/SequencingEffortsPageStateSelector';
 import { getDashboardsConfig } from '../../config';
 import SingleVariantOrganismPageLayout from '../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
@@ -43,7 +44,9 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-    />
+    >
+        <SequencingEffortsSelectorFallback slot='fallback' />
+    </SequencingEffortsPageStateSelector>
 
     <ComponentsGrid slot='dataDisplay'>
         <ComponentWrapper title='Number sequences' height='600px'>


### PR DESCRIPTION
Resolves #363

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Adds a fallback to our client-side loaded PageStateSelectors. The page now show not shift anylonger. 

Know issues:
  - the mutation filter expands when there are mutations selected. It is hard to compensate for that
  - the covid collections are of different size. They therefore shift the other elements. However, on the analyze single variant page, this does not show so prominent, since the filter covers almost the whole screen on mobile.

### Screenshot

While loading:
![grafik](https://github.com/user-attachments/assets/b0bd9472-fcf3-4544-a322-c32fae6b6f69)

When finished loading:
![grafik](https://github.com/user-attachments/assets/1e622632-a290-4ca9-9289-7f8b30fc6b7f)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
