### PR TITLE
fix(website): add required lapisDateField to relative growth advantage

### DIFF
--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -111,6 +111,7 @@ const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
                             pageSize={defaultTablePageSize}
                             width='100%'
                             height='100%'
+                            lapisDateField={view.organismConstants.mainDateField}
                         />
                     </ComponentWrapper>
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Otherwise, the component will show an error on the single variant page of covid.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
