### PR TITLE
feat(website): update GsTextInput and GsLineageFilter to only show options that correspond to current filters

### DIFF
--- a/website/src/components/genspectrum/GsLineageFilter.tsx
+++ b/website/src/components/genspectrum/GsLineageFilter.tsx
@@ -1,3 +1,4 @@
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useEffect, useRef } from 'react';
 
 import '@genspectrum/dashboard-components/components';
@@ -8,12 +9,14 @@ export function GsLineageFilter<Lineage extends string>({
     placeholderText,
     width,
     onLineageChange = () => {},
+    lapisFilter,
 }: {
     lapisField: Lineage;
     initialValue?: string;
     placeholderText?: string;
     width?: string;
     onLineageChange?: (lineage: { [key in Lineage]: string | undefined }) => void;
+    lapisFilter: LapisFilter;
 }) {
     const lineageFilterRef = useRef<HTMLElement>();
 
@@ -37,6 +40,7 @@ export function GsLineageFilter<Lineage extends string>({
     return (
         <gs-lineage-filter
             lapisField={lapisField}
+            lapisFilter={JSON.stringify(lapisFilter)}
             placeholderText={placeholderText}
             initialValue={initialValue ?? ''}
             width={width}

--- a/website/src/components/genspectrum/GsLocationFilter.tsx
+++ b/website/src/components/genspectrum/GsLocationFilter.tsx
@@ -1,46 +1,38 @@
-import { useEffect, useRef } from 'react';
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
+import { GsTextInput } from '../genspectrum/GsTextInput.tsx';
 import '@genspectrum/dashboard-components/components';
+import type { LocationFilterConfig } from '../pageStateSelectors/BaselineSelector.tsx';
 
-export function GsLocationFilter<Field extends string>({
+export function GsLocationFilter({
     onLocationChange = () => {},
-    fields,
-    placeholderText,
-    width,
-    initialValue,
+    locationFilterConfig,
+    lapisFilter,
 }: {
-    width?: string;
-    placeholderText?: string;
-    fields: Field[];
-    onLocationChange?: (location: { [key in Field]: string | undefined }) => void;
-    initialValue?: string;
+    onLocationChange?: (locationFilterConfig: LocationFilterConfig) => void;
+    locationFilterConfig: LocationFilterConfig;
+    lapisFilter: LapisFilter;
 }) {
-    const locationFilterRef = useRef<HTMLElement>();
+    return locationFilterConfig.locationFields.map((field) => {
+        return (
+            <GsTextInput
+                key={field}
+                lapisField={field}
+                lapisFilter={lapisFilter}
+                placeholderText={field}
+                initialValue={locationFilterConfig.initialLocation[field] ?? ''}
+                onInputChange={(location) => {
+                    const newLocationFilterConfig = {
+                        ...locationFilterConfig,
+                        initialLocation: {
+                            ...locationFilterConfig.initialLocation,
+                            ...location,
+                        },
+                    };
 
-    useEffect(() => {
-        const handleLocationChange = (event: CustomEvent) => {
-            onLocationChange(event.detail);
-        };
-
-        const currentLocationFilterRef = locationFilterRef.current;
-        if (currentLocationFilterRef) {
-            currentLocationFilterRef.addEventListener('gs-location-changed', handleLocationChange);
-        }
-
-        return () => {
-            if (currentLocationFilterRef) {
-                currentLocationFilterRef.removeEventListener('gs-location-changed', handleLocationChange);
-            }
-        };
-    }, [onLocationChange]);
-
-    return (
-        <gs-location-filter
-            fields={JSON.stringify(fields)}
-            placeholderText={placeholderText}
-            width={width}
-            ref={locationFilterRef}
-            initialValue={initialValue}
-        ></gs-location-filter>
-    );
+                    onLocationChange(newLocationFilterConfig);
+                }}
+            />
+        );
+    });
 }

--- a/website/src/components/genspectrum/GsTextInput.tsx
+++ b/website/src/components/genspectrum/GsTextInput.tsx
@@ -1,3 +1,4 @@
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useEffect, useRef } from 'react';
 
 import '@genspectrum/dashboard-components/components';
@@ -8,12 +9,14 @@ export function GsTextInput<LapisField extends string>({
     width,
     onInputChange = () => {},
     initialValue,
+    lapisFilter,
 }: {
     lapisField: LapisField;
     placeholderText?: string;
     width?: string;
     onInputChange?: (input: { [key in LapisField]: string | undefined }) => void;
     initialValue?: string | undefined;
+    lapisFilter: LapisFilter;
 }) {
     const textInputRef = useRef<HTMLElement>();
 
@@ -38,6 +41,7 @@ export function GsTextInput<LapisField extends string>({
         <gs-text-input
             ref={textInputRef}
             lapisField={lapisField}
+            lapisFilter={JSON.stringify(lapisFilter)}
             placeholderText={placeholderText}
             width={width}
             initialValue={initialValue ?? ''}

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -1,4 +1,4 @@
-import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
+import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import type { LapisLocation } from '../../views/helpers.ts';
 import { GsDateRangeSelector } from '../genspectrum/GsDateRangeSelector.tsx';
@@ -22,22 +22,20 @@ export function BaselineSelector({
     onLocationChange,
     dateRangeFilterConfig,
     onDateRangeChange,
+    lapisFilter,
 }: {
-    onLocationChange: (location: LapisLocation) => void;
+    onLocationChange: (locationFilterConfig: LocationFilterConfig) => void;
     locationFilterConfig: LocationFilterConfig;
     onDateRangeChange: (dateRange: DateRangeOption) => void;
     dateRangeFilterConfig: DateRangeFilterConfig;
+    lapisFilter: LapisFilter;
 }) {
     return (
         <div className='flex flex-col gap-2'>
             <GsLocationFilter
-                fields={locationFilterConfig.locationFields}
                 onLocationChange={onLocationChange}
-                initialValue={locationFilterConfig.locationFields
-                    .map((field) => locationFilterConfig.initialLocation[field])
-                    .filter(Boolean)
-                    .join(' / ')}
-                placeholderText={locationFilterConfig.placeholderText}
+                locationFilterConfig={locationFilterConfig}
+                lapisFilter={lapisFilter}
             ></GsLocationFilter>
             <GsDateRangeSelector
                 lapisDateField={dateRangeFilterConfig.dateColumn}

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -8,7 +8,6 @@ import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig
 import { VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
 import type { CovidCompareSideBySideData } from '../../views/covid.ts';
-import { type LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { compareSideBySideViewKey } from '../../views/viewKeys.ts';
 
@@ -31,7 +30,7 @@ export function CompareSideBySidePageStateSelector({
     organismsConfig: OrganismsConfig;
     lapisFilter: LapisFilter;
 }) {
-    const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
+    const [locationConfig, setLocationConfig] = useState<LocationFilterConfig>(locationFilterConfig);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
     const [variantFilterConfigState, setVariantFilterConfigState] = useState<VariantFilterConfig>(variantFilterConfig);
 
@@ -41,7 +40,7 @@ export function CompareSideBySidePageStateSelector({
         const updatedFilters = new Map(pageState.filters);
         updatedFilters.set(filterId, {
             datasetFilter: {
-                location,
+                location: locationConfig.initialLocation,
                 dateRange,
             },
             variantFilter: toVariantFilter(variantFilterConfigState),
@@ -51,7 +50,7 @@ export function CompareSideBySidePageStateSelector({
             ...pageState,
             filters: updatedFilters,
         };
-    }, [location, dateRange, variantFilterConfigState, filterId, pageState]);
+    }, [locationConfig, dateRange, variantFilterConfigState, filterId, pageState]);
 
     useEffect(() => {
         const newUrl = view.pageStateHandler.toUrl(newPageState);
@@ -70,10 +69,11 @@ export function CompareSideBySidePageStateSelector({
                 <div className='flex-0'>
                     <SelectorHeadline>Filter dataset</SelectorHeadline>
                     <BaselineSelector
-                        onLocationChange={(location) => setLocation(location)}
+                        onLocationChange={(locationConfig) => setLocationConfig(locationConfig)}
                         locationFilterConfig={locationFilterConfig}
                         onDateRangeChange={(dateRange) => setDateRange(dateRange)}
                         dateRangeFilterConfig={dateRangeFilterConfig}
+                        lapisFilter={lapisFilter}
                     />
                 </div>
                 <div className='flex-grow'>

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -1,4 +1,5 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
@@ -20,6 +21,7 @@ export function CompareSideBySidePageStateSelector({
     pageState,
     organismViewKey,
     organismsConfig,
+    lapisFilter,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
@@ -28,6 +30,7 @@ export function CompareSideBySidePageStateSelector({
     pageState: CovidCompareSideBySideData;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareSideBySideViewKey}`;
     organismsConfig: OrganismsConfig;
+    lapisFilter: LapisFilter;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
@@ -64,6 +67,7 @@ export function CompareSideBySidePageStateSelector({
                     <VariantSelector
                         onVariantFilterChange={(variantFilter) => setVariantFilterConfigState(variantFilter)}
                         variantFilterConfig={variantFilterConfigState}
+                        lapisFilter={lapisFilter}
                     />
                 </div>
             </div>

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -1,4 +1,4 @@
-import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
+import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
@@ -18,12 +18,14 @@ export function CompareVariantsPageStateSelector({
     variantFilterConfigs,
     organismViewKey,
     organismsConfig,
+    lapisFilter,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
     variantFilterConfigs: Map<Id, VariantFilterConfig>;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareVariantsViewKey}`;
     organismsConfig: OrganismsConfig;
+    lapisFilter: LapisFilter;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
@@ -66,6 +68,7 @@ export function CompareVariantsPageStateSelector({
                 <SelectorHeadline>Variant Filters</SelectorHeadline>
                 <VariantsSelector
                     variantFilterConfigs={variantConfigs}
+                    lapisFilter={lapisFilter}
                     setVariantFilterConfigs={setVariantConfigs}
                     emptyVariantFilterConfigProvider={() => view.pageStateHandler.getEmptyVariantFilterConfig()}
                 />

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -1,7 +1,6 @@
 import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
@@ -53,6 +52,19 @@ export function CompareVariantsPageStateSelector({
         };
     }, [location, dateRange, variantConfigs]);
 
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const newUrl = view.pageStateHandler.toUrl(newPageState);
+
+            const currentUrl = new URL(window.location.href);
+            const targetUrl = new URL(newUrl, window.location.origin);
+
+            if (currentUrl.href !== targetUrl.href) {
+                window.location.href = targetUrl.href;
+            }
+        }
+    }, [newPageState, view]);
+
     return (
         <div className='flex flex-col gap-6'>
             <div>
@@ -73,7 +85,6 @@ export function CompareVariantsPageStateSelector({
                     emptyVariantFilterConfigProvider={() => view.pageStateHandler.getEmptyVariantFilterConfig()}
                 />
             </div>
-            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -7,7 +7,6 @@ import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig
 import { VariantsSelector } from './VariantsSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
 import type { Id } from '../../views/View.ts';
-import { type LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { compareVariantsViewKey } from '../../views/viewKeys.ts';
 
@@ -26,7 +25,7 @@ export function CompareVariantsPageStateSelector({
     organismsConfig: OrganismsConfig;
     lapisFilter: LapisFilter;
 }) {
-    const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
+    const [locationConfig, setLocationConfig] = useState<LocationFilterConfig>(locationFilterConfig);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
 
     const [variantConfigs, setVariantConfigs] = useState<Map<Id, VariantFilterConfig>>(variantFilterConfigs);
@@ -45,12 +44,12 @@ export function CompareVariantsPageStateSelector({
 
         return {
             datasetFilter: {
-                location,
+                location: locationConfig.initialLocation,
                 dateRange,
             },
             variants,
         };
-    }, [location, dateRange, variantConfigs]);
+    }, [locationConfig, dateRange, variantConfigs]);
 
     useEffect(() => {
         if (typeof window !== 'undefined') {
@@ -70,10 +69,11 @@ export function CompareVariantsPageStateSelector({
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <BaselineSelector
-                    onLocationChange={setLocation}
+                    onLocationChange={setLocationConfig}
                     locationFilterConfig={locationFilterConfig}
                     onDateRangeChange={setDateRange}
                     dateRangeFilterConfig={dateRangeFilterConfig}
+                    lapisFilter={lapisFilter}
                 />
             </div>
             <div>

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -9,7 +9,6 @@ import { VariantSelector } from './VariantSelector.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
 import type { Id } from '../../views/View.ts';
-import { type LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import { type compareToBaselineViewKey } from '../../views/viewKeys.ts';
 
@@ -30,7 +29,7 @@ export function CompareVariantsToBaselineStateSelector({
     organismsConfig: OrganismsConfig;
     lapisFilter: LapisFilter;
 }) {
-    const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
+    const [locationConfig, setLocationConfig] = useState<LocationFilterConfig>(locationFilterConfig);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
     const [baselineFilterConfigState, setBaselineFilterConfigState] =
         useState<VariantFilterConfig>(baselineFilterConfig);
@@ -51,13 +50,13 @@ export function CompareVariantsToBaselineStateSelector({
 
         return {
             datasetFilter: {
-                location,
+                location: locationConfig.initialLocation,
                 dateRange,
             },
             variants,
             baselineFilter: toVariantFilter(baselineFilterConfigState),
         };
-    }, [variantConfigs, location, dateRange, baselineFilterConfigState]);
+    }, [variantConfigs, locationConfig, dateRange, baselineFilterConfigState]);
 
     useEffect(() => {
         if (typeof window !== 'undefined') {
@@ -77,10 +76,11 @@ export function CompareVariantsToBaselineStateSelector({
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <BaselineSelector
-                    onLocationChange={setLocation}
+                    onLocationChange={setLocationConfig}
                     locationFilterConfig={locationFilterConfig}
                     onDateRangeChange={setDateRange}
                     dateRangeFilterConfig={dateRangeFilterConfig}
+                    lapisFilter={lapisFilter}
                 />
             </div>
             <div>

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -1,4 +1,5 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
@@ -20,6 +21,7 @@ export function CompareVariantsToBaselineStateSelector({
     variantFilterConfigs,
     organismViewKey,
     organismsConfig,
+    lapisFilter,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
@@ -27,6 +29,7 @@ export function CompareVariantsToBaselineStateSelector({
     variantFilterConfigs: Map<Id, VariantFilterConfig>;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareToBaselineViewKey}`;
     organismsConfig: OrganismsConfig;
+    lapisFilter: LapisFilter;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
@@ -73,6 +76,7 @@ export function CompareVariantsToBaselineStateSelector({
                 <VariantSelector
                     onVariantFilterChange={setBaselineFilterConfigState}
                     variantFilterConfig={baselineFilterConfigState}
+                    lapisFilter={lapisFilter}
                 />
             </div>
             <div>
@@ -81,6 +85,7 @@ export function CompareVariantsToBaselineStateSelector({
                     variantFilterConfigs={variantConfigs}
                     setVariantFilterConfigs={setVariantConfigs}
                     emptyVariantFilterConfigProvider={() => view.pageStateHandler.getEmptyVariantFilterConfig()}
+                    lapisFilter={lapisFilter}
                 />
             </div>
             <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -1,8 +1,7 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
@@ -60,6 +59,19 @@ export function CompareVariantsToBaselineStateSelector({
         };
     }, [variantConfigs, location, dateRange, baselineFilterConfigState]);
 
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const newUrl = view.pageStateHandler.toUrl(newPageState);
+
+            const currentUrl = new URL(window.location.href);
+            const targetUrl = new URL(newUrl, window.location.origin);
+
+            if (currentUrl.href !== targetUrl.href) {
+                window.location.href = targetUrl.href;
+            }
+        }
+    }, [newPageState, view]);
+
     return (
         <div className='flex flex-col gap-6'>
             <div>
@@ -88,7 +100,6 @@ export function CompareVariantsToBaselineStateSelector({
                     lapisFilter={lapisFilter}
                 />
             </div>
-            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/LineageFilterInput.tsx
+++ b/website/src/components/pageStateSelectors/LineageFilterInput.tsx
@@ -1,3 +1,5 @@
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+
 import { GsLineageFilter } from '../genspectrum/GsLineageFilter.tsx';
 import { GsTextInput } from '../genspectrum/GsTextInput.tsx';
 
@@ -11,15 +13,18 @@ export type LineageFilterConfig = {
 export function LineageFilterInput({
     lineageFilterConfig,
     onLineageChange,
+    lapisFilter,
 }: {
     lineageFilterConfig: LineageFilterConfig;
     onLineageChange: (lineage: string | undefined) => void;
+    lapisFilter: LapisFilter;
 }) {
     switch (lineageFilterConfig.filterType) {
         case 'lineage':
             return (
                 <GsLineageFilter
                     lapisField={lineageFilterConfig.lapisField}
+                    lapisFilter={lapisFilter}
                     placeholderText={lineageFilterConfig.placeholderText}
                     onLineageChange={(lineage) => onLineageChange(lineage[lineageFilterConfig.lapisField])}
                     initialValue={lineageFilterConfig.initialValue}
@@ -30,6 +35,7 @@ export function LineageFilterInput({
             return (
                 <GsTextInput
                     lapisField={lineageFilterConfig.lapisField}
+                    lapisFilter={lapisFilter}
                     placeholderText={lineageFilterConfig.placeholderText}
                     onInputChange={(lineage) => onLineageChange(lineage[lineageFilterConfig.lapisField])}
                     initialValue={lineageFilterConfig.initialValue}

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -1,8 +1,7 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
@@ -43,6 +42,19 @@ export function SequencingEffortsPageStateSelector({
         [location, dateRange, variantFilterConfigState],
     );
 
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const newUrl = view.pageStateHandler.toUrl(newPageState);
+
+            const currentUrl = new URL(window.location.href);
+            const targetUrl = new URL(newUrl, window.location.origin);
+
+            if (currentUrl.href !== targetUrl.href) {
+                window.location.href = targetUrl.href;
+            }
+        }
+    }, [newPageState, view]);
+
     return (
         <div className='flex flex-col gap-6'>
             <div>
@@ -62,7 +74,6 @@ export function SequencingEffortsPageStateSelector({
                     lapisFilter={lapisFilter}
                 />
             </div>
-            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -1,4 +1,5 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
@@ -17,12 +18,14 @@ export function SequencingEffortsPageStateSelector({
     variantFilterConfig,
     organismViewKey,
     organismsConfig,
+    lapisFilter,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
     variantFilterConfig: VariantFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof sequencingEffortsViewKey}`;
     organismsConfig: OrganismsConfig;
+    lapisFilter: LapisFilter;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
     const [variantFilterConfigState, setVariantFilterConfigState] = useState<VariantFilterConfig>(variantFilterConfig);
@@ -56,6 +59,7 @@ export function SequencingEffortsPageStateSelector({
                     onVariantFilterChange={setVariantFilterConfigState}
                     variantFilterConfig={variantFilterConfigState}
                     hideMutationFilter={true}
+                    lapisFilter={lapisFilter}
                 />
             </div>
             <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -7,7 +7,6 @@ import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
 import { VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
-import type { LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { sequencingEffortsViewKey } from '../../views/viewKeys.ts';
 
@@ -26,7 +25,7 @@ export function SequencingEffortsPageStateSelector({
     organismsConfig: OrganismsConfig;
     lapisFilter: LapisFilter;
 }) {
-    const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
+    const [locationConfig, setLocationConfig] = useState<LocationFilterConfig>(locationFilterConfig);
     const [variantFilterConfigState, setVariantFilterConfigState] = useState<VariantFilterConfig>(variantFilterConfig);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
@@ -34,12 +33,12 @@ export function SequencingEffortsPageStateSelector({
     const newPageState = useMemo(
         () => ({
             datasetFilter: {
-                location,
+                location: locationConfig.initialLocation,
                 dateRange,
             },
             variantFilter: toVariantFilter(variantFilterConfigState),
         }),
-        [location, dateRange, variantFilterConfigState],
+        [locationConfig, dateRange, variantFilterConfigState],
     );
 
     useEffect(() => {
@@ -60,10 +59,11 @@ export function SequencingEffortsPageStateSelector({
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <BaselineSelector
-                    onLocationChange={(location) => setLocation(location)}
+                    onLocationChange={(locationConfig) => setLocationConfig(locationConfig)}
                     locationFilterConfig={locationFilterConfig}
                     onDateRangeChange={(dateRange) => setDateRange(dateRange)}
                     dateRangeFilterConfig={dateRangeFilterConfig}
+                    lapisFilter={lapisFilter}
                 />
             </div>
             <div>

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -7,7 +7,6 @@ import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
 import { VariantSelector } from './VariantSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
-import { type LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { singleVariantViewKey } from '../../views/viewKeys.ts';
 
@@ -26,7 +25,7 @@ export function SingleVariantPageStateSelector({
     organismsConfig: OrganismsConfig;
     lapisFilter: LapisFilter;
 }) {
-    const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
+    const [locationConfig, setLocationConfig] = useState<LocationFilterConfig>(locationFilterConfig);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
 
     const [variantFilterConfigState, setVariantFilterConfigState] = useState<VariantFilterConfig>(variantFilterConfig);
@@ -36,12 +35,12 @@ export function SingleVariantPageStateSelector({
     const newPageState = useMemo(
         () => ({
             datasetFilter: {
-                location,
+                location: locationConfig.initialLocation,
                 dateRange,
             },
             variantFilter: toVariantFilter(variantFilterConfigState),
         }),
-        [location, dateRange, variantFilterConfigState],
+        [locationConfig, dateRange, variantFilterConfigState],
     );
 
     useEffect(() => {
@@ -62,10 +61,11 @@ export function SingleVariantPageStateSelector({
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <BaselineSelector
-                    onLocationChange={setLocation}
+                    onLocationChange={(locationConfig) => setLocationConfig(locationConfig)}
                     locationFilterConfig={locationFilterConfig}
-                    onDateRangeChange={setDateRange}
+                    onDateRangeChange={(dateRange) => setDateRange(dateRange)}
                     dateRangeFilterConfig={dateRangeFilterConfig}
+                    lapisFilter={lapisFilter}
                 />
             </div>
             <div>

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -1,8 +1,7 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
@@ -45,6 +44,19 @@ export function SingleVariantPageStateSelector({
         [location, dateRange, variantFilterConfigState],
     );
 
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const newUrl = view.pageStateHandler.toUrl(newPageState);
+
+            const currentUrl = new URL(window.location.href);
+            const targetUrl = new URL(newUrl, window.location.origin);
+
+            if (currentUrl.href !== targetUrl.href) {
+                window.location.href = targetUrl.href;
+            }
+        }
+    }, [newPageState, view]);
+
     return (
         <div className='flex flex-col gap-6'>
             <div>
@@ -64,7 +76,6 @@ export function SingleVariantPageStateSelector({
                     lapisFilter={lapisFilter}
                 />
             </div>
-            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -1,4 +1,5 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
@@ -17,12 +18,14 @@ export function SingleVariantPageStateSelector({
     variantFilterConfig,
     organismViewKey,
     organismsConfig,
+    lapisFilter,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
     variantFilterConfig: VariantFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof singleVariantViewKey}`;
     organismsConfig: OrganismsConfig;
+    lapisFilter: LapisFilter;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
@@ -58,6 +61,7 @@ export function SingleVariantPageStateSelector({
                 <VariantSelector
                     onVariantFilterChange={setVariantFilterConfigState}
                     variantFilterConfig={variantFilterConfigState}
+                    lapisFilter={lapisFilter}
                 />
             </div>
             <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -1,3 +1,5 @@
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+
 import { LineageFilterInput } from './LineageFilterInput.tsx';
 import type { VariantFilterConfig } from './VariantFilterConfig.ts';
 import { getMutationFilter } from '../../views/helpers.ts';
@@ -7,10 +9,12 @@ export function VariantSelector({
     onVariantFilterChange,
     variantFilterConfig,
     hideMutationFilter,
+    lapisFilter,
 }: {
     variantFilterConfig: VariantFilterConfig;
     onVariantFilterChange: (variantFilter: VariantFilterConfig) => void;
     hideMutationFilter?: boolean | undefined;
+    lapisFilter: LapisFilter;
 }) {
     return (
         <div className='flex flex-col gap-2'>
@@ -29,6 +33,7 @@ export function VariantSelector({
                         onVariantFilterChange(newVariantFilterConfig);
                     }}
                     key={lineageFilterConfig.lapisField}
+                    lapisFilter={lapisFilter}
                 />
             ))}
             {!hideMutationFilter && (

--- a/website/src/components/pageStateSelectors/VariantsSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantsSelector.tsx
@@ -1,3 +1,5 @@
+import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+
 import { type VariantFilterConfig } from './VariantFilterConfig.ts';
 import { VariantSelector } from './VariantSelector.tsx';
 import type { Id } from '../../views/View.ts';
@@ -6,10 +8,12 @@ export function VariantsSelector({
     variantFilterConfigs,
     setVariantFilterConfigs,
     emptyVariantFilterConfigProvider,
+    lapisFilter,
 }: {
     variantFilterConfigs: Map<Id, VariantFilterConfig>;
     setVariantFilterConfigs: (variants: Map<Id, VariantFilterConfig>) => void;
     emptyVariantFilterConfigProvider: () => VariantFilterConfig;
+    lapisFilter: LapisFilter;
 }) {
     const removeVariant = (id: Id) => {
         setVariantFilterConfigs(new Map(Array.from(variantFilterConfigs).filter(([key]) => key !== id)));
@@ -44,6 +48,7 @@ export function VariantsSelector({
                     </div>
                     <VariantSelector
                         variantFilterConfig={filterConfig}
+                        lapisFilter={lapisFilter}
                         onVariantFilterChange={(variantFilter) => updateVariantFilter(id, variantFilter)}
                     />
                 </div>

--- a/website/src/components/subscriptions/create/BaselineInput.tsx
+++ b/website/src/components/subscriptions/create/BaselineInput.tsx
@@ -4,6 +4,12 @@ import { InputLabel } from '../../../styles/input/InputLabel.tsx';
 import { GsLocationFilter } from '../../genspectrum/GsLocationFilter.tsx';
 
 export function BaselineInput({ onBaselineChange }: { onBaselineChange: (baseline: LapisFilter) => void }) {
+    const locationFilterConfig = {
+        locationFields: ['region', 'country'],
+        initialLocation: {},
+        placeholderText: 'Location',
+    };
+
     return (
         <InputLabel
             title='Baseline'
@@ -11,12 +17,12 @@ export function BaselineInput({ onBaselineChange }: { onBaselineChange: (baselin
         >
             <div className='w-full'>
                 <GsLocationFilter
-                    fields={['region', 'country']}
-                    placeholderText='Baseline location'
-                    onLocationChange={(location) => {
-                        onBaselineChange(location);
+                    locationFilterConfig={locationFilterConfig}
+                    onLocationChange={(locationConfig) => {
+                        onBaselineChange(locationConfig.initialLocation);
                     }}
-                />
+                    lapisFilter={{}}
+                ></GsLocationFilter>
             </div>
         </InputLabel>
     );

--- a/website/src/components/subscriptions/create/CountFilterInput.tsx
+++ b/website/src/components/subscriptions/create/CountFilterInput.tsx
@@ -4,16 +4,22 @@ import { InputLabel } from '../../../styles/input/InputLabel.tsx';
 import { GsLocationFilter } from '../../genspectrum/GsLocationFilter.tsx';
 
 export function CountFilterInput({ onCountFilterChange }: { onCountFilterChange: (filter: LapisFilter) => void }) {
+    const locationFilterConfig = {
+        locationFields: ['region', 'country'],
+        initialLocation: {},
+        placeholderText: 'Location',
+    };
+
     return (
         <InputLabel title='Filter' description='The filter for the subscription.'>
             <div className='w-full'>
                 <GsLocationFilter
-                    fields={['region', 'country']}
-                    placeholderText='Location'
-                    onLocationChange={(location) => {
-                        onCountFilterChange(location);
+                    locationFilterConfig={locationFilterConfig}
+                    onLocationChange={(locationConfig) => {
+                        onCountFilterChange(locationConfig.initialLocation);
                     }}
-                />
+                    lapisFilter={{}}
+                ></GsLocationFilter>
             </div>
         </InputLabel>
     );

--- a/website/src/components/subscriptions/create/VariantInput.tsx
+++ b/website/src/components/subscriptions/create/VariantInput.tsx
@@ -20,6 +20,7 @@ export function VariantInput({ onVariantInputChange }: { onVariantInputChange: (
             <div className='flex w-full flex-col gap-2'>
                 <GsLineageFilter
                     lapisField='pangoLineage'
+                    lapisFilter={{}}
                     placeholderText='Pangolineage'
                     onLineageChange={(lineage) => {
                         setVariantFilter((prevVariantFilter) => {

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -83,6 +83,7 @@ const downloadLinks = noVariantSelected
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
+        lapisFilter={datasetLapisFilter}
     >
         <AnalyzeSingleVariantSelectorFallback slot='fallback' />
     </SingleVariantPageStateSelector>

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -83,7 +83,7 @@ const downloadLinks = noVariantSelected
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-        lapisFilter={datasetLapisFilter}
+        lapisFilter={variantLapisFilter}
     >
         <AnalyzeSingleVariantSelectorFallback slot='fallback' />
     </SingleVariantPageStateSelector>

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -81,7 +81,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
                                     client:only='react'
-                                    lapisFilter={datasetLapisFilter}
+                                    lapisFilter={numeratorFilter}
                                 >
                                     <CompareSideBySideSelectorFallback
                                         slot='fallback'

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -81,6 +81,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
                                     client:only='react'
+                                    lapisFilter={datasetLapisFilter}
                                 >
                                     <CompareSideBySideSelectorFallback
                                         slot='fallback'

--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
@@ -63,6 +63,7 @@ const downloadLinks = noVariantSelected
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
+        lapisFilter={baselineLapisFilter}
     >
         <CompareToBaselineSelectorFallback slot='fallback' numFilters={numeratorLapisFilters.length} />
     </CompareVariantsToBaselineStateSelector>

--- a/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
+++ b/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
@@ -63,6 +63,7 @@ const downloadLinks = notEnoughVariantsSelected
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
+        lapisFilter={datasetLapisFilter}
     >
         <CompareVariantsSelectorFallback slot='fallback' numFilters={numeratorLapisFilters.length} />
     </CompareVariantsPageStateSelector>

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -69,6 +69,7 @@ const lineageFilterConfigs = getLineageFilterConfigs(
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
         variantFilterConfig={{ mutationFilterConfig: pageState.variantFilter.mutations, lineageFilterConfigs }}
+        lapisFilter={lapisFilter}
     >
         <SequencingEffortsSelectorFallback slot='fallback' />
     </SequencingEffortsPageStateSelector>

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -78,6 +78,7 @@ const downloadLinks = [...pageState.filters.entries()].map(
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
                                     client:only='react'
+                                    lapisFilter={baselineLapisFilter}
                                 >
                                     <CompareSideBySideSelectorFallback
                                         slot='fallback'

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -78,7 +78,7 @@ const downloadLinks = [...pageState.filters.entries()].map(
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
                                     client:only='react'
-                                    lapisFilter={baselineLapisFilter}
+                                    lapisFilter={numeratorFilter}
                                 >
                                     <CompareSideBySideSelectorFallback
                                         slot='fallback'

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -77,6 +77,7 @@ const downloadLinks = noVariantSelected
             organismViewKey={organismViewKey}
             organismsConfig={getDashboardsConfig().dashboards.organisms}
             client:only='react'
+            lapisFilter={datasetLapisFilter}
         >
             <AnalyzeSingleVariantSelectorFallback slot='fallback' />
         </SingleVariantPageStateSelector>

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -77,7 +77,7 @@ const downloadLinks = noVariantSelected
             organismViewKey={organismViewKey}
             organismsConfig={getDashboardsConfig().dashboards.organisms}
             client:only='react'
-            lapisFilter={datasetLapisFilter}
+            lapisFilter={variantFilter}
         >
             <AnalyzeSingleVariantSelectorFallback slot='fallback' />
         </SingleVariantPageStateSelector>

--- a/website/tests/CompareVariantsPage.ts
+++ b/website/tests/CompareVariantsPage.ts
@@ -15,12 +15,14 @@ export class CompareVariantsPage extends ViewPage {
         await this.page.goto(`/${organismConfig[organism].pathFragment}/compare-variants`);
     }
 
-    public async addVariant(lineageFieldPlaceholder: string, lineage: string) {
+    public async addVariant(lineageFieldPlaceholder: string, lineage: string, startingNumber: number) {
+        await expect(this.page.getByText('Variant Filters')).toBeVisible({ timeout: 5000 });
         const lineageFieldLocator = this.page.getByPlaceholder(lineageFieldPlaceholder);
-        const numberLineageFields = await lineageFieldLocator.count();
+        await expect(lineageFieldLocator).toHaveCount(startingNumber, { timeout: 5000 });
 
         await this.page.getByRole('button', { name: '+ Add variant' }).click();
-        await expect(lineageFieldLocator).toHaveCount(numberLineageFields + 1);
+        await expect(this.page.getByText('Variant Filters')).toBeVisible({ timeout: 5000 });
+        await expect(lineageFieldLocator).toHaveCount(startingNumber + 1, { timeout: 5000 });
 
         await lineageFieldLocator.last().fill(lineage);
     }

--- a/website/tests/SequencingEffortsPage.ts
+++ b/website/tests/SequencingEffortsPage.ts
@@ -6,8 +6,8 @@ export class SequencingEffortsPage extends ViewPage {
         await this.page.goto(`/${organismConfig[organism].pathFragment}/sequencing-efforts`);
     }
 
-    public async selectLocation(location: string) {
-        const locationField = this.page.getByPlaceholder('Sampling location');
+    public async selectLocation(placeholder: string, location: string) {
+        const locationField = this.page.getByPlaceholder(placeholder);
         await locationField.fill(location);
     }
 

--- a/website/tests/ViewPage.ts
+++ b/website/tests/ViewPage.ts
@@ -7,10 +7,6 @@ export abstract class ViewPage {
 
     public abstract goto(organism: Organism): Promise<void>;
 
-    public async submitFilters() {
-        await this.page.getByRole('button', { name: 'Apply filters' }).click();
-    }
-
     public diagramTitle(title: string) {
         return this.page.getByRole('heading', { name: title });
     }

--- a/website/tests/compareVariants.spec.ts
+++ b/website/tests/compareVariants.spec.ts
@@ -21,8 +21,10 @@ test.describe('The Compare Variants page', () => {
             await expect(compareVariantsPage.selectVariantsMessage).toBeVisible();
             await expect(compareVariantsPage.diagramTitle('Prevalence over time')).not.toBeVisible();
 
-            await compareVariantsPage.addVariant(options.lineageFieldPlaceholder, options.lineage);
-            await compareVariantsPage.addVariant(options.lineageFieldPlaceholder, options.lineage);
+            await compareVariantsPage.expectToSeeNoComponentErrors();
+            await compareVariantsPage.addVariant(options.lineageFieldPlaceholder, options.lineage, 0);
+            await compareVariantsPage.expectToSeeNoComponentErrors();
+            await compareVariantsPage.addVariant(options.lineageFieldPlaceholder, options.lineage, 1);
 
             await expect(compareVariantsPage.diagramTitle('Prevalence over time')).toBeVisible();
             await compareVariantsPage.expectToSeeNoComponentErrors();

--- a/website/tests/compareVariants.spec.ts
+++ b/website/tests/compareVariants.spec.ts
@@ -23,7 +23,6 @@ test.describe('The Compare Variants page', () => {
 
             await compareVariantsPage.addVariant(options.lineageFieldPlaceholder, options.lineage);
             await compareVariantsPage.addVariant(options.lineageFieldPlaceholder, options.lineage);
-            await compareVariantsPage.submitFilters();
 
             await expect(compareVariantsPage.diagramTitle('Prevalence over time')).toBeVisible();
             await compareVariantsPage.expectToSeeNoComponentErrors();

--- a/website/tests/sequencingEfforts.spec.ts
+++ b/website/tests/sequencingEfforts.spec.ts
@@ -4,12 +4,12 @@ import { test } from './e2e.fixture.ts';
 import { allOrganisms, Organisms } from '../src/types/Organism.ts';
 
 const organismOptions = {
-    [Organisms.covid]: { location: 'North America' },
-    [Organisms.h5n1]: { location: 'USA' },
-    [Organisms.westNile]: { location: 'USA' },
-    [Organisms.rsvA]: { location: 'USA' },
-    [Organisms.rsvB]: { location: 'USA' },
-    [Organisms.mpox]: { location: 'USA' },
+    [Organisms.covid]: { placeholder: 'division', location: 'North America' },
+    [Organisms.h5n1]: { placeholder: 'country', location: 'USA' },
+    [Organisms.westNile]: { placeholder: 'country', location: 'USA' },
+    [Organisms.rsvA]: { placeholder: 'country', location: 'USA' },
+    [Organisms.rsvB]: { placeholder: 'country', location: 'USA' },
+    [Organisms.mpox]: { placeholder: 'country', location: 'USA' },
 };
 
 test.describe('The Sequencing Efforts Page', () => {
@@ -22,7 +22,7 @@ test.describe('The Sequencing Efforts Page', () => {
 
                 await sequencingEffortsPage.goto(organism);
                 await sequencingEffortsPage.expectToSeeNoComponentErrors();
-                await sequencingEffortsPage.selectLocation(options.location);
+                await sequencingEffortsPage.selectLocation(options.placeholder, options.location);
                 await sequencingEffortsPage.selectDateRange('All times');
 
                 await expect(sequencingEffortsPage.diagramTitle('Number sequences')).toBeVisible();

--- a/website/tests/sequencingEfforts.spec.ts
+++ b/website/tests/sequencingEfforts.spec.ts
@@ -24,7 +24,6 @@ test.describe('The Sequencing Efforts Page', () => {
                 await sequencingEffortsPage.expectToSeeNoComponentErrors();
                 await sequencingEffortsPage.selectLocation(options.location);
                 await sequencingEffortsPage.selectDateRange('All times');
-                await sequencingEffortsPage.submitFilters();
 
                 await expect(sequencingEffortsPage.diagramTitle('Number sequences')).toBeVisible();
                 await sequencingEffortsPage.expectToSeeNoComponentErrors();


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves https://github.com/GenSpectrum/dashboard-components/issues/609, https://github.com/GenSpectrum/dashboard-components/issues/632

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Currently the search bar shows all clades and countries that have ever been sequenced regardless of which other filters (such as time) have been applied - this means that for our start page most options will lead to 0 results. This isn't great for user experience. This filters down the options list in each filter using the currently applied filters.

As we currently apply filters based on page state this now means each filter change will result in a page reload. I do not see another solution to this problem without wrapping the filter bar in a react component with another temporary state.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->


https://github.com/user-attachments/assets/493f3339-9859-4417-9e17-80ff5a7d95ee


Relies on https://github.com/GenSpectrum/dashboard-components/pull/633

## TO DO
- [x] use for location filter as well
- [x] make sure that new lapisFilter is applied as soon as new options are selected and not only when apply filters button is clicked 
