### PR TITLE
feat(website): Allow each organism to not include all pages

### DIFF
--- a/website/.prettierrc
+++ b/website/.prettierrc
@@ -1,18 +1,18 @@
 {
-  "printWidth": 120,
-  "tabWidth": 4,
-  "trailingComma": "all",
-  "semi": true,
-  "jsxSingleQuote": true,
-  "singleQuote": true,
-  "quoteProps": "consistent",
-  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
-  "overrides": [
-    {
-      "files": "*.astro",
-      "options": {
-        "parser": "astro"
-      }
-    }
-  ]
+    "printWidth": 120,
+    "tabWidth": 4,
+    "trailingComma": "all",
+    "semi": true,
+    "jsxSingleQuote": true,
+    "singleQuote": true,
+    "quoteProps": "consistent",
+    "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
+    "overrides": [
+        {
+            "files": "*.astro",
+            "options": {
+                "parser": "astro"
+            }
+        }
+    ]
 }

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -2,12 +2,11 @@
 import SelectVariant from './SelectVariant.astro';
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
-import type { Organism } from '../../../types/Organism';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../../util/hasOnlyUndefinedValues';
 import { getLineageFilterConfigs, getLineageFilterFields } from '../../../views/View';
 import { getLocationSubdivision } from '../../../views/helpers';
-import { type OrganismViewKey } from '../../../views/routing';
+import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { singleVariantViewKey } from '../../../views/viewKeys';
 import ComponentHeadline from '../../ComponentHeadline.astro';
@@ -19,8 +18,9 @@ import GsPrevalenceOverTime from '../../genspectrum/GsPrevalenceOverTime.astro';
 import { AnalyzeSingleVariantSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 import { SingleVariantPageStateSelector } from '../../pageStateSelectors/SingleVariantPageStateSelector';
 
+type OrganismViewCompareVariant = OrganismWithViewKey<typeof singleVariantViewKey>;
 interface Props {
-    organism: Organism;
+    organism: OrganismViewCompareVariant;
 }
 
 const { organism } = Astro.props;

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -1,10 +1,9 @@
 ---
 import { getDashboardsConfig, getLapisUrl } from '../../../config';
 import OrganismPageLayout from '../../../layouts/OrganismPage/OrganismPageLayout.astro';
-import { type Organism } from '../../../types/Organism';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { getLineageFilterConfigs, getLineageFilterFields } from '../../../views/View';
-import { type OrganismViewKey } from '../../../views/routing';
+import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { compareSideBySideViewKey } from '../../../views/viewKeys';
 import GsAggregate from '../../genspectrum/GsAggregate.astro';
@@ -13,8 +12,9 @@ import GsPrevalenceOverTime from '../../genspectrum/GsPrevalenceOverTime.astro';
 import { CompareSideBySidePageStateSelector } from '../../pageStateSelectors/CompareSideBySidePageStateSelector';
 import { CompareSideBySideSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 
+type OrganismViewCompareVariant = OrganismWithViewKey<typeof compareSideBySideViewKey>;
 interface Props {
-    organism: Organism;
+    organism: OrganismViewCompareVariant;
 }
 
 const { organism } = Astro.props;

--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
@@ -1,9 +1,8 @@
 ---
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
-import type { Organism } from '../../../types/Organism';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
-import { type OrganismViewKey } from '../../../views/routing';
+import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { compareToBaselineViewKey } from '../../../views/viewKeys';
 import ComponentsGrid from '../../ComponentsGrid.astro';
@@ -11,8 +10,9 @@ import GsPrevalenceOverTime from '../../genspectrum/GsPrevalenceOverTime.astro';
 import { CompareVariantsToBaselineStateSelector } from '../../pageStateSelectors/CompareVariantsToBaselineStateSelector';
 import { CompareToBaselineSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 
+type OrganismViewCompareVariant = OrganismWithViewKey<typeof compareToBaselineViewKey>;
 interface Props {
-    organism: Organism;
+    organism: OrganismViewCompareVariant;
 }
 
 const { organism } = Astro.props;

--- a/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
+++ b/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
@@ -2,9 +2,8 @@
 import SelectVariants from './SelectVariants.astro';
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
-import type { Organism } from '../../../types/Organism';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
-import { type OrganismViewKey } from '../../../views/routing';
+import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { compareVariantsViewKey } from '../../../views/viewKeys';
 import ComponentsGrid from '../../ComponentsGrid.astro';
@@ -13,8 +12,9 @@ import GsPrevalenceOverTime from '../../genspectrum/GsPrevalenceOverTime.astro';
 import { CompareVariantsPageStateSelector } from '../../pageStateSelectors/CompareVariantsPageStateSelector';
 import { CompareVariantsSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 
+type OrganismViewCompareVariant = OrganismWithViewKey<typeof compareVariantsViewKey>;
 interface Props {
-    organism: Organism;
+    organism: OrganismViewCompareVariant;
 }
 
 const { organism } = Astro.props;

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -1,11 +1,10 @@
 ---
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
-import { type Organism } from '../../../types/Organism';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { ComponentHeight } from '../../../views/OrganismConstants';
 import { getLocationSubdivision } from '../../../views/helpers';
-import { type OrganismViewKey } from '../../../views/routing';
+import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { sequencingEffortsViewKey } from '../../../views/viewKeys';
 import ComponentsGrid from '../../ComponentsGrid.astro';
@@ -14,8 +13,9 @@ import GsNumberSequencesOverTime from '../../genspectrum/GsNumberSequencesOverTi
 import { SequencingEffortsSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 import { SequencingEffortsPageStateSelector } from '../../pageStateSelectors/SequencingEffortsPageStateSelector';
 
+type OrganismViewCompareVariant = OrganismWithViewKey<typeof sequencingEffortsViewKey>;
 interface Props {
-    organism: Organism;
+    organism: OrganismViewCompareVariant;
 }
 
 const { organism } = Astro.props;

--- a/website/src/views/routing.ts
+++ b/website/src/views/routing.ts
@@ -66,6 +66,9 @@ export type OrganismViewKey = {
     }[ViewKey<Organism>];
 }[keyof ViewsMap];
 
+type OrganismExtractor<T, ViewKey extends string> = T extends `${infer O}.${ViewKey}` ? O : never;
+export type OrganismWithViewKey<ViewKey extends string> = OrganismExtractor<OrganismViewKey, ViewKey>;
+
 export class Routing {
     public readonly views;
     public readonly externalPages;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Currently the generic view pages will error if an organism does not have that page - as the pages an organism has should be customizable we create a new organism subtype which includes all organisms with that specific view/page. 

Thanks @chaoran-chen for helping with this!

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
