### PR TITLE
395 bring back mpox pages

### DIFF
--- a/backend/src/main/resources/application-dashboards-dev.yaml
+++ b/backend/src/main/resources/application-dashboards-dev.yaml
@@ -34,11 +34,11 @@ dashboards:
           menuIcon: "database"
     mpox:
       lapis:
-        url: "https://gs-staging-1.int.genspectrum.org/mpox"
-        mainDateField: "sampleCollectionDate"
+        url: "https://lapis.pathoplexus.org/mpox"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
-          - "country"
-          - "division"
+          - "geoLocCountry"
+          - "geoLocAdmin1"
         hostField: "hostNameScientific"
         authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
@@ -46,7 +46,7 @@ dashboards:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
       externalNavigationLinks:
-        - url: "https://loculus.staging.genspectrum.org/mpox"
+        - url: "https://pathoplexus.org/mpox"
           label: "Browse data"
           menuIcon: "database"
     westNile:

--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -34,11 +34,11 @@ dashboards:
           menuIcon: "database"
     mpox:
       lapis:
-        url: "https://api.loculus.genspectrum.org/mpox"
-        mainDateField: "sampleCollectionDate"
+        url: "https://lapis.pathoplexus.org/mpox"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
-          - "country"
-          - "division"
+          - "geoLocCountry"
+          - "geoLocAdmin1"
         hostField: "hostNameScientific"
         authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
@@ -46,7 +46,7 @@ dashboards:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
       externalNavigationLinks:
-        - url: "https://loculus.genspectrum.org/mpox"
+        - url: "https://pathoplexus.org/mpox"
           label: "Browse data"
           menuIcon: "database"
     westNile:

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -34,11 +34,11 @@ dashboards:
           menuIcon: "database"
     mpox:
       lapis:
-        url: "https://api.loculus.staging.genspectrum.org/mpox"
-        mainDateField: "sampleCollectionDate"
+        url: "https://lapis.pathoplexus.org/mpox"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
-          - "country"
-          - "division"
+          - "geoLocCountry"
+          - "geoLocAdmin1"
         hostField: "hostNameScientific"
         authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
@@ -46,7 +46,7 @@ dashboards:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
       externalNavigationLinks:
-        - url: "https://loculus.staging.genspectrum.org/mpox"
+        - url: "https://pathoplexus.org/mpox"
           label: "Browse data"
           menuIcon: "database"
     westNile:

--- a/website/src/pages/covid/index.astro
+++ b/website/src/pages/covid/index.astro
@@ -1,5 +1,7 @@
 ---
 import { ServerSide } from '../../views/serverSideRouting';
 
-return Astro.redirect(ServerSide.routing.getOrganismView('covid.singleVariantView').getDefaultPageUrl());
+return Astro.redirect(
+    ServerSide.routing.getOrganismView('covid.singleVariantView').pageStateHandler.getDefaultPageUrl(),
+);
 ---

--- a/website/src/pages/data.astro
+++ b/website/src/pages/data.astro
@@ -43,8 +43,8 @@ import { Page } from '../types/pages';
                 >, we have an instance which uses data from <a href='https://gisaid.org'>GISAID</a>.)
             </li>
             <li>
-                For the West Nile virus, we use data from <a href='https://pathoplexus.org'>Pathoplexus</a>, which also
-                includes data from INSDC.
+                For the West Nile virus and Mpox, we use data from <a href='https://pathoplexus.org'>Pathoplexus</a>,
+                which also includes data from INSDC.
             </li>
         </ul>
         <p>
@@ -53,6 +53,7 @@ import { Page } from '../types/pages';
         </p>
         <ul class='ml-6 list-disc'>
             <li>SARS-CoV-2: <a href='https://www.ncbi.nlm.nih.gov/nuccore/NC_045512'>NC_045512</a></li>
+            <li>Mpox: <a href='https://www.ncbi.nlm.nih.gov/nuccore/NC_063383.1'>NC_063383.1</a></li>
             <li>
                 RSV-A: EPI_ISL_412866 (available on <a href='https://gisaid.org'>GISAID</a>; an almost identical
                 sequences is <a href='https://www.ncbi.nlm.nih.gov/nuccore/LR699737'>LR699737</a>)

--- a/website/src/pages/flu/h5n1/index.astro
+++ b/website/src/pages/flu/h5n1/index.astro
@@ -1,5 +1,7 @@
 ---
 import { ServerSide } from '../../../views/serverSideRouting';
 
-return Astro.redirect(ServerSide.routing.getOrganismView('h5n1.singleVariantView').getDefaultPageUrl());
+return Astro.redirect(
+    ServerSide.routing.getOrganismView('h5n1.singleVariantView').pageStateHandler.getDefaultPageUrl(),
+);
 ---

--- a/website/src/pages/mpox/compare-side-by-side.astro
+++ b/website/src/pages/mpox/compare-side-by-side.astro
@@ -1,0 +1,6 @@
+---
+import GenericCompareSideBySidePage from '../../components/views/compareSideBySide/GenericCompareSideBySidePage.astro';
+import { Organisms } from '../../types/Organism';
+---
+
+<GenericCompareSideBySidePage organism={Organisms.mpox} />

--- a/website/src/pages/mpox/compare-to-baseline.astro
+++ b/website/src/pages/mpox/compare-to-baseline.astro
@@ -1,0 +1,6 @@
+---
+import GenericCompareToBaselinePage from '../../components/views/compareToBaseline/GenericCompareToBaselinePage.astro';
+import { Organisms } from '../../types/Organism';
+---
+
+<GenericCompareToBaselinePage organism={Organisms.mpox} />

--- a/website/src/pages/mpox/compare-variants.astro
+++ b/website/src/pages/mpox/compare-variants.astro
@@ -1,0 +1,6 @@
+---
+import GenericCompareVariantsPage from '../../components/views/compareVariants/GenericCompareVariantsPage.astro';
+import { Organisms } from '../../types/Organism';
+---
+
+<GenericCompareVariantsPage organism={Organisms.mpox} />

--- a/website/src/pages/mpox/index.astro
+++ b/website/src/pages/mpox/index.astro
@@ -1,0 +1,7 @@
+---
+import { ServerSide } from '../../views/serverSideRouting';
+
+return Astro.redirect(
+    ServerSide.routing.getOrganismView('mpox.singleVariantView').pageStateHandler.getDefaultPageUrl(),
+);
+---

--- a/website/src/pages/mpox/sequencing-efforts.astro
+++ b/website/src/pages/mpox/sequencing-efforts.astro
@@ -1,0 +1,127 @@
+---
+import ComponentWrapper from '../../components/ComponentWrapper.astro';
+import ComponentsGrid from '../../components/ComponentsGrid.astro';
+import { SequencingEffortsSelectorFallback } from '../../components/pageStateSelectors/FallbackElement';
+import { SequencingEffortsPageStateSelector } from '../../components/pageStateSelectors/SequencingEffortsPageStateSelector';
+import { getDashboardsConfig } from '../../config';
+import SingleVariantOrganismPageLayout from '../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
+import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
+import { defaultTablePageSize, pathoplexusGroupNameField } from '../../views/View';
+import { getLocationSubdivision } from '../../views/helpers';
+import type { OrganismViewKey } from '../../views/routing';
+import { ServerSide } from '../../views/serverSideRouting';
+
+const organismViewKey: OrganismViewKey = 'mpox.sequencingEffortsView';
+const view = ServerSide.routing.getOrganismView(organismViewKey);
+const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
+
+const datasetLapisFilter = view.pageStateHandler.toLapisFilter(pageState);
+
+const timeGranularity = chooseGranularityBasedOnDateRange(
+    pageState.datasetFilter.dateRange,
+    new Date(view.organismConstants.earliestDate),
+);
+const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
+    view.organismConstants.locationFields,
+    pageState.datasetFilter.location,
+);
+---
+
+<SingleVariantOrganismPageLayout view={view}>
+    <SequencingEffortsPageStateSelector
+        slot='filters'
+        locationFilterConfig={{
+            locationFields: view.organismConstants.locationFields,
+            initialLocation: pageState.datasetFilter.location,
+            placeholderText: 'Sampling location',
+        }}
+        dateRangeFilterConfig={{
+            initialDateRange: pageState.datasetFilter.dateRange,
+            dateRangeOptions: view.organismConstants.dateRangeOptions,
+            earliestDate: view.organismConstants.earliestDate,
+            dateColumn: view.organismConstants.mainDateField,
+        }}
+        organismViewKey={organismViewKey}
+        organismsConfig={getDashboardsConfig().dashboards.organisms}
+        client:only='react'
+    >
+        <SequencingEffortsSelectorFallback slot='fallback' />
+    </SequencingEffortsPageStateSelector>
+
+    <ComponentsGrid slot='dataDisplay'>
+        <ComponentWrapper title='Number sequences' height='600px'>
+            <gs-number-sequences-over-time
+                lapisFilter={JSON.stringify({
+                    displayName: '',
+                    lapisFilter: datasetLapisFilter,
+                })}
+                lapisDateField={view.organismConstants.mainDateField}
+                views='["bar", "line", "table"]'
+                pageSize={defaultTablePageSize}
+                width='100%'
+                height='100%'
+                granularity={timeGranularity}></gs-number-sequences-over-time>
+        </ComponentWrapper>
+        {
+            subdivisionField !== undefined && (
+                <ComponentWrapper title={subdivisionLabel} height='600px'>
+                    <gs-aggregate
+                        fields={JSON.stringify([subdivisionField])}
+                        filter={JSON.stringify(datasetLapisFilter)}
+                        pageSize={defaultTablePageSize}
+                        width='100%'
+                        height='100%'
+                    />
+                </ComponentWrapper>
+            )
+        }
+        <ComponentWrapper title='Hosts' height='600px'>
+            <gs-aggregate
+                fields={JSON.stringify([view.organismConstants.hostField])}
+                filter={JSON.stringify(datasetLapisFilter)}
+                pageSize={defaultTablePageSize}
+                width='100%'
+                height='100%'></gs-aggregate>
+        </ComponentWrapper>
+        <ComponentWrapper title='Pathoplexus submitting groups' height='600px'>
+            <gs-aggregate
+                fields={JSON.stringify([pathoplexusGroupNameField])}
+                filter={JSON.stringify(datasetLapisFilter)}
+                pageSize={defaultTablePageSize}
+                width='100%'
+                height='100%'></gs-aggregate>
+        </ComponentWrapper>
+        <ComponentWrapper title='Author affiliations' height='600px'>
+            <gs-aggregate
+                fields={JSON.stringify([view.organismConstants.authorAffiliationsField])}
+                filter={JSON.stringify(datasetLapisFilter)}
+                pageSize={defaultTablePageSize}
+                width='100%'
+                height='100%'></gs-aggregate>
+        </ComponentWrapper>
+        <ComponentWrapper title='Authors' height='600px'>
+            <gs-aggregate
+                fields={JSON.stringify([
+                    view.organismConstants.authorsField,
+                    view.organismConstants.authorAffiliationsField,
+                ])}
+                filter={JSON.stringify(datasetLapisFilter)}
+                pageSize={defaultTablePageSize}
+                width='100%'
+                height='100%'></gs-aggregate>
+        </ComponentWrapper>
+        {
+            view.organismConstants.additionalSequencingEffortsFields.map(({ label, fieldName }) => (
+                <ComponentWrapper title={label} height='300px'>
+                    <gs-aggregate
+                        fields={JSON.stringify([fieldName])}
+                        filter={JSON.stringify(datasetLapisFilter)}
+                        pageSize={defaultTablePageSize}
+                        width='100%'
+                        height='100%'
+                    />
+                </ComponentWrapper>
+            ))
+        }
+    </ComponentsGrid>
+</SingleVariantOrganismPageLayout>

--- a/website/src/pages/mpox/single-variant.astro
+++ b/website/src/pages/mpox/single-variant.astro
@@ -1,0 +1,6 @@
+---
+import GenericAnalyzeSingleVariantPage from '../../components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro';
+import { Organisms } from '../../types/Organism';
+---
+
+<GenericAnalyzeSingleVariantPage organism={Organisms.mpox} />

--- a/website/src/pages/rsv-a/index.astro
+++ b/website/src/pages/rsv-a/index.astro
@@ -1,5 +1,7 @@
 ---
 import { ServerSide } from '../../views/serverSideRouting';
 
-return Astro.redirect(ServerSide.routing.getOrganismView('rsvA.singleVariantView').getDefaultPageUrl());
+return Astro.redirect(
+    ServerSide.routing.getOrganismView('rsvA.singleVariantView').pageStateHandler.getDefaultPageUrl(),
+);
 ---

--- a/website/src/pages/rsv-b/index.astro
+++ b/website/src/pages/rsv-b/index.astro
@@ -1,4 +1,6 @@
 ---
 import { ServerSide } from '../../views/serverSideRouting';
-return Astro.redirect(ServerSide.routing.getOrganismView('rsvB.singleVariantView').getDefaultPageUrl());
+return Astro.redirect(
+    ServerSide.routing.getOrganismView('rsvB.singleVariantView').pageStateHandler.getDefaultPageUrl(),
+);
 ---

--- a/website/src/pages/west-nile/index.astro
+++ b/website/src/pages/west-nile/index.astro
@@ -1,5 +1,7 @@
 ---
 import { ServerSide } from '../../views/serverSideRouting';
 
-return Astro.redirect(ServerSide.routing.getOrganismView('westNile.singleVariantView').getDefaultPageUrl());
+return Astro.redirect(
+    ServerSide.routing.getOrganismView('westNile.singleVariantView').pageStateHandler.getDefaultPageUrl(),
+);
 ---

--- a/website/src/types/Organism.ts
+++ b/website/src/types/Organism.ts
@@ -6,6 +6,7 @@ export const Organisms = {
     westNile: 'westNile' as const,
     rsvA: 'rsvA' as const,
     rsvB: 'rsvB' as const,
+    mpox: 'mpox' as const,
 };
 
 export const organismConfig = {
@@ -53,6 +54,15 @@ export const organismConfig = {
         backgroundColorFocus: 'group-hover:bg-purple',
         menuListEntryDecoration: 'hover:decoration-purple',
         borderEntryDecoration: 'hover:border-purple',
+    },
+    [Organisms.mpox]: {
+        organism: Organisms.mpox,
+        pathFragment: 'mpox',
+        label: 'Mpox',
+        backgroundColor: 'bg-roseMuted',
+        backgroundColorFocus: 'group-hover:bg-rose',
+        menuListEntryDecoration: 'hover:decoration-rose',
+        borderEntryDecoration: 'hover:border-rose',
     },
 };
 export const allOrganisms = Object.keys(organismConfig) as Organism[];

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -23,7 +23,7 @@ import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBy
 import { type PageStateHandler } from './pageStateHandlers/PageStateHandler.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
-import type { DataOrigin } from '../types/dataOrigins.ts';
+import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { SequencingEffortsStateHandler } from './pageStateHandlers/SequencingEffortsPageStateHandler.ts';
 import { SingleVariantPageStateHandler } from './pageStateHandlers/SingleVariantPageStateHandler.ts';
 
@@ -60,7 +60,7 @@ class CovidConstants implements SingleVariantConstants {
     public readonly originatingLabField: string | undefined;
     public readonly submittingLabField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
-    public readonly dataOrigins: DataOrigin[] = ['nextstrain'];
+    public readonly dataOrigins: DataOrigin[] = [dataOrigins.nextstrain];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.covid.lapis.mainDateField;

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -13,7 +13,7 @@ import type { SingleVariantConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
-import type { DataOrigin } from '../types/dataOrigins.ts';
+import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 
 const earliestDate = '1905-01-01';
@@ -49,7 +49,7 @@ class H5n1Constants implements SingleVariantConstants {
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
-    public readonly dataOrigins: DataOrigin[] = ['insdc'];
+    public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.h5n1.lapis.mainDateField;

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -1,7 +1,7 @@
 import { type DateRangeOption, dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';
 
 import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
-import type { OrganismsConfig } from '../config.ts';
+import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
     GenericCompareToBaselineView,
@@ -16,22 +16,25 @@ import { organismConfig, Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 
-class RsvAConstants implements SingleVariantConstants {
-    public readonly organism = Organisms.rsvA;
+class MpoxConstants implements SingleVariantConstants {
+    public readonly organism = Organisms.mpox;
+    public readonly earliestDate = '1960-01-01';
     public readonly defaultDateRange = dateRangeOptionPresets.lastYear;
-    public readonly earliestDate = '1956-01-01';
     public readonly dateRangeOptions: DateRangeOption[] = [
         dateRangeOptionPresets.lastMonth,
         dateRangeOptionPresets.last2Months,
         dateRangeOptionPresets.last3Months,
         dateRangeOptionPresets.last6Months,
         dateRangeOptionPresets.lastYear,
-        { label: 'Since 2020', dateFrom: '2020-01-01' },
-        { label: '2010-2019', dateFrom: '2010-01-01', dateTo: '2019-12-31' },
-        { label: '2000-2009', dateFrom: '2000-01-01', dateTo: '2009-12-31' },
-        { label: 'Since 2000', dateFrom: '2000-01-01' },
-        { label: 'Before 2000', dateFrom: this.earliestDate, dateTo: '1999-12-31' },
-        { label: 'All times', dateFrom: this.earliestDate },
+        { label: '2024', dateFrom: '2024-01-01' },
+        { label: '2023', dateFrom: '2023-01-01', dateTo: '2023-12-31' },
+        { label: '2022', dateFrom: '2022-01-01', dateTo: '2022-12-31' },
+        { label: '2021', dateFrom: '2021-01-01', dateTo: '2021-12-31' },
+        { label: 'Since 2021', dateFrom: '2021-01-01' },
+        { label: 'Before 2021', dateFrom: this.earliestDate, dateTo: '2020-12-31' },
+        { label: 'Since 2017', dateFrom: '2017-01-01' },
+        { label: '2017-2020', dateFrom: '2017-01-01', dateTo: '2020-12-31' },
+        { label: 'Before 2017', dateFrom: this.earliestDate, dateTo: '2016-12-31' },
     ];
     public readonly mainDateField: string;
     public readonly locationFields: string[];
@@ -42,36 +45,50 @@ class RsvAConstants implements SingleVariantConstants {
             filterType: 'text' as const,
             initialValue: undefined,
         },
+        {
+            lapisField: 'clade',
+            placeholderText: 'Clade',
+            filterType: 'text' as const,
+            initialValue: undefined,
+        },
     ];
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
+    public readonly additionalSequencingEffortsFields = [
+        { label: 'Collection device', fieldName: 'collectionDevice' },
+        { label: 'Collection method', fieldName: 'collectionMethod' },
+        { label: 'Purpose of sampling', fieldName: 'purposeOfSampling' },
+        { label: 'Sample type', fieldName: 'sampleType' },
+        { label: 'Amplicon PCR primer scheme', fieldName: 'ampliconPcrPrimerScheme' },
+        { label: 'Sequencing protocol', fieldName: 'sequencingProtocol' },
+    ];
     public readonly additionalFilters: Record<string, string> | undefined;
-    public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
+    public readonly dataOrigins: DataOrigin[] = [dataOrigins.pathoplexus];
 
     constructor(organismsConfig: OrganismsConfig) {
-        this.mainDateField = organismsConfig.rsvA.lapis.mainDateField;
-        this.locationFields = organismsConfig.rsvA.lapis.locationFields;
-        this.hostField = organismsConfig.rsvA.lapis.hostField;
-        this.authorsField = organismsConfig.rsvA.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.rsvA.lapis.authorAffiliationsField;
-        this.additionalFilters = organismsConfig.rsvA.lapis.additionalFilters;
+        this.mainDateField = organismsConfig.mpox.lapis.mainDateField;
+        this.locationFields = organismsConfig.mpox.lapis.locationFields;
+        this.hostField = organismsConfig.mpox.lapis.hostField;
+        this.authorsField = organismsConfig.mpox.lapis.authorsField;
+        this.authorAffiliationsField = organismsConfig.mpox.lapis.authorAffiliationsField;
+        this.additionalFilters = organismsConfig.mpox.lapis.additionalFilters;
     }
 }
 
-export class RsvAAnalyzeSingleVariantView extends GenericSingleVariantView<RsvAConstants> {
+export class MpoxAnalyzeSingleVariantView extends GenericSingleVariantView<MpoxConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvAConstants(organismsConfig));
+        super(new MpoxConstants(organismsConfig));
     }
 }
 
-export class RsvACompareSideBySideView extends BaseView<
+export class MpoxCompareSideBySideView extends BaseView<
     CompareSideBySideData,
-    RsvAConstants,
+    MpoxConstants,
     GenericCompareSideBySideStateHandler
 > {
     constructor(organismsConfig: OrganismsConfig) {
-        const constants = new RsvAConstants(organismsConfig);
+        const constants = new MpoxConstants(organismsConfig);
         const defaultPageState = {
             filters: new Map<Id, DatasetAndVariantData>([
                 [
@@ -82,7 +99,9 @@ export class RsvACompareSideBySideView extends BaseView<
                             dateRange: constants.defaultDateRange,
                         },
                         variantFilter: {
-                            lineages: {},
+                            lineages: {
+                                lineage: 'F.1',
+                            },
                             mutations: {},
                         },
                     },
@@ -96,7 +115,7 @@ export class RsvACompareSideBySideView extends BaseView<
                         },
                         variantFilter: {
                             lineages: {
-                                lineage: 'A.D.5.2',
+                                lineage: 'F.2',
                             },
                             mutations: {},
                         },
@@ -117,20 +136,20 @@ export class RsvACompareSideBySideView extends BaseView<
     }
 }
 
-export class RsvASequencingEffortsView extends GenericSequencingEffortsView<RsvAConstants> {
+export class MpoxSequencingEffortsView extends GenericSequencingEffortsView<MpoxConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvAConstants(organismsConfig));
+        super(new MpoxConstants(organismsConfig));
     }
 }
 
-export class RsvACompareVariantsView extends GenericCompareVariantsView<RsvAConstants> {
+export class MpoxCompareVariantsView extends GenericCompareVariantsView<MpoxConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvAConstants(organismsConfig));
+        super(new MpoxConstants(organismsConfig));
     }
 }
 
-export class RsvACompareToBaselineView extends GenericCompareToBaselineView<RsvAConstants> {
+export class MpoxCompareToBaselineView extends GenericCompareToBaselineView<MpoxConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvAConstants(organismsConfig));
+        super(new MpoxConstants(organismsConfig));
     }
 }

--- a/website/src/views/routing.ts
+++ b/website/src/views/routing.ts
@@ -14,6 +14,13 @@ import {
     H5n1CompareVariantsView,
     H5n1SequencingEffortsView,
 } from './h5n1.ts';
+import {
+    MpoxAnalyzeSingleVariantView,
+    MpoxCompareSideBySideView,
+    MpoxCompareToBaselineView,
+    MpoxCompareVariantsView,
+    MpoxSequencingEffortsView,
+} from './mpox.ts';
 import type { PageStateHandler } from './pageStateHandlers/PageStateHandler.ts';
 import {
     RsvAAnalyzeSingleVariantView,
@@ -100,6 +107,13 @@ export class Routing {
                 [compareVariantsViewKey]: new WestNileCompareVariantsView(organismsConfig),
                 [compareToBaselineViewKey]: new WestNileCompareToBaselineView(organismsConfig),
             },
+            [Organisms.mpox]: {
+                [singleVariantViewKey]: new MpoxAnalyzeSingleVariantView(organismsConfig),
+                [compareSideBySideViewKey]: new MpoxCompareSideBySideView(organismsConfig),
+                [sequencingEffortsViewKey]: new MpoxSequencingEffortsView(organismsConfig),
+                [compareVariantsViewKey]: new MpoxCompareVariantsView(organismsConfig),
+                [compareToBaselineViewKey]: new MpoxCompareToBaselineView(organismsConfig),
+            },
         } as const;
 
         this.externalPages = this.initializeExternalPages(organismsConfig);
@@ -117,6 +131,8 @@ export class Routing {
                 return Object.values(this.views[Organisms.rsvB]);
             case Organisms.westNile:
                 return Object.values(this.views[Organisms.westNile]);
+            case Organisms.mpox:
+                return Object.values(this.views[Organisms.mpox]);
         }
     }
 

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -13,7 +13,7 @@ import type { SingleVariantConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
-import type { DataOrigin } from '../types/dataOrigins.ts';
+import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 
 class RsvBConstants implements SingleVariantConstants {
@@ -47,7 +47,7 @@ class RsvBConstants implements SingleVariantConstants {
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
-    public readonly dataOrigins: DataOrigin[] = ['insdc'];
+    public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.rsvB.lapis.mainDateField;

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -13,7 +13,7 @@ import type { SingleVariantConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
-import type { DataOrigin } from '../types/dataOrigins.ts';
+import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 
 class WestNileConstants implements SingleVariantConstants {
@@ -55,7 +55,7 @@ class WestNileConstants implements SingleVariantConstants {
         { label: 'Sequencing protocol', fieldName: 'sequencingProtocol' },
     ];
     public readonly additionalFilters: Record<string, string> | undefined;
-    public readonly dataOrigins: DataOrigin[] = ['pathoplexus'];
+    public readonly dataOrigins: DataOrigin[] = [dataOrigins.pathoplexus];
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.westNile.lapis.mainDateField;

--- a/website/tests/compareVariants.spec.ts
+++ b/website/tests/compareVariants.spec.ts
@@ -9,6 +9,7 @@ const organismOptions = {
     [Organisms.westNile]: { lineage: '2', lineageFieldPlaceholder: 'Lineage' },
     [Organisms.rsvA]: { lineage: 'A.D.5.2', lineageFieldPlaceholder: 'Lineage' },
     [Organisms.rsvB]: { lineage: 'B.D.E.1', lineageFieldPlaceholder: 'Lineage' },
+    [Organisms.mpox]: { lineage: 'F.1', lineageFieldPlaceholder: 'Lineage' },
 };
 
 test.describe('The Compare Variants page', () => {

--- a/website/tests/mainPage.spec.ts
+++ b/website/tests/mainPage.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-const organisms = ['SARS-CoV-2', 'Influenza A/H5N1', 'West Nile', 'RSV-A', 'RSV-B'];
+const organisms = ['SARS-CoV-2', 'Influenza A/H5N1', 'West Nile', 'RSV-A', 'RSV-B', 'Mpox'];
 const views = [
     {
         linkName: 'Analyze a single variant',


### PR DESCRIPTION
Resolves: #395

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary

Adds Mpox back to the list of organisms, with all views. Now uses the same sequencing efforts page as west-nile.

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
