### PR TITLE
feat(website): add button to download accession list of the sequences used on each page

### DIFF
--- a/backend/src/main/resources/application-dashboards-dev.yaml
+++ b/backend/src/main/resources/application-dashboards-dev.yaml
@@ -11,6 +11,8 @@ dashboards:
         hostField: "host"
         originatingLabField: "originatingLab"
         submittingLabField: "submittingLab"
+        accessionDownloadFields:
+          - "strain"
       externalNavigationLinks:
         - url: "https://cov-spectrum.org"
           label: "CoV-Spectrum"
@@ -28,6 +30,15 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull_seg1"
+          - "insdcAccessionFull_seg2"
+          - "insdcAccessionFull_seg3"
+          - "insdcAccessionFull_seg4"
+          - "insdcAccessionFull_seg5"
+          - "insdcAccessionFull_seg6"
+          - "insdcAccessionFull_seg7"
+          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/h5n1"
           label: "Browse data"
@@ -45,6 +56,9 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
+          - "accessionVersion"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/mpox"
           label: "Browse data"
@@ -56,13 +70,15 @@ dashboards:
         locationFields:
           - "geoLocCountry"
           - "geoLocAdmin1"
-
         hostField: "hostNameScientific"
         authorAffiliationsField: "authorAffiliations"
         authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
+          - "accessionVersion"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/west-nile"
           label: "Browse data"
@@ -80,6 +96,8 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/rsv-a"
           label: "Browse data"
@@ -97,6 +115,8 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/rsv-b"
           label: "Browse data"

--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -11,6 +11,8 @@ dashboards:
         hostField: "host"
         originatingLabField: "originatingLab"
         submittingLabField: "submittingLab"
+        accessionDownloadFields:
+          - "strain"
       externalNavigationLinks:
         - url: "https://cov-spectrum.org"
           label: "CoV-Spectrum"
@@ -28,6 +30,15 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull_seg1"
+          - "insdcAccessionFull_seg2"
+          - "insdcAccessionFull_seg3"
+          - "insdcAccessionFull_seg4"
+          - "insdcAccessionFull_seg5"
+          - "insdcAccessionFull_seg6"
+          - "insdcAccessionFull_seg7"
+          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/h5n1"
           label: "Browse data"
@@ -45,6 +56,9 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
+          - "accessionVersion"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/mpox"
           label: "Browse data"
@@ -62,6 +76,9 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
+          - "accessionVersion"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/west-nile"
           label: "Browse data"
@@ -79,6 +96,8 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/rsv-a"
           label: "Browse data"
@@ -96,6 +115,8 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/rsv-b"
           label: "Browse data"

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -11,6 +11,8 @@ dashboards:
         hostField: "host"
         originatingLabField: "originatingLab"
         submittingLabField: "submittingLab"
+        accessionDownloadFields:
+          - "strain"
       externalNavigationLinks:
         - url: "https://cov-spectrum.org"
           label: "CoV-Spectrum"
@@ -28,6 +30,15 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull_seg1"
+          - "insdcAccessionFull_seg2"
+          - "insdcAccessionFull_seg3"
+          - "insdcAccessionFull_seg4"
+          - "insdcAccessionFull_seg5"
+          - "insdcAccessionFull_seg6"
+          - "insdcAccessionFull_seg7"
+          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/h5n1"
           label: "Browse data"
@@ -45,6 +56,9 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
+          - "accessionVersion"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/mpox"
           label: "Browse data"
@@ -62,6 +76,9 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
+          - "accessionVersion"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/west-nile"
           label: "Browse data"
@@ -79,6 +96,8 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/rsv-a"
           label: "Browse data"
@@ -96,6 +115,8 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
+        accessionDownloadFields:
+          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/rsv-b"
           label: "Browse data"

--- a/website/src/components/subscriptions/notificationChannels/NotificationChannelDisplay.tsx
+++ b/website/src/components/subscriptions/notificationChannels/NotificationChannelDisplay.tsx
@@ -1,11 +1,9 @@
-import { useRef } from 'react';
-
 import { BorderedCard } from '../../../styles/containers/BorderedCard.tsx';
 import { CardContent } from '../../../styles/containers/CardContent.tsx';
 import { CardDescription } from '../../../styles/containers/CardDescription.tsx';
 import { CardHeader } from '../../../styles/containers/CardHeader.tsx';
 import { DividerList } from '../../../styles/containers/DividerList.tsx';
-import { ModalBox } from '../../../styles/containers/ModalBox.tsx';
+import { Modal, useModalRef } from '../../../styles/containers/Modal.tsx';
 import { ModalContent } from '../../../styles/containers/ModalContent.tsx';
 import { ModalHeader } from '../../../styles/containers/ModalHeader.tsx';
 import { PageContainer } from '../../../styles/containers/PageContainer.tsx';
@@ -75,7 +73,7 @@ function EmailEntry({ channel }: { channel: EmailChannel }) {
 }
 
 function AddEmailButton() {
-    const addMailDialog = useRef<HTMLDialogElement>(null);
+    const addMailDialog = useModalRef();
 
     const toggleDialog = () => {
         addMailDialog.current?.showModal();
@@ -86,40 +84,37 @@ function AddEmailButton() {
             <button className='btn btn-primary btn-sm' onClick={toggleDialog}>
                 + Add
             </button>
-            <dialog className='modal' ref={addMailDialog}>
-                <ModalBox>
-                    <ModalHeader title='Add Email' icon='mdi--email' />
+            <Modal modalRef={addMailDialog}>
+                <ModalHeader title='Add Email' icon='mdi--email' />
+                <ModalContent>
+                    <InputLabel
+                        title='Email address'
+                        description='You can provide the email address where you want to send the messages.'
+                    >
+                        <input className='input input-sm input-bordered w-full' placeholder='test@mailbox.org' />
+                    </InputLabel>
 
-                    <ModalContent>
-                        <InputLabel
-                            title='Email address'
-                            description='You can provide the email address where you want to send the messages.'
-                        >
-                            <input className='input input-sm input-bordered w-full' placeholder='test@mailbox.org' />
-                        </InputLabel>
+                    <div className='divider'></div>
 
-                        <div className='divider'></div>
+                    <InputLabel
+                        title='Name'
+                        description='You can provide a custom name for your email to find it later on.'
+                    >
+                        <input className='input input-sm input-bordered w-full' placeholder='Name' />
+                    </InputLabel>
 
-                        <InputLabel
-                            title='Name'
-                            description='You can provide a custom name for your email to find it later on.'
-                        >
-                            <input className='input input-sm input-bordered w-full' placeholder='Name' />
-                        </InputLabel>
+                    <div className='divider'></div>
 
-                        <div className='divider'></div>
-
-                        <div className='modal-action'>
-                            <form method='dialog'>
-                                <button className='btn btn-outline float-right w-24'>Discard</button>
-                            </form>
-                            <form method='dialog'>
-                                <button className='btn btn-primary float-right w-24 underline'>Add</button>
-                            </form>
-                        </div>
-                    </ModalContent>
-                </ModalBox>
-            </dialog>
+                    <div className='modal-action'>
+                        <form method='dialog'>
+                            <button className='btn btn-outline float-right w-24'>Discard</button>
+                        </form>
+                        <form method='dialog'>
+                            <button className='btn btn-primary float-right w-24 underline'>Add</button>
+                        </form>
+                    </div>
+                </ModalContent>
+            </Modal>
         </>
     );
 }
@@ -151,7 +146,7 @@ function SlackEntry({ channel }: { channel: SlackChannel }) {
 }
 
 function AddSlackButton() {
-    const addSlackDialog = useRef<HTMLDialogElement>(null);
+    const addSlackDialog = useModalRef();
 
     const toggleDialog = () => {
         addSlackDialog.current?.showModal();
@@ -162,45 +157,43 @@ function AddSlackButton() {
             <button className='btn btn-primary btn-sm' onClick={toggleDialog}>
                 + Add
             </button>
-            <dialog className='modal' ref={addSlackDialog}>
-                <ModalBox>
-                    <ModalHeader title='Add Slack channel' icon='mdi--slack' />
+            <Modal modalRef={addSlackDialog}>
+                <ModalHeader title='Add Slack channel' icon='mdi--slack' />
 
-                    <ModalContent>
-                        <InputLabel
-                            title='Slack webhook URL'
-                            description={
-                                'You can get the Slack Incoming Webhook URL in the Slack settings:\nChannel Settings > Add an App > Incoming WebHooks.'
-                            }
-                        >
-                            <input
-                                className='input input-sm input-bordered w-full'
-                                placeholder='https://hooks.slack.com/services/...'
-                            />
-                        </InputLabel>
+                <ModalContent>
+                    <InputLabel
+                        title='Slack webhook URL'
+                        description={
+                            'You can get the Slack Incoming Webhook URL in the Slack settings:\nChannel Settings > Add an App > Incoming WebHooks.'
+                        }
+                    >
+                        <input
+                            className='input input-sm input-bordered w-full'
+                            placeholder='https://hooks.slack.com/services/...'
+                        />
+                    </InputLabel>
 
-                        <div className='divider'></div>
+                    <div className='divider'></div>
 
-                        <InputLabel
-                            title='Name of channel'
-                            description='You can provide a custom name for your channel to find it later on.'
-                        >
-                            <input className='input input-sm input-bordered w-full' placeholder='Name' />
-                        </InputLabel>
+                    <InputLabel
+                        title='Name of channel'
+                        description='You can provide a custom name for your channel to find it later on.'
+                    >
+                        <input className='input input-sm input-bordered w-full' placeholder='Name' />
+                    </InputLabel>
 
-                        <div className='divider'></div>
+                    <div className='divider'></div>
 
-                        <div className='modal-action'>
-                            <form method='dialog'>
-                                <button className='btn btn-outline float-right w-24'>Discard</button>
-                            </form>
-                            <form method='dialog'>
-                                <button className='btn btn-primary float-right w-24 underline'>Add</button>
-                            </form>
-                        </div>
-                    </ModalContent>
-                </ModalBox>
-            </dialog>
+                    <div className='modal-action'>
+                        <form method='dialog'>
+                            <button className='btn btn-outline float-right w-24'>Discard</button>
+                        </form>
+                        <form method='dialog'>
+                            <button className='btn btn-primary float-right w-24 underline'>Add</button>
+                        </form>
+                    </div>
+                </ModalContent>
+            </Modal>
         </>
     );
 }

--- a/website/src/components/subscriptions/overview/SubscriptionEntry.tsx
+++ b/website/src/components/subscriptions/overview/SubscriptionEntry.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { type JSX, type RefObject, useRef } from 'react';
+import { type JSX, type RefObject } from 'react';
 import { toast } from 'react-toastify';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -7,7 +7,7 @@ import { SubscriptionDisplay } from './SubscriptionDisplay.tsx';
 import { getClientLogger } from '../../../clientLogger.ts';
 import { BorderedCard } from '../../../styles/containers/BorderedCard.tsx';
 import { CardDescription } from '../../../styles/containers/CardDescription.tsx';
-import { ModalBox } from '../../../styles/containers/ModalBox.tsx';
+import { Modal, useModalRef } from '../../../styles/containers/Modal.tsx';
 import { ModalContent } from '../../../styles/containers/ModalContent.tsx';
 import { ModalHeader } from '../../../styles/containers/ModalHeader.tsx';
 import { organismConfig } from '../../../types/Organism.ts';
@@ -135,7 +135,7 @@ function MoreDropdown({
         },
     });
 
-    const deleteSubscriptionDialog = useRef<HTMLDialogElement>(null);
+    const deleteSubscriptionDialog = useModalRef();
 
     const toggleConfirmDeletionDialog = () => {
         deleteSubscriptionDialog.current?.showModal();
@@ -235,33 +235,28 @@ function ConfirmDeletionModal({
     modalRef: RefObject<HTMLDialogElement>;
 }) {
     return (
-        <dialog className='modal' ref={modalRef}>
-            <ModalBox>
-                <ModalHeader title='Delete subscription' icon='mdi--delete' />
-                <ModalContent>
-                    <p>Are you sure you want to delete this subscription?</p>
-                    <div className='divider' />
-                    <div className='modal-action'>
-                        <form method='dialog'>
-                            <button
-                                type='submit'
-                                className='btn btn-outline float-right w-24'
-                                onClick={() => modalRef.current?.close()}
-                            >
-                                Cancel
-                            </button>
-                        </form>
-                        <form method='dialog'>
-                            <button type='submit' className='btn btn-error float-right w-24' onClick={onDelete}>
-                                Delete
-                            </button>
-                        </form>
-                    </div>
-                </ModalContent>
-            </ModalBox>
-            <form method='dialog' className='modal-backdrop'>
-                <button>close on clicking outside of modal</button>
-            </form>
-        </dialog>
+        <Modal modalRef={modalRef}>
+            <ModalHeader title='Delete subscription' icon='mdi--delete' />
+            <ModalContent>
+                <p>Are you sure you want to delete this subscription?</p>
+                <div className='divider' />
+                <div className='modal-action'>
+                    <form method='dialog'>
+                        <button
+                            type='submit'
+                            className='btn btn-outline float-right w-24'
+                            onClick={() => modalRef.current?.close()}
+                        >
+                            Cancel
+                        </button>
+                    </form>
+                    <form method='dialog'>
+                        <button type='submit' className='btn btn-error float-right w-24' onClick={onDelete}>
+                            Delete
+                        </button>
+                    </form>
+                </div>
+            </ModalContent>
+        </Modal>
     );
 }

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -6,6 +6,7 @@ import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranulari
 import { hasOnlyUndefinedValues } from '../../../util/hasOnlyUndefinedValues';
 import { getLineageFilterConfigs, getLineageFilterFields } from '../../../views/View';
 import { getLocationSubdivision } from '../../../views/locationHelpers';
+import { toDisplayName } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { singleVariantViewKey } from '../../../views/viewKeys';
@@ -17,6 +18,7 @@ import GsMutationsOverTime from '../../genspectrum/GsMutationsOverTime.astro';
 import GsPrevalenceOverTime from '../../genspectrum/GsPrevalenceOverTime.astro';
 import { AnalyzeSingleVariantSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 import { SingleVariantPageStateSelector } from '../../pageStateSelectors/SingleVariantPageStateSelector';
+import { sanitizeForFilename } from '../compareSideBySide/toDownloadLink';
 
 type OrganismViewCompareVariant = OrganismWithViewKey<typeof singleVariantViewKey>;
 interface Props {
@@ -47,9 +49,20 @@ const lineageFilterConfigs = getLineageFilterConfigs(
 );
 
 const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
+
+const displayName = toDisplayName(pageState.variantFilter);
+const downloadLinks = noVariantSelected
+    ? []
+    : [
+          {
+              label: `Download accessions of "${displayName}"`,
+              filter: variantLapisFilter,
+              downloadFileBasename: `${organism}_${sanitizeForFilename(displayName)}_accessions`,
+          },
+      ];
 ---
 
-<SingleVariantOrganismPageLayout view={view}>
+<SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <SingleVariantPageStateSelector
         slot='filters'
         locationFilterConfig={{

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -1,4 +1,5 @@
 ---
+import { toDownloadLink } from './toDownloadLink';
 import { getDashboardsConfig, getLapisUrl } from '../../../config';
 import OrganismPageLayout from '../../../layouts/OrganismPage/OrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
@@ -23,9 +24,11 @@ const organismViewKey = `${organism}.${compareSideBySideViewKey}` satisfies Orga
 const view = ServerSide.routing.getOrganismView(organismViewKey);
 
 const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
+
+const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.pageStateHandler, organism));
 ---
 
-<OrganismPageLayout view={view}>
+<OrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <gs-app lapis={getLapisUrl(view.organismConstants.organism)}>
         <div class='flex overflow-x-auto'>
             {
@@ -35,11 +38,10 @@ const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
                         datasetFilter.dateRange,
                         new Date(view.organismConstants.earliestDate),
                     );
-                    const numeratorFilter = {
-                        ...variantFilter.lineages,
-                        ...variantFilter.mutations,
-                        ...datasetLapisFilter,
-                    };
+                    const numeratorFilter = view.pageStateHandler.variantFilterToLapisFilter(
+                        datasetFilter,
+                        variantFilter,
+                    );
                     const lineageFilterConfigs = getLineageFilterConfigs(
                         view.organismConstants.lineageFilters,
                         variantFilter.lineages,

--- a/website/src/components/views/compareSideBySide/toDownloadLink.ts
+++ b/website/src/components/views/compareSideBySide/toDownloadLink.ts
@@ -1,0 +1,22 @@
+import type { Organism } from '../../../types/Organism.ts';
+import type { DatasetAndVariantData, Id } from '../../../views/View.ts';
+import type { CompareSideBySideStateHandler } from '../../../views/pageStateHandlers/CompareSideBySidePageStateHandler.ts';
+import { toDisplayName } from '../../../views/pageStateHandlers/PageStateHandler.ts';
+
+export function toDownloadLink(pageStateHandler: CompareSideBySideStateHandler, organism: Organism) {
+    return ([id, { variantFilter, datasetFilter }]: [Id, DatasetAndVariantData]) => {
+        const filter = pageStateHandler.variantFilterToLapisFilter(datasetFilter, variantFilter);
+        const displayName = toDisplayName(variantFilter);
+        const variantName = displayName.length > 0 ? displayName : `variant ${id + 1}`;
+
+        return {
+            label: `Download accessions of "${variantName}"`,
+            filter,
+            downloadFileBasename: `${organism}_${sanitizeForFilename(displayName)}_accessions`,
+        };
+    };
+}
+
+export function sanitizeForFilename(variantName: string) {
+    return variantName.replaceAll(/[*\s]/g, '').replaceAll(/[+:]/g, '_');
+}

--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
@@ -10,6 +10,7 @@ import ComponentsGrid from '../../ComponentsGrid.astro';
 import GsPrevalenceOverTime from '../../genspectrum/GsPrevalenceOverTime.astro';
 import { CompareVariantsToBaselineStateSelector } from '../../pageStateSelectors/CompareVariantsToBaselineStateSelector';
 import { CompareToBaselineSelectorFallback } from '../../pageStateSelectors/FallbackElement';
+import { sanitizeForFilename } from '../compareSideBySide/toDownloadLink';
 
 type OrganismViewCompareVariant = OrganismWithViewKey<typeof compareToBaselineViewKey>;
 interface Props {
@@ -33,9 +34,17 @@ const baselineFilterConfig = view.pageStateHandler.toBaselineFilterConfig(pageSt
 
 const numeratorLapisFilters = view.pageStateHandler.variantFiltersToNamedLapisFilters(pageState);
 const noVariantSelected = pageState.variants.size < 1;
+
+const downloadLinks = noVariantSelected
+    ? []
+    : numeratorLapisFilters.map(({ lapisFilter, displayName }) => ({
+          label: `Download accessions of "${displayName}"`,
+          filter: lapisFilter,
+          downloadFileBasename: `${organism}_${sanitizeForFilename(displayName)}_accessions`,
+      }));
 ---
 
-<SingleVariantOrganismPageLayout view={view}>
+<SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <CompareVariantsToBaselineStateSelector
         slot='filters'
         locationFilterConfig={{

--- a/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
+++ b/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
@@ -11,6 +11,7 @@ import GsMutationComparison from '../../genspectrum/GsMutationComparison.astro';
 import GsPrevalenceOverTime from '../../genspectrum/GsPrevalenceOverTime.astro';
 import { CompareVariantsPageStateSelector } from '../../pageStateSelectors/CompareVariantsPageStateSelector';
 import { CompareVariantsSelectorFallback } from '../../pageStateSelectors/FallbackElement';
+import { sanitizeForFilename } from '../compareSideBySide/toDownloadLink';
 
 type OrganismViewCompareVariant = OrganismWithViewKey<typeof compareVariantsViewKey>;
 interface Props {
@@ -34,9 +35,17 @@ const variantFilterConfigs = view.pageStateHandler.toVariantFilterConfigs(pageSt
 const numeratorLapisFilters = view.pageStateHandler.variantFiltersToNamedLapisFilters(pageState);
 
 const notEnoughVariantsSelected = pageState.variants.size < 2;
+
+const downloadLinks = notEnoughVariantsSelected
+    ? []
+    : numeratorLapisFilters.map(({ lapisFilter, displayName }) => ({
+          label: `Download accessions of "${displayName}"`,
+          filter: lapisFilter,
+          downloadFileBasename: `${organism}_${sanitizeForFilename(displayName)}_accessions`,
+      }));
 ---
 
-<SingleVariantOrganismPageLayout view={view}>
+<SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <CompareVariantsPageStateSelector
         slot='filters'
         locationFilterConfig={{

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -26,7 +26,7 @@ const view = ServerSide.routing.getOrganismView(organismViewKey);
 
 const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
 
-const variantLapisFilter = view.pageStateHandler.toLapisFilter(pageState);
+const lapisFilter = view.pageStateHandler.toLapisFilter(pageState);
 const timeGranularity = chooseGranularityBasedOnDateRange(
     pageState.datasetFilter.dateRange,
     new Date(view.organismConstants.earliestDate),
@@ -42,7 +42,16 @@ const lineageFilterConfigs = getLineageFilterConfigs(
 );
 ---
 
-<SingleVariantOrganismPageLayout view={view}>
+<SingleVariantOrganismPageLayout
+    view={view}
+    downloadLinks={[
+        {
+            label: 'Download accessions',
+            filter: lapisFilter,
+            downloadFileBasename: `${organism}_sequencing_efforts_accessions`,
+        },
+    ]}
+>
     <SequencingEffortsPageStateSelector
         slot='filters'
         locationFilterConfig={{
@@ -69,7 +78,7 @@ const lineageFilterConfigs = getLineageFilterConfigs(
             lapisFilters={[
                 {
                     displayName: '',
-                    lapisFilter: variantLapisFilter,
+                    lapisFilter: lapisFilter,
                 },
             ]}
             lapisDateField={view.organismConstants.mainDateField}
@@ -81,7 +90,7 @@ const lineageFilterConfigs = getLineageFilterConfigs(
                     title={locationLabel}
                     height={ComponentHeight.large}
                     lapisLocationField={locationField}
-                    lapisFilter={variantLapisFilter}
+                    lapisFilter={lapisFilter}
                     mapName={mapName}
                 />
             )
@@ -90,16 +99,16 @@ const lineageFilterConfigs = getLineageFilterConfigs(
             title='Hosts'
             height={ComponentHeight.large}
             fields={[view.organismConstants.hostField]}
-            lapisFilter={variantLapisFilter}
+            lapisFilter={lapisFilter}
         />
         <GsAggregate
             title='Sub-lineages'
             fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
-            lapisFilter={variantLapisFilter}
+            lapisFilter={lapisFilter}
         />
         {
             view.organismConstants.additionalSequencingEffortsFields.map(({ label, fields, height }) => (
-                <GsAggregate title={label} height={height} fields={fields} lapisFilter={variantLapisFilter} />
+                <GsAggregate title={label} height={height} fields={fields} lapisFilter={lapisFilter} />
             ))
         }
     </ComponentsGrid>

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -17,6 +17,7 @@ const lapisConfigSchema = z.object({
     originatingLabField: z.optional(z.string()),
     submittingLabField: z.optional(z.string()),
     additionalFilters: z.optional(z.record(z.string())),
+    accessionDownloadFields: z.array(z.string()),
 });
 
 const externalNavigationLinkSchema = z.object({

--- a/website/src/layouts/OrganismPage/AccessionsDownloadButton.astro
+++ b/website/src/layouts/OrganismPage/AccessionsDownloadButton.astro
@@ -1,0 +1,61 @@
+---
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+
+import { assembleDownloadUrl } from './assembleDownloadUrl';
+import { getLapisUrl } from '../../config';
+import { Modal } from '../../styles/containers/Modal';
+import { ModalContent } from '../../styles/containers/ModalContent';
+import { ModalHeader } from '../../styles/containers/ModalHeader';
+import type { OrganismConstants } from '../../views/OrganismConstants';
+import type { View } from '../../views/View';
+import type { PageStateHandler } from '../../views/pageStateHandlers/PageStateHandler';
+
+type DownloadLink = {
+    label: string;
+    filter: LapisFilter;
+    downloadFileBasename: string;
+};
+
+interface Props {
+    view: View<object, OrganismConstants, PageStateHandler<object>>;
+    downloadLinks: DownloadLink[];
+}
+
+const { view, downloadLinks } = Astro.props;
+
+const modalId = 'accessionDownloadModal';
+---
+
+<button class='flex items-center gap-1 p-2 text-xs' onclick={`${modalId}.showModal()`}>
+    <span class='iconify text-base mdi--download'></span>
+    Download data
+</button>
+<Modal id={modalId}>
+    <ModalHeader title='Download data' icon='mdi--download' />
+    <ModalContent>
+        <p>You can download a list of accessions that are used for the visualizations on this page:</p>
+        <div class='m-8'>
+            {
+                downloadLinks
+                    .map(({ label, filter, downloadFileBasename }) => ({
+                        label,
+                        url: assembleDownloadUrl(
+                            view.organismConstants.accessionDownloadFields,
+                            filter,
+                            downloadFileBasename,
+                            getLapisUrl(view.organismConstants.organism),
+                        ),
+                    }))
+                    .map(({ label, url }) => (
+                        <a class='link m-2 flex items-center gap-1' href={url}>
+                            <span class='iconify text-xl mdi--download' />
+                            {label}
+                        </a>
+                    ))
+            }
+        </div>
+        <form method='dialog' class='flex flex-col items-end'>
+            <button class='underline'>Close</button>
+        </form>
+    </ModalContent>
+</Modal>

--- a/website/src/layouts/OrganismPage/AccessionsDownloadButton.astro
+++ b/website/src/layouts/OrganismPage/AccessionsDownloadButton.astro
@@ -26,7 +26,7 @@ const { view, downloadLinks } = Astro.props;
 const modalId = 'accessionDownloadModal';
 ---
 
-<button class='flex items-center gap-1 p-2 text-xs' onclick={`${modalId}.showModal()`}>
+<button class='flex items-center justify-center gap-1 p-2 text-xs' onclick={`${modalId}.showModal()`}>
     <span class='iconify text-base mdi--download'></span>
     Download data
 </button>

--- a/website/src/layouts/OrganismPage/LastUpdatedInfo.astro
+++ b/website/src/layouts/OrganismPage/LastUpdatedInfo.astro
@@ -1,0 +1,17 @@
+---
+import { getLapisUrl } from '../../config';
+import { getLastUpdatedDate } from '../../lapis/getLastUpdatedDate';
+import type { OrganismConstants } from '../../views/OrganismConstants';
+import type { View } from '../../views/View';
+import type { PageStateHandler } from '../../views/pageStateHandlers/PageStateHandler';
+
+interface Props {
+    view: View<object, OrganismConstants, PageStateHandler<object>>;
+}
+
+const { view } = Astro.props;
+
+const lastUpdatedDate = await getLastUpdatedDate(getLapisUrl(view.organismConstants.organism));
+---
+
+<span class='flex justify-center p-2 text-xs'>Data last updated: {lastUpdatedDate ?? 'unknown'}</span>

--- a/website/src/layouts/OrganismPage/OrganismPageLayout.astro
+++ b/website/src/layouts/OrganismPage/OrganismPageLayout.astro
@@ -1,4 +1,7 @@
 ---
+import type { ComponentProps } from 'astro/types';
+
+import AccessionsDownloadButton from './AccessionsDownloadButton.astro';
 import { getLapisUrl } from '../../config';
 import { getLastUpdatedDate } from '../../lapis/getLastUpdatedDate';
 import type { OrganismConstants } from '../../views/OrganismConstants';
@@ -10,9 +13,10 @@ import DataInfo from '../base/footer/DataInfo.astro';
 
 interface Props {
     view: View<object, OrganismConstants, PageStateHandler<object>>;
+    downloadLinks: ComponentProps<typeof AccessionsDownloadButton>['downloadLinks'];
 }
 
-const { view } = Astro.props;
+const { view, downloadLinks } = Astro.props;
 
 const lastUpdatedDate = await getLastUpdatedDate(getLapisUrl(view.organismConstants.organism));
 ---
@@ -22,8 +26,9 @@ const lastUpdatedDate = await getLastUpdatedDate(getLapisUrl(view.organismConsta
         <Breadcrumbs breadcrumbs={view.viewBreadcrumbEntries} />
     </div>
     <slot />
-    <div class='flex justify-center' slot='secondary-footer'>
-        <span class='mr-4 p-2 text-xs'>Data last updated: {lastUpdatedDate ?? 'unknown'}</span>
+    <div class='flex justify-center gap-4' slot='secondary-footer'>
+        {downloadLinks.length > 0 && <AccessionsDownloadButton view={view} downloadLinks={downloadLinks} />}
+        <span class='p-2 text-xs'>Data last updated: {lastUpdatedDate ?? 'unknown'}</span>
         <DataInfo dataOrigins={view.organismConstants.dataOrigins} />
     </div>
 </BaseLayout>

--- a/website/src/layouts/OrganismPage/OrganismPageLayout.astro
+++ b/website/src/layouts/OrganismPage/OrganismPageLayout.astro
@@ -2,8 +2,7 @@
 import type { ComponentProps } from 'astro/types';
 
 import AccessionsDownloadButton from './AccessionsDownloadButton.astro';
-import { getLapisUrl } from '../../config';
-import { getLastUpdatedDate } from '../../lapis/getLastUpdatedDate';
+import LastUpdatedInfo from './LastUpdatedInfo.astro';
 import type { OrganismConstants } from '../../views/OrganismConstants';
 import { type View } from '../../views/View';
 import type { PageStateHandler } from '../../views/pageStateHandlers/PageStateHandler';
@@ -17,8 +16,6 @@ interface Props {
 }
 
 const { view, downloadLinks } = Astro.props;
-
-const lastUpdatedDate = await getLastUpdatedDate(getLapisUrl(view.organismConstants.organism));
 ---
 
 <BaseLayout title={view.viewTitle}>
@@ -28,7 +25,7 @@ const lastUpdatedDate = await getLastUpdatedDate(getLapisUrl(view.organismConsta
     <slot />
     <div class='flex flex-col justify-center sm:flex-row sm:gap-4' slot='secondary-footer'>
         {downloadLinks.length > 0 && <AccessionsDownloadButton view={view} downloadLinks={downloadLinks} />}
-        <span class='flex justify-center p-2 text-xs'>Data last updated: {lastUpdatedDate ?? 'unknown'}</span>
+        <LastUpdatedInfo view={view} />
         <DataInfo dataOrigins={view.organismConstants.dataOrigins} />
     </div>
 </BaseLayout>

--- a/website/src/layouts/OrganismPage/OrganismPageLayout.astro
+++ b/website/src/layouts/OrganismPage/OrganismPageLayout.astro
@@ -26,9 +26,9 @@ const lastUpdatedDate = await getLastUpdatedDate(getLapisUrl(view.organismConsta
         <Breadcrumbs breadcrumbs={view.viewBreadcrumbEntries} />
     </div>
     <slot />
-    <div class='flex justify-center gap-4' slot='secondary-footer'>
+    <div class='flex flex-col justify-center sm:flex-row sm:gap-4' slot='secondary-footer'>
         {downloadLinks.length > 0 && <AccessionsDownloadButton view={view} downloadLinks={downloadLinks} />}
-        <span class='p-2 text-xs'>Data last updated: {lastUpdatedDate ?? 'unknown'}</span>
+        <span class='flex justify-center p-2 text-xs'>Data last updated: {lastUpdatedDate ?? 'unknown'}</span>
         <DataInfo dataOrigins={view.organismConstants.dataOrigins} />
     </div>
 </BaseLayout>

--- a/website/src/layouts/OrganismPage/SingleVariantOrganismPageLayout.astro
+++ b/website/src/layouts/OrganismPage/SingleVariantOrganismPageLayout.astro
@@ -1,4 +1,7 @@
 ---
+import type { ComponentProps } from 'astro/types';
+
+import AccessionsDownloadButton from './AccessionsDownloadButton.astro';
 import OrganismPageLayout from './OrganismPageLayout.astro';
 import { getLapisUrl } from '../../config';
 import type { OrganismConstants } from '../../views/OrganismConstants';
@@ -7,12 +10,13 @@ import { type PageStateHandler } from '../../views/pageStateHandlers/PageStateHa
 
 interface Props {
     view: View<object, OrganismConstants, PageStateHandler<object>>;
+    downloadLinks: ComponentProps<typeof AccessionsDownloadButton>['downloadLinks'];
 }
 
-const { view } = Astro.props;
+const { view, downloadLinks } = Astro.props;
 ---
 
-<OrganismPageLayout view={view}>
+<OrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <gs-app lapis={getLapisUrl(view.organismConstants.organism)}>
         <div class='grid-cols-[300px_1fr] gap-x-4 lg:grid'>
             <div class='h-fit bg-gray-50 p-2'>

--- a/website/src/layouts/OrganismPage/assembleDownloadUrl.spec.ts
+++ b/website/src/layouts/OrganismPage/assembleDownloadUrl.spec.ts
@@ -1,0 +1,45 @@
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+import { describe, expect, test } from 'vitest';
+
+import { assembleDownloadUrl } from './assembleDownloadUrl.ts';
+
+describe('assembleDownloadUrl', () => {
+    test('should return a valid URL', () => {
+        const result = assembleDownloadUrl(['accession1', 'accession2'], {}, 'my_filename', 'https://my.lapis.com');
+
+        expect(result).to.equal(
+            'https://my.lapis.com/sample/details?fields=accession1&fields=accession2&dataFormat=tsv&downloadAsFile=true&downloadFileBasename=my_filename',
+        );
+    });
+
+    for (const [filterKey, filterValue, expectedUrlPart] of [
+        ['stringValue', 'myStringValue', 'stringValue=myStringValue'],
+        ['numberValue', 42, 'numberValue=42'],
+        ['arrayValue', ['item1', 'item2'], 'arrayValue=item1&arrayValue=item2'],
+        ['trueBoolean', true, 'trueBoolean=true'],
+        ['falseBoolean', false, 'falseBoolean=false'],
+    ] satisfies [string, LapisFilter[string], string][]) {
+        test(`should put ${filterKey} LAPIS filter into the URL`, () => {
+            const lapisFilter = { [filterKey]: filterValue };
+
+            const result = assembleDownloadUrl(['accession'], lapisFilter, 'my_filename', 'https://my.lapis.com');
+
+            expect(result).to.contain(expectedUrlPart);
+        });
+    }
+
+    test('should ignore null and undefined values', () => {
+        const result = assembleDownloadUrl(
+            ['accession'],
+            {
+                undefinedValue: undefined,
+                nullValue: null,
+            },
+            'my_filename',
+            'https://my.lapis.com',
+        );
+
+        expect(result).not.to.contain('undefinedValue=');
+        expect(result).not.to.contain('nullValue=');
+    });
+});

--- a/website/src/layouts/OrganismPage/assembleDownloadUrl.ts
+++ b/website/src/layouts/OrganismPage/assembleDownloadUrl.ts
@@ -1,0 +1,40 @@
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+
+export function assembleDownloadUrl(
+    accessionDownloadFields: string[],
+    filter: LapisFilter,
+    downloadFileBasename: string,
+    lapisUrl: string,
+) {
+    const urlSearchParams = new URLSearchParams();
+    for (const accessionField of accessionDownloadFields) {
+        urlSearchParams.append('fields', accessionField);
+    }
+    urlSearchParams.set('dataFormat', 'tsv');
+    urlSearchParams.set('downloadAsFile', 'true');
+    urlSearchParams.set('downloadFileBasename', downloadFileBasename);
+    addLapisFilters(urlSearchParams, filter);
+
+    const url = new URL(lapisUrl);
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/sample/details`;
+    url.search = urlSearchParams.toString();
+
+    return url.toString();
+}
+
+function addLapisFilters(urlSearchParams: URLSearchParams, filter: LapisFilter) {
+    for (const key in filter) {
+        const value = filter[key];
+        if (value === undefined || value === null) {
+            continue;
+        }
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                urlSearchParams.append(key, item);
+            }
+        } else {
+            urlSearchParams.append(key, `${value}`);
+        }
+    }
+}

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -5,6 +5,7 @@ import GsPrevalenceOverTime from '../../components/genspectrum/GsPrevalenceOverT
 import GsRelativeGrowthAdvantage from '../../components/genspectrum/GsRelativeGrowthAdvantage.astro';
 import { CompareSideBySidePageStateSelector } from '../../components/pageStateSelectors/CompareSideBySidePageStateSelector';
 import { CompareSideBySideSelectorFallback } from '../../components/pageStateSelectors/FallbackElement';
+import { toDownloadLink } from '../../components/views/compareSideBySide/toDownloadLink';
 import { getDashboardsConfig, getLapisUrl } from '../../config';
 import OrganismPageLayout from '../../layouts/OrganismPage/OrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
@@ -16,9 +17,13 @@ const organismViewKey: OrganismViewKey = 'covid.compareSideBySideView';
 const view = ServerSide.routing.getOrganismView(organismViewKey);
 
 const pageState = view.pageStateHandler.parsePageStateFromUrl(Astro.url);
+
+const downloadLinks = [...pageState.filters.entries()].map(
+    toDownloadLink(view.pageStateHandler, view.organismConstants.organism),
+);
 ---
 
-<OrganismPageLayout view={view}>
+<OrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <gs-app lapis={getLapisUrl(view.organismConstants.organism)}>
         <div class='flex overflow-x-auto'>
             {

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -10,12 +10,14 @@ import { AnalyzeSingleVariantSelectorFallback } from '../../components/pageState
 import { SingleVariantPageStateSelector } from '../../components/pageStateSelectors/SingleVariantPageStateSelector';
 import { CollectionsList } from '../../components/views/analyzeSingleVariant/CollectionsList';
 import SelectVariant from '../../components/views/analyzeSingleVariant/SelectVariant.astro';
+import { sanitizeForFilename } from '../../components/views/compareSideBySide/toDownloadLink';
 import { getDashboardsConfig } from '../../config';
 import SingleVariantOrganismPageLayout from '../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../util/hasOnlyUndefinedValues';
 import { getLineageFilterConfigs, getLineageFilterFields } from '../../views/View';
 import { getLocationSubdivision } from '../../views/locationHelpers';
+import { toDisplayName } from '../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey } from '../../views/routing';
 import { ServerSide } from '../../views/serverSideRouting';
 
@@ -41,9 +43,20 @@ const lineageFilterConfigs = getLineageFilterConfigs(
 );
 
 const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
+
+const displayName = toDisplayName(pageState.variantFilter);
+const downloadLinks = noVariantSelected
+    ? []
+    : [
+          {
+              label: `Download accessions of ${displayName}`,
+              filter: variantFilter,
+              downloadFileBasename: `${view.organismConstants.organism}_${sanitizeForFilename(displayName)}_accessions`,
+          },
+      ];
 ---
 
-<SingleVariantOrganismPageLayout view={view}>
+<SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <div slot='filters'>
         <SingleVariantPageStateSelector
             locationFilterConfig={{

--- a/website/src/styles/containers/Modal.tsx
+++ b/website/src/styles/containers/Modal.tsx
@@ -1,0 +1,30 @@
+import { type FC, type PropsWithChildren, type RefObject, useRef } from 'react';
+
+import { ModalBox } from './ModalBox.tsx';
+
+export function useModalRef() {
+    return useRef<HTMLDialogElement>(null);
+}
+
+type ModalProps =
+    | {
+          /** set this when using from React and open it via `modalRef.current?.showModal()` */
+          modalRef: RefObject<HTMLDialogElement>;
+          id?: undefined;
+      }
+    | {
+          /** set this when using from Astro and open it via `onclick="id.showModal()"` */
+          id: string;
+          modalRef?: undefined;
+      };
+
+export const Modal: FC<PropsWithChildren<ModalProps>> = ({ children, modalRef, id }) => {
+    return (
+        <dialog className='modal' ref={modalRef} id={id}>
+            <ModalBox>{children}</ModalBox>
+            <form method='dialog' className='modal-backdrop'>
+                <button>close on clicking outside of modal</button>
+            </form>
+        </dialog>
+    );
+};

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -8,6 +8,7 @@ import type { DataOrigin } from '../types/dataOrigins.ts';
 export interface OrganismConstants {
     readonly organism: Organism;
     readonly dataOrigins: DataOrigin[];
+    readonly accessionDownloadFields: string[];
 }
 
 export const ComponentHeight = {

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -1,4 +1,4 @@
-import { type DateRangeOption, dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';
+import { type DateRangeOption, dateRangeOptionPresets, type LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import {
     type CompareSideBySideData,
@@ -67,6 +67,7 @@ class CovidConstants implements ExtendedConstants {
     public readonly submittingLabField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.nextstrain];
+    public readonly accessionDownloadFields;
 
     public get additionalSequencingEffortsFields() {
         const originatingLab =
@@ -87,6 +88,7 @@ class CovidConstants implements ExtendedConstants {
         this.originatingLabField = organismsConfig.covid.lapis.originatingLabField;
         this.submittingLabField = organismsConfig.covid.lapis.submittingLabField;
         this.additionalFilters = organismsConfig.covid.lapis.additionalFilters;
+        this.accessionDownloadFields = organismsConfig.covid.lapis.accessionDownloadFields;
     }
 }
 
@@ -276,6 +278,18 @@ class CovidCompareSideBySideStateHandler extends CompareSideBySideStateHandler<C
                 filterParams,
                 getLineageFilterFields(this.constants.lineageFilters),
             ),
+        };
+    }
+
+    public variantFilterToLapisFilter(
+        datasetFilter: CovidCompareSideBySideFilter['datasetFilter'],
+        variantFilter: CovidCompareSideBySideFilter['variantFilter'],
+    ): LapisFilter {
+        return {
+            ...variantFilter.lineages,
+            ...variantFilter.mutations,
+            variantQuery: variantFilter.variantQuery,
+            ...this.datasetFilterToLapisFilter(datasetFilter),
         };
     }
 }

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -50,6 +50,7 @@ class H5n1Constants implements ExtendedConstants {
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
+    public readonly accessionDownloadFields;
 
     public get additionalSequencingEffortsFields() {
         return getAuthorRelatedSequencingEffortsFields(this);
@@ -62,6 +63,7 @@ class H5n1Constants implements ExtendedConstants {
         this.authorsField = organismsConfig.h5n1.lapis.authorsField;
         this.authorAffiliationsField = organismsConfig.h5n1.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.h5n1.lapis.additionalFilters;
+        this.accessionDownloadFields = organismsConfig.h5n1.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -56,6 +56,7 @@ class MpoxConstants implements ExtendedConstants {
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
+    public readonly accessionDownloadFields;
 
     public get additionalSequencingEffortsFields() {
         return getPathoplexusAdditionalSequencingEffortsFields(this);
@@ -71,6 +72,7 @@ class MpoxConstants implements ExtendedConstants {
         this.authorsField = organismsConfig.mpox.lapis.authorsField;
         this.authorAffiliationsField = organismsConfig.mpox.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.mpox.lapis.additionalFilters;
+        this.accessionDownloadFields = organismsConfig.mpox.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
@@ -88,6 +88,11 @@ export abstract class CompareSideBySideStateHandler<ColumnData extends DatasetAn
         return toLapisFilterWithoutVariant({ datasetFilter }, this.constants);
     }
 
+    public abstract variantFilterToLapisFilter(
+        datasetFilter: ColumnData['datasetFilter'],
+        variantFilter: ColumnData['variantFilter'],
+    ): LapisFilter;
+
     protected abstract writeColumnDataToSearchParams(searchOfFilter: URLSearchParams, filter: ColumnData): void;
 
     protected abstract getEmptyColumnData(): ColumnData;
@@ -131,6 +136,17 @@ export class GenericCompareSideBySideStateHandler extends CompareSideBySideState
                     ) ?? this.constants.defaultDateRange,
             },
             variantFilter: getLapisVariantQuery(filterParams, getLineageFilterFields(this.constants.lineageFilters)),
+        };
+    }
+
+    public variantFilterToLapisFilter(
+        datasetFilter: DatasetAndVariantData['datasetFilter'],
+        variantFilter: DatasetAndVariantData['variantFilter'],
+    ): LapisFilter {
+        return {
+            ...variantFilter.lineages,
+            ...variantFilter.mutations,
+            ...this.datasetFilterToLapisFilter(datasetFilter),
         };
     }
 }

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -22,6 +22,7 @@ const mockConstants: ExtendedConstants = {
         },
     ],
     additionalSequencingEffortsFields: [],
+    accessionDownloadFields: [],
 };
 
 const mockDefaultPageState: CompareToBaselineData = {

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -22,6 +22,7 @@ const mockConstants: ExtendedConstants = {
         },
     ],
     additionalSequencingEffortsFields: [],
+    accessionDownloadFields: [],
 };
 
 const mockDefaultPageState: CompareVariantsData = {

--- a/website/src/views/pageStateHandlers/PageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.ts
@@ -1,8 +1,8 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import type { ExtendedConstants } from '../OrganismConstants.ts';
-import { type Dataset, type Id, type VariantFilter } from '../View.ts';
-import { type LapisLocation } from '../helpers.ts';
+import { type Dataset, type Id } from '../View.ts';
+import { type LapisCovidVariantFilter, type LapisLocation } from '../helpers.ts';
 
 export interface PageStateHandler<PageState extends object> {
     parsePageStateFromUrl(url: URL): PageState;
@@ -81,12 +81,13 @@ export function searchParamsFromFilterMap<Entry>(
     return encodeMultipleFiltersToUrlSearchParam(searchParameterMap);
 }
 
-export function toDisplayName(variantFilter: VariantFilter) {
+export function toDisplayName(variantFilter: LapisCovidVariantFilter) {
     return [
         ...Object.values(variantFilter.lineages).filter((lineage) => lineage !== undefined),
         ...(variantFilter.mutations.nucleotideMutations ?? []),
         ...(variantFilter.mutations.aminoAcidMutations ?? []),
         ...(variantFilter.mutations.nucleotideInsertions ?? []),
         ...(variantFilter.mutations.aminoAcidInsertions ?? []),
+        ...(variantFilter.variantQuery !== undefined ? [variantFilter.variantQuery] : []),
     ].join(' + ');
 }

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -48,6 +48,7 @@ class RsvAConstants implements ExtendedConstants {
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
+    public readonly accessionDownloadFields;
 
     public get additionalSequencingEffortsFields() {
         return getAuthorRelatedSequencingEffortsFields(this);
@@ -60,6 +61,7 @@ class RsvAConstants implements ExtendedConstants {
         this.authorsField = organismsConfig.rsvA.lapis.authorsField;
         this.authorAffiliationsField = organismsConfig.rsvA.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.rsvA.lapis.additionalFilters;
+        this.accessionDownloadFields = organismsConfig.rsvA.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -48,6 +48,7 @@ class RsvBConstants implements ExtendedConstants {
     public readonly authorAffiliationsField: string | undefined;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
+    public readonly accessionDownloadFields;
 
     public get additionalSequencingEffortsFields() {
         return getAuthorRelatedSequencingEffortsFields(this);
@@ -60,6 +61,7 @@ class RsvBConstants implements ExtendedConstants {
         this.authorsField = organismsConfig.rsvB.lapis.authorsField;
         this.authorAffiliationsField = organismsConfig.rsvB.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.rsvB.lapis.additionalFilters;
+        this.accessionDownloadFields = organismsConfig.rsvB.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -46,6 +46,7 @@ class WestNileConstants implements ExtendedConstants {
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;
+    public readonly accessionDownloadFields;
 
     public get additionalSequencingEffortsFields() {
         return getPathoplexusAdditionalSequencingEffortsFields(this);
@@ -61,6 +62,7 @@ class WestNileConstants implements ExtendedConstants {
         this.authorsField = organismsConfig.westNile.lapis.authorsField;
         this.authorAffiliationsField = organismsConfig.westNile.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.westNile.lapis.additionalFilters;
+        this.accessionDownloadFields = organismsConfig.westNile.lapis.accessionDownloadFields;
     }
 }
 


### PR DESCRIPTION
 

resolves #425, #432



### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

This adds a "download data" button to the footer of every organism page. Clicking it opens a modal that offers links to download the accessions of every variant on the page.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/user-attachments/assets/3cb40d4e-30fb-488f-b161-a44dbd9e166b)
