### PR TITLE
feat(website): add option to search by clades on sequencing efforts page

### DIFF
--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from 'react';
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
+import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
+import { VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
 import type { LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
@@ -12,15 +14,18 @@ import type { sequencingEffortsViewKey } from '../../views/viewKeys.ts';
 export function SequencingEffortsPageStateSelector({
     locationFilterConfig,
     dateRangeFilterConfig,
+    variantFilterConfig,
     organismViewKey,
     organismsConfig,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
+    variantFilterConfig: VariantFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof sequencingEffortsViewKey}`;
     organismsConfig: OrganismsConfig;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
+    const [variantFilterConfigState, setVariantFilterConfigState] = useState<VariantFilterConfig>(variantFilterConfig);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
 
@@ -30,8 +35,9 @@ export function SequencingEffortsPageStateSelector({
                 location,
                 dateRange,
             },
+            variantFilter: toVariantFilter(variantFilterConfigState),
         }),
-        [location, dateRange],
+        [location, dateRange, variantFilterConfigState],
     );
 
     return (
@@ -43,6 +49,13 @@ export function SequencingEffortsPageStateSelector({
                     locationFilterConfig={locationFilterConfig}
                     onDateRangeChange={(dateRange) => setDateRange(dateRange)}
                     dateRangeFilterConfig={dateRangeFilterConfig}
+                />
+            </div>
+            <div>
+                <VariantSelector
+                    onVariantFilterChange={setVariantFilterConfigState}
+                    variantFilterConfig={variantFilterConfigState}
+                    hideMutationFilter={true}
                 />
             </div>
             <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -6,9 +6,11 @@ import { GsMutationFilter } from '../genspectrum/GsMutationFilter.tsx';
 export function VariantSelector({
     onVariantFilterChange,
     variantFilterConfig,
+    hideMutationFilter,
 }: {
     variantFilterConfig: VariantFilterConfig;
     onVariantFilterChange: (variantFilter: VariantFilterConfig) => void;
+    hideMutationFilter?: boolean | undefined;
 }) {
     return (
         <div className='flex flex-col gap-2'>
@@ -29,19 +31,21 @@ export function VariantSelector({
                     key={lineageFilterConfig.lapisField}
                 />
             ))}
-            <GsMutationFilter
-                initialValue={getMutationFilter(variantFilterConfig.mutationFilterConfig)}
-                onMutationChange={(mutation) => {
-                    if (mutation === undefined) {
-                        return;
-                    }
-                    const newVariantFilterConfig = {
-                        ...variantFilterConfig,
-                        mutationFilterConfig: mutation,
-                    };
-                    onVariantFilterChange(newVariantFilterConfig);
-                }}
-            />
+            {!hideMutationFilter && (
+                <GsMutationFilter
+                    initialValue={getMutationFilter(variantFilterConfig.mutationFilterConfig)}
+                    onMutationChange={(mutation) => {
+                        if (mutation === undefined) {
+                            return;
+                        }
+                        const newVariantFilterConfig = {
+                            ...variantFilterConfig,
+                            mutationFilterConfig: mutation,
+                        };
+                        onVariantFilterChange(newVariantFilterConfig);
+                    }}
+                />
+            )}
         </div>
     );
 }

--- a/website/src/components/views/analyzeSingleVariant/CollectionsList.tsx
+++ b/website/src/components/views/analyzeSingleVariant/CollectionsList.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { z } from 'zod';
 
 import type { OrganismsConfig } from '../../../config.ts';
-import { type CovidAnalyzeSingleVariantData } from '../../../views/covid.ts';
+import { type CovidVariantData } from '../../../views/covid.ts';
 import { Routing } from '../../../views/routing.ts';
 import { withQueryProvider } from '../../subscriptions/backendApi/withQueryProvider.tsx';
 
@@ -104,7 +104,7 @@ function CollectionVariantList({ collection, organismsConfig }: CollectionVarian
         const currentPageState = routing
             .getOrganismView('covid.singleVariantView')
             .pageStateHandler.parsePageStateFromUrl(new URL(window.location.href));
-        let newPageState: CovidAnalyzeSingleVariantData;
+        let newPageState: CovidVariantData;
         const query = querySchema.parse(JSON.parse(variant.query));
         if (query.variantQuery !== undefined) {
             newPageState = {

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -15,9 +15,10 @@ import { CompareSideBySideSelectorFallback } from '../../pageStateSelectors/Fall
 type OrganismViewCompareVariant = OrganismWithViewKey<typeof compareSideBySideViewKey>;
 interface Props {
     organism: OrganismViewCompareVariant;
+    hideMutationFilter?: boolean;
 }
 
-const { organism } = Astro.props;
+const { organism, hideMutationFilter } = Astro.props;
 const organismViewKey = `${organism}.${compareSideBySideViewKey}` satisfies OrganismViewKey;
 const view = ServerSide.routing.getOrganismView(organismViewKey);
 
@@ -97,8 +98,12 @@ const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
                                 lapisDateField={view.organismConstants.mainDateField}
                                 granularity={timeGranularity}
                             />
-                            <GsMutations lapisFilter={numeratorFilter} sequenceType='nucleotide' />
-                            <GsMutations lapisFilter={numeratorFilter} sequenceType='amino acid' />
+                            {!hideMutationFilter && (
+                                <>
+                                    <GsMutations lapisFilter={numeratorFilter} sequenceType='nucleotide' />
+                                    <GsMutations lapisFilter={numeratorFilter} sequenceType='amino acid' />
+                                </>
+                            )}
                             <GsAggregate
                                 title='Sub-lineages'
                                 fields={getLineageFilterFields(view.organismConstants.lineageFilters)}

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -3,6 +3,7 @@ import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { ComponentHeight } from '../../../views/OrganismConstants';
+import { getLineageFilterConfigs, getLineageFilterFields } from '../../../views/View';
 import { getLocationDisplayConfig } from '../../../views/locationHelpers';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
@@ -22,10 +23,10 @@ interface Props {
 const { organism } = Astro.props;
 const organismViewKey: OrganismViewKey = `${organism}.${sequencingEffortsViewKey}` satisfies OrganismViewKey;
 const view = ServerSide.routing.getOrganismView(organismViewKey);
+
 const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
 
-const datasetLapisFilter = view.pageStateHandler.toLapisFilter(pageState);
-
+const variantLapisFilter = view.pageStateHandler.toLapisFilter(pageState);
 const timeGranularity = chooseGranularityBasedOnDateRange(
     pageState.datasetFilter.dateRange,
     new Date(view.organismConstants.earliestDate),
@@ -35,6 +36,10 @@ const {
     locationField,
     mapName,
 } = getLocationDisplayConfig(view.organismConstants.locationFields, pageState.datasetFilter.location);
+const lineageFilterConfigs = getLineageFilterConfigs(
+    view.organismConstants.lineageFilters,
+    pageState.variantFilter.lineages,
+);
 ---
 
 <SingleVariantOrganismPageLayout view={view}>
@@ -54,6 +59,7 @@ const {
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
+        variantFilterConfig={{ mutationFilterConfig: pageState.variantFilter.mutations, lineageFilterConfigs }}
     >
         <SequencingEffortsSelectorFallback slot='fallback' />
     </SequencingEffortsPageStateSelector>
@@ -63,7 +69,7 @@ const {
             lapisFilters={[
                 {
                     displayName: '',
-                    lapisFilter: datasetLapisFilter,
+                    lapisFilter: variantLapisFilter,
                 },
             ]}
             lapisDateField={view.organismConstants.mainDateField}
@@ -75,7 +81,7 @@ const {
                     title={locationLabel}
                     height={ComponentHeight.large}
                     lapisLocationField={locationField}
-                    lapisFilter={datasetLapisFilter}
+                    lapisFilter={variantLapisFilter}
                     mapName={mapName}
                 />
             )
@@ -84,11 +90,16 @@ const {
             title='Hosts'
             height={ComponentHeight.large}
             fields={[view.organismConstants.hostField]}
-            lapisFilter={datasetLapisFilter}
+            lapisFilter={variantLapisFilter}
+        />
+        <GsAggregate
+            title='Sub-lineages'
+            fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
+            lapisFilter={variantLapisFilter}
         />
         {
             view.organismConstants.additionalSequencingEffortsFields.map(({ label, fields, height }) => (
-                <GsAggregate title={label} height={height} fields={fields} lapisFilter={datasetLapisFilter} />
+                <GsAggregate title={label} height={height} fields={fields} lapisFilter={variantLapisFilter} />
             ))
         }
     </ComponentsGrid>

--- a/website/src/views/BaseView.ts
+++ b/website/src/views/BaseView.ts
@@ -1,5 +1,5 @@
-import type { OrganismConstants, SequencingEffortsConstants, SingleVariantConstants } from './OrganismConstants.ts';
-import type { CompareToBaselineData, CompareVariantsData, Dataset, DatasetAndVariantData, View } from './View.ts';
+import type { OrganismConstants, ExtendedConstants } from './OrganismConstants.ts';
+import type { CompareToBaselineData, CompareVariantsData, DatasetAndVariantData, View } from './View.ts';
 import {
     compareToBaselineViewConstants,
     compareVariantsViewConstants,
@@ -40,7 +40,7 @@ export abstract class BaseView<
     }
 }
 
-export class GenericSingleVariantView<Constants extends SingleVariantConstants> extends BaseView<
+export class GenericSingleVariantView<Constants extends ExtendedConstants> extends BaseView<
     DatasetAndVariantData,
     Constants,
     SingleVariantPageStateHandler
@@ -67,8 +67,8 @@ export class GenericSingleVariantView<Constants extends SingleVariantConstants> 
     }
 }
 
-export class GenericSequencingEffortsView<Constants extends SequencingEffortsConstants> extends BaseView<
-    Dataset,
+export class GenericSequencingEffortsView<Constants extends ExtendedConstants> extends BaseView<
+    DatasetAndVariantData,
     Constants,
     SequencingEffortsStateHandler
 > {
@@ -82,6 +82,10 @@ export class GenericSequencingEffortsView<Constants extends SequencingEffortsCon
                         location: {},
                         dateRange: constants.defaultDateRange,
                     },
+                    variantFilter: {
+                        mutations: {},
+                        lineages: {},
+                    },
                 },
                 organismConfig[constants.organism].pathFragment,
             ),
@@ -90,7 +94,7 @@ export class GenericSequencingEffortsView<Constants extends SequencingEffortsCon
     }
 }
 
-export class GenericCompareVariantsView<Constants extends SingleVariantConstants> extends BaseView<
+export class GenericCompareVariantsView<Constants extends ExtendedConstants> extends BaseView<
     CompareVariantsData,
     Constants,
     CompareVariantsPageStateHandler
@@ -114,7 +118,7 @@ export class GenericCompareVariantsView<Constants extends SingleVariantConstants
     }
 }
 
-export class GenericCompareToBaselineView<Constants extends SingleVariantConstants> extends BaseView<
+export class GenericCompareToBaselineView<Constants extends ExtendedConstants> extends BaseView<
     CompareToBaselineData,
     Constants,
     CompareToBaselineStateHandler

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -21,16 +21,13 @@ export interface AdditionalSequencingEffortsField {
     readonly height: (typeof ComponentHeight)[keyof typeof ComponentHeight];
 }
 
-export interface SequencingEffortsConstants extends OrganismConstants {
+export interface ExtendedConstants extends OrganismConstants {
     readonly locationFields: string[];
     readonly mainDateField: string;
     readonly dateRangeOptions: DateRangeOption[];
     readonly defaultDateRange: DateRangeOption;
     readonly additionalFilters: Record<string, string> | undefined;
     readonly additionalSequencingEffortsFields: AdditionalSequencingEffortsField[];
-}
-
-export interface SingleVariantConstants extends SequencingEffortsConstants {
     readonly lineageFilters: LineageFilterConfig[];
 }
 

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type SingleVariantConstants } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type ExtendedConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -18,7 +18,7 @@ import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/Compar
 
 const earliestDate = '1905-01-01';
 
-class H5n1Constants implements SingleVariantConstants {
+class H5n1Constants implements ExtendedConstants {
     public readonly organism = Organisms.h5n1;
     public readonly earliestDate = '1905-01-01';
     public readonly defaultDateRange = dateRangeOptionPresets.lastYear;

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -9,14 +9,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getPathoplexusAdditionalSequencingEffortsFields, type SingleVariantConstants } from './OrganismConstants.ts';
+import { getPathoplexusAdditionalSequencingEffortsFields, type ExtendedConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 
-class MpoxConstants implements SingleVariantConstants {
+class MpoxConstants implements ExtendedConstants {
     public readonly organism = Organisms.mpox;
     public readonly earliestDate = '1960-01-01';
     public readonly defaultDateRange = dateRangeOptionPresets.lastYear;

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { SingleVariantConstants } from '../OrganismConstants.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
 import { type CompareSideBySideData, type DatasetAndVariantData, getLineageFilterFields, type Id } from '../View.ts';
 import { compareSideBySideViewConstants } from '../ViewConstants.ts';
 import type { CovidCompareSideBySideData } from '../covid.ts';
@@ -25,7 +25,7 @@ export abstract class CompareSideBySideStateHandler<ColumnData extends DatasetAn
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: SingleVariantConstants,
+        protected readonly constants: ExtendedConstants,
         protected readonly defaultPageState: CompareSideBySideData<ColumnData>,
         pathFragment: string,
     ) {

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { Organisms } from '../../types/Organism.ts';
-import type { SingleVariantConstants } from '../OrganismConstants.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
 import type { CompareToBaselineData } from '../View.ts';
 import { CompareToBaselineStateHandler } from './CompareToBaselinePageStateHandler.ts';
 
-const mockConstants: SingleVariantConstants = {
+const mockConstants: ExtendedConstants = {
     organism: Organisms.covid,
     dataOrigins: [],
     locationFields: ['country', 'region'],

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter, NamedLapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { SingleVariantConstants } from '../OrganismConstants.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
 import {
     type CompareToBaselineData,
     type DatasetFilter,
@@ -31,7 +31,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: SingleVariantConstants,
+        protected readonly constants: ExtendedConstants,
         protected readonly defaultPageState: CompareToBaselineData,
         pathFragment: string,
     ) {

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { Organisms } from '../../types/Organism.ts';
-import type { SingleVariantConstants } from '../OrganismConstants.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
 import type { CompareVariantsData } from '../View.ts';
 import { CompareVariantsPageStateHandler } from './CompareVariantsPageStateHandler.ts';
 
-const mockConstants: SingleVariantConstants = {
+const mockConstants: ExtendedConstants = {
     organism: Organisms.covid,
     dataOrigins: [],
     locationFields: ['country', 'region'],

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter, NamedLapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { SingleVariantConstants } from '../OrganismConstants.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
 import {
     type CompareVariantsData,
     type DatasetFilter,
@@ -31,7 +31,7 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: SingleVariantConstants,
+        protected readonly constants: ExtendedConstants,
         protected readonly defaultPageState: CompareVariantsData,
         pathFragment: string,
     ) {

--- a/website/src/views/pageStateHandlers/PageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { SequencingEffortsConstants } from '../OrganismConstants.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
 import { type Dataset, type Id, type VariantFilter } from '../View.ts';
 import { type LapisLocation } from '../helpers.ts';
 
@@ -14,7 +14,7 @@ export interface PageStateHandler<PageState extends object> {
 
 export function toLapisFilterWithoutVariant(
     pageState: Dataset,
-    constants: SequencingEffortsConstants,
+    constants: ExtendedConstants,
 ): LapisFilter & LapisLocation {
     return {
         ...pageState.datasetFilter.location,

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -1,26 +1,30 @@
-import type { SequencingEffortsConstants } from '../OrganismConstants.ts';
-import type { Dataset } from '../View.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
+import { getLineageFilterFields, type DatasetAndVariantData } from '../View.ts';
 import { sequencingEffortsViewConstants } from '../ViewConstants.ts';
 import {
     getDateRangeFromSearch,
     getLapisLocationFromSearch,
+    getLapisVariantQuery,
     setSearchFromDateRange,
+    setSearchFromLapisVariantQuery,
     setSearchFromLocation,
 } from '../helpers.ts';
 import { type PageStateHandler, toLapisFilterWithoutVariant } from './PageStateHandler.ts';
 
-export class SequencingEffortsStateHandler implements PageStateHandler<Dataset> {
+export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantData = DatasetAndVariantData>
+    implements PageStateHandler<DatasetAndVariantData>
+{
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: SequencingEffortsConstants,
-        protected readonly defaultPageState: Dataset,
+        protected readonly constants: ExtendedConstants,
+        protected readonly defaultPageState: PageState,
         pathFragment: string,
     ) {
         this.pathname = `/${pathFragment}/${sequencingEffortsViewConstants.pathFragment}`;
     }
 
-    public parsePageStateFromUrl(url: URL): Dataset {
+    public parsePageStateFromUrl(url: URL): DatasetAndVariantData {
         const search = url.searchParams;
         return {
             datasetFilter: {
@@ -29,23 +33,33 @@ export class SequencingEffortsStateHandler implements PageStateHandler<Dataset> 
                     getDateRangeFromSearch(search, this.constants.mainDateField, this.constants.dateRangeOptions) ??
                     this.constants.defaultDateRange,
             },
+            variantFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
         };
     }
 
-    public toUrl(pageState: Dataset): string {
+    public toUrl(pageState: DatasetAndVariantData): string {
         const search = new URLSearchParams();
         setSearchFromLocation(search, pageState.datasetFilter.location);
         if (pageState.datasetFilter.dateRange !== this.constants.defaultDateRange) {
             setSearchFromDateRange(search, this.constants.mainDateField, pageState.datasetFilter.dateRange);
         }
+        setSearchFromLapisVariantQuery(
+            search,
+            pageState.variantFilter,
+            getLineageFilterFields(this.constants.lineageFilters),
+        );
         return `${this.pathname}?${search}`;
+    }
+
+    public toLapisFilter(pageState: DatasetAndVariantData) {
+        return {
+            ...toLapisFilterWithoutVariant(pageState, this.constants),
+            ...pageState.variantFilter.lineages,
+            ...pageState.variantFilter.mutations,
+        };
     }
 
     public getDefaultPageUrl(): string {
         return this.toUrl(this.defaultPageState);
-    }
-
-    public toLapisFilter(pageState: Dataset) {
-        return toLapisFilterWithoutVariant(pageState, this.constants);
     }
 }

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { SingleVariantConstants } from '../OrganismConstants.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
 import { type Dataset, type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { singleVariantViewConstants } from '../ViewConstants.ts';
 import {
@@ -20,7 +20,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: SingleVariantConstants,
+        protected readonly constants: ExtendedConstants,
         protected readonly defaultPageState: PageState,
         pathFragment: string,
     ) {

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -9,14 +9,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type SingleVariantConstants } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type ExtendedConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 
-class RsvAConstants implements SingleVariantConstants {
+class RsvAConstants implements ExtendedConstants {
     public readonly organism = Organisms.rsvA;
     public readonly defaultDateRange = dateRangeOptionPresets.lastYear;
     public readonly earliestDate = '1956-01-01';

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -9,14 +9,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type SingleVariantConstants } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type ExtendedConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 
-class RsvBConstants implements SingleVariantConstants {
+class RsvBConstants implements ExtendedConstants {
     public readonly organism = Organisms.rsvB;
     public readonly defaultDateRange = dateRangeOptionPresets.lastYear;
     public readonly earliestDate = '1956-01-01';

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -9,14 +9,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getPathoplexusAdditionalSequencingEffortsFields, type SingleVariantConstants } from './OrganismConstants.ts';
+import { getPathoplexusAdditionalSequencingEffortsFields, type ExtendedConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 
-class WestNileConstants implements SingleVariantConstants {
+class WestNileConstants implements ExtendedConstants {
     public readonly organism = Organisms.westNile;
     public readonly earliestDate = '1930-01-01';
     public readonly defaultDateRange = dateRangeOptionPresets.lastYear;


### PR DESCRIPTION
This will be very useful for influenza - but its anyways nice to give users more filter options - this also gives the option to not show sequence mutations on the compare variant page - which will also be useful for Influenza and other parent pages where we group all information and do not align. 

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

https://github.com/user-attachments/assets/04ed1a51-3c95-426a-82b2-004ff4f7fbc9



<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
