### PR TITLE
feat(website): add fragment links to scroll to component headlines

### DIFF
--- a/website/src/components/ComponentHeadline.astro
+++ b/website/src/components/ComponentHeadline.astro
@@ -1,7 +1,17 @@
 ---
+import { fragmentLinkScrollMargin } from '../layouts/base/header/headerConstants';
+interface Props {
+    title: string;
+}
 
+const { title } = Astro.props;
+
+const fragmentId = title.toLowerCase().replace(/ /g, '-');
 ---
 
-<h2 class='font-bold'>
-    <slot />
+<h2 class={`font-bold ${fragmentLinkScrollMargin} `} id={fragmentId}>
+    <a href={`#${fragmentId}`} class='group flex items-center gap-1'>
+        {title}
+        <span class='iconify font-normal opacity-0 mdi--link-variant group-hover:opacity-100'></span>
+    </a>
 </h2>

--- a/website/src/components/ComponentWrapper.astro
+++ b/website/src/components/ComponentWrapper.astro
@@ -9,7 +9,7 @@ const { title, height = '400px' } = Astro.props;
 ---
 
 <div>
-    <ComponentHeadline>{title}</ComponentHeadline>
+    <ComponentHeadline title={title} />
     <div style={{ height }}>
         <slot />
     </div>

--- a/website/src/components/genspectrum/GsStatistics.astro
+++ b/website/src/components/genspectrum/GsStatistics.astro
@@ -1,0 +1,21 @@
+---
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+
+import ComponentHeadline from '../ComponentHeadline.astro';
+
+interface Props {
+    numeratorFilter: LapisFilter;
+    denominatorFilter: LapisFilter;
+}
+
+const { numeratorFilter, denominatorFilter } = Astro.props;
+---
+
+<div class='h-56 sm:h-32'>
+    <ComponentHeadline title='Stats' />
+    <gs-statistics
+        numeratorFilter={JSON.stringify(numeratorFilter)}
+        denominatorFilter={JSON.stringify(denominatorFilter)}
+        width='100%'
+        height='100%'></gs-statistics>
+</div>

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -10,12 +10,12 @@ import { toDisplayName } from '../../../views/pageStateHandlers/PageStateHandler
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { singleVariantViewKey } from '../../../views/viewKeys';
-import ComponentHeadline from '../../ComponentHeadline.astro';
 import ComponentsGrid from '../../ComponentsGrid.astro';
 import GsAggregate from '../../genspectrum/GsAggregate.astro';
 import GsMutations from '../../genspectrum/GsMutations.astro';
 import GsMutationsOverTime from '../../genspectrum/GsMutationsOverTime.astro';
 import GsPrevalenceOverTime from '../../genspectrum/GsPrevalenceOverTime.astro';
+import GsStatistics from '../../genspectrum/GsStatistics.astro';
 import { AnalyzeSingleVariantSelectorFallback } from '../../pageStateSelectors/FallbackElement';
 import { SingleVariantPageStateSelector } from '../../pageStateSelectors/SingleVariantPageStateSelector';
 import { sanitizeForFilename } from '../compareSideBySide/toDownloadLink';
@@ -92,15 +92,7 @@ const downloadLinks = noVariantSelected
             <SelectVariant slot='dataDisplay' />
         ) : (
             <div class='mx-[8px] flex flex-col gap-y-6' slot='dataDisplay'>
-                <div class='h-56 sm:h-32'>
-                    <ComponentHeadline>Stats</ComponentHeadline>
-                    <gs-statistics
-                        numeratorFilter={JSON.stringify(variantLapisFilter)}
-                        denominatorFilter={JSON.stringify(datasetLapisFilter)}
-                        width='100%'
-                        height='100%'
-                    />
-                </div>
+                <GsStatistics numeratorFilter={variantLapisFilter} denominatorFilter={datasetLapisFilter} />
                 <ComponentsGrid>
                     <GsPrevalenceOverTime
                         numeratorFilters={[

--- a/website/src/layouts/base/BaseLayout.astro
+++ b/website/src/layouts/base/BaseLayout.astro
@@ -16,7 +16,7 @@ interface Props {
 const { title, forceLoggedOutState = false } = Astro.props;
 ---
 
-<html lang='en'>
+<html lang='en' class='scroll-smooth'>
     <head>
         <meta charset='utf-8' />
         <link rel='icon' type='image/png' href='/virus-outline-colorful.svg' />

--- a/website/src/layouts/base/header/headerConstants.ts
+++ b/website/src/layouts/base/header/headerConstants.ts
@@ -1,1 +1,8 @@
 export const headerHeight = 'h-16';
+
+/**
+ * Account for the header when scrolling to a fragment link (href="#my-fragment").
+ * Otherwise, the fragment that we scroll to will be hidden behind the header.
+ * The height must match the header height (plus a little extra spacing).
+ */
+export const fragmentLinkScrollMargin = 'scroll-mt-20';

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -1,11 +1,11 @@
 ---
-import ComponentHeadline from '../../components/ComponentHeadline.astro';
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import GsAggregate from '../../components/genspectrum/GsAggregate.astro';
 import GsMutations from '../../components/genspectrum/GsMutations.astro';
 import GsMutationsOverTime from '../../components/genspectrum/GsMutationsOverTime.astro';
 import GsPrevalenceOverTime from '../../components/genspectrum/GsPrevalenceOverTime.astro';
 import GsRelativeGrowthAdvantage from '../../components/genspectrum/GsRelativeGrowthAdvantage.astro';
+import GsStatistics from '../../components/genspectrum/GsStatistics.astro';
 import { AnalyzeSingleVariantSelectorFallback } from '../../components/pageStateSelectors/FallbackElement';
 import { SingleVariantPageStateSelector } from '../../components/pageStateSelectors/SingleVariantPageStateSelector';
 import { CollectionsList } from '../../components/views/analyzeSingleVariant/CollectionsList';
@@ -95,15 +95,7 @@ const downloadLinks = noVariantSelected
             <SelectVariant slot='dataDisplay' />
         ) : (
             <div class='mx-[8px] flex flex-col gap-y-6' slot='dataDisplay'>
-                <div class='h-56 sm:h-32'>
-                    <ComponentHeadline>Stats</ComponentHeadline>
-                    <gs-statistics
-                        numeratorFilter={JSON.stringify(variantFilter)}
-                        denominatorFilter={JSON.stringify(datasetLapisFilter)}
-                        width='100%'
-                        height='100%'
-                    />
-                </div>
+                <GsStatistics numeratorFilter={variantFilter} denominatorFilter={datasetLapisFilter} />
                 <ComponentsGrid>
                     <GsPrevalenceOverTime
                         numeratorFilters={[


### PR DESCRIPTION
resolves #426



### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

Clicking the headline will scroll to the component. When hovering the headline, a link symbol is displayed.
![grafik](https://github.com/user-attachments/assets/f246caa6-48b3-4bca-aa48-5958bf97490e)

