### PR TITLE
fix(website): allow scrolling on mega menu

### DIFF
--- a/website/src/layouts/base/header/MegaMenu.tsx
+++ b/website/src/layouts/base/header/MegaMenu.tsx
@@ -5,7 +5,9 @@ import type { WithClassName } from '../../../types/WithClassName.ts';
 export function MegaMenu({ className, children }: PropsWithChildren<WithClassName>) {
     return (
         <div className={`absolute left-0 w-screen bg-white shadow-lg ${className}`}>
-            <ul className='grid grid-cols-2 gap-4 border-2 border-gray-100 p-8 xl:grid-cols-5'>{children}</ul>
+            <ul className='grid max-h-[80vh] grid-cols-2 gap-4 overflow-y-scroll overscroll-none border-2 border-gray-100 p-8 lg:grid-cols-3 xl:grid-cols-5'>
+                {children}
+            </ul>
         </div>
     );
 }

--- a/website/src/views/ViewConstants.ts
+++ b/website/src/views/ViewConstants.ts
@@ -14,9 +14,10 @@ export const singleVariantViewConstants = {
     iconType: 'magnify',
 } as const satisfies ViewConstants;
 
+export const nonBreakingHyphen = '\u2011';
 export const compareSideBySideViewConstants = {
-    label: 'Compare side-by-side',
-    labelLong: 'Compare variants side-by-side',
+    label: `Compare side${nonBreakingHyphen}by${nonBreakingHyphen}side`,
+    labelLong: `Compare variants side${nonBreakingHyphen}by${nonBreakingHyphen}side`,
     pathFragment: 'compare-side-by-side',
     iconType: 'table',
 } as const satisfies ViewConstants;

--- a/website/tests/mainPage.spec.ts
+++ b/website/tests/mainPage.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { nonBreakingHyphen } from '../src/views/ViewConstants.ts';
+
 const organisms = ['SARS-CoV-2', 'Influenza A/H5N1', 'West Nile', 'RSV-A', 'RSV-B', 'Mpox'];
 const views = [
     {
@@ -8,8 +10,8 @@ const views = [
         expectedHeadline: 'Analyze a single variant',
     },
     {
-        linkName: 'Compare variants side-by-side',
-        title: 'Compare side-by-side',
+        linkName: `Compare variants side${nonBreakingHyphen}by${nonBreakingHyphen}side`,
+        title: `Compare side${nonBreakingHyphen}by${nonBreakingHyphen}side`,
         expectedHeadline: 'Prevalence over time',
     },
     { linkName: 'Sequencing efforts', title: 'Sequencing efforts', expectedHeadline: 'Number sequences' },


### PR DESCRIPTION
Resolves: #402

### Summary

Now allows for a scrollable mega menu. Also adjust the columns of the mega menu.

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

Three column menu
![grafik](https://github.com/user-attachments/assets/9c7bb294-10f1-4392-8cdd-a803cdfed7fb)

Two column menu
![grafik](https://github.com/user-attachments/assets/54ec6915-3bc8-4538-9933-66331730e2f6)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
