### PR TITLE
feat(website): add compare to baseline landing page

### DIFF
--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
@@ -1,4 +1,5 @@
 ---
+import SelectBaseline from './SelectBaseline.astro';
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
@@ -31,6 +32,7 @@ const variantFilterConfigs = view.pageStateHandler.toVariantFilterConfigs(pageSt
 const baselineFilterConfig = view.pageStateHandler.toBaselineFilterConfig(pageState);
 
 const numeratorLapisFilters = view.pageStateHandler.variantFiltersToNamedLapisFilters(pageState);
+const noVariantSelected = pageState.variants.size < 1;
 ---
 
 <SingleVariantOrganismPageLayout view={view}>
@@ -55,13 +57,19 @@ const numeratorLapisFilters = view.pageStateHandler.variantFiltersToNamedLapisFi
     >
         <CompareToBaselineSelectorFallback slot='fallback' numFilters={numeratorLapisFilters.length} />
     </CompareVariantsToBaselineStateSelector>
-    <ComponentsGrid slot='dataDisplay'>
-        <GsPrevalenceOverTime
-            numeratorFilters={numeratorLapisFilters}
-            denominatorFilter={baselineLapisFilter}
-            lapisDateField={view.organismConstants.mainDateField}
-            granularity={timeGranularity}
-            views={['line', 'table', 'bar']}
-        />
-    </ComponentsGrid>
+    {
+        noVariantSelected ? (
+            <SelectBaseline slot='dataDisplay' />
+        ) : (
+            <ComponentsGrid slot='dataDisplay'>
+                <GsPrevalenceOverTime
+                    numeratorFilters={numeratorLapisFilters}
+                    denominatorFilter={baselineLapisFilter}
+                    lapisDateField={view.organismConstants.mainDateField}
+                    granularity={timeGranularity}
+                    views={['line', 'table', 'bar']}
+                />
+            </ComponentsGrid>
+        )
+    }
 </SingleVariantOrganismPageLayout>

--- a/website/src/components/views/compareToBaseline/SelectBaseline.astro
+++ b/website/src/components/views/compareToBaseline/SelectBaseline.astro
@@ -1,0 +1,18 @@
+---
+import { PageHeadline } from '../../../styles/containers/PageHeadline';
+---
+
+<div class='mx-4 mt-20 flex min-h-64 flex-col items-center'>
+    <PageHeadline>Analyze a variant compared to a baseline</PageHeadline>
+    <div class='max-w-xl'>
+        <p class='mb-2'>To proceed, please select a variant filter.</p>
+        <p>
+            If no baseline is selected all sequences will be used as a baseline for comparing against sequences with a
+            specified variant.{' '}
+            Note that the dataset filter is applied to the entire dataset including both the baseline and variant subsets.{
+                ' '
+            }
+            Adjust the dataset filter as needed to refine your selection.
+        </p>
+    </div>
+</div>

--- a/website/src/components/views/compareToBaseline/SelectBaseline.astro
+++ b/website/src/components/views/compareToBaseline/SelectBaseline.astro
@@ -8,11 +8,8 @@ import { PageHeadline } from '../../../styles/containers/PageHeadline';
         <p class='mb-2'>To proceed, please select a variant filter.</p>
         <p>
             If no baseline is selected all sequences will be used as a baseline for comparing against sequences with a
-            specified variant.{' '}
-            Note that the dataset filter is applied to the entire dataset including both the baseline and variant subsets.{
-                ' '
-            }
-            Adjust the dataset filter as needed to refine your selection.
+            specified variant. Note that the dataset filter is applied to the entire dataset including both the baseline
+            and variant subsets. Adjust the dataset filter as needed to refine your selection.
         </p>
     </div>
 </div>

--- a/website/tests/mainPage.spec.ts
+++ b/website/tests/mainPage.spec.ts
@@ -16,7 +16,11 @@ const views = [
     },
     { linkName: 'Sequencing efforts', title: 'Sequencing efforts', expectedHeadline: 'Number sequences' },
     { linkName: 'Compare variants', title: 'Compare variants', expectedHeadline: 'Compare Variants' },
-    { linkName: 'Compare to baseline', title: 'Compare to baseline', expectedHeadline: 'Analyze a variant compared to a baseline' },
+    {
+        linkName: 'Compare to baseline',
+        title: 'Compare to baseline',
+        expectedHeadline: 'Analyze a variant compared to a baseline',
+    },
 ];
 
 test.describe('Main page', () => {
@@ -37,6 +41,8 @@ test.describe('Main page', () => {
                     .locator('..')
                     .getByText(linkName, { exact: true })
                     .click();
+                await expect(page.locator('text=Error -')).not.toBeVisible();
+                await expect(page.locator('text=Something went wrong')).not.toBeVisible();
                 await expect(page).toHaveTitle(`${title} | ${organism} | GenSpectrum`);
                 await expect(page.getByRole('heading', { name: expectedHeadline }).first()).toBeVisible();
             }

--- a/website/tests/mainPage.spec.ts
+++ b/website/tests/mainPage.spec.ts
@@ -16,7 +16,7 @@ const views = [
     },
     { linkName: 'Sequencing efforts', title: 'Sequencing efforts', expectedHeadline: 'Number sequences' },
     { linkName: 'Compare variants', title: 'Compare variants', expectedHeadline: 'Compare Variants' },
-    { linkName: 'Compare to baseline', title: 'Compare to baseline', expectedHeadline: 'Prevalence over time' },
+    { linkName: 'Compare to baseline', title: 'Compare to baseline', expectedHeadline: 'Analyze a variant compared to a baseline' },
 ];
 
 test.describe('Main page', () => {

--- a/website/tests/sequencingEfforts.spec.ts
+++ b/website/tests/sequencingEfforts.spec.ts
@@ -21,6 +21,7 @@ test.describe('The Sequencing Efforts Page', () => {
                 const options = organismOptions[organism];
 
                 await sequencingEffortsPage.goto(organism);
+                await sequencingEffortsPage.expectToSeeNoComponentErrors();
                 await sequencingEffortsPage.selectLocation(options.location);
                 await sequencingEffortsPage.selectDateRange('All times');
                 await sequencingEffortsPage.submitFilters();


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves https://github.com/GenSpectrum/dashboards/issues/421

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Since the refactor a landing page is required for the compare baseline page - this PR adds a landing page with a description of the component to be shown when no variants are selected.
![image](https://github.com/user-attachments/assets/898f5e46-e7a1-45d4-a100-1a89625d8b50)

It additionally adds an e2e test to ensure no component can have an error on a page on first load. Confirmed this fails on the main page currently: 
![image](https://github.com/user-attachments/assets/864134ad-5466-4e7c-adb0-bb7e3d484dcb)



### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
