### PR TITLE
fix(website): explicitly specify views on `gs-aggregate`

### DIFF
--- a/website/src/components/genspectrum/GsAggregate.astro
+++ b/website/src/components/genspectrum/GsAggregate.astro
@@ -1,5 +1,5 @@
 ---
-import { type LapisFilter } from '@genspectrum/dashboard-components/util';
+import { type LapisFilter, views } from '@genspectrum/dashboard-components/util';
 
 import { defaultTablePageSize } from '../../views/View';
 import ComponentWrapper from '../ComponentWrapper.astro';
@@ -16,6 +16,7 @@ const { title, height, fields, lapisFilter } = Astro.props;
 
 <ComponentWrapper title={title} height={height}>
     <gs-aggregate
+        views={JSON.stringify([views.table])}
         fields={JSON.stringify(fields)}
         lapisFilter={JSON.stringify(lapisFilter)}
         pageSize={defaultTablePageSize}


### PR DESCRIPTION

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->To prepare for https://github.com/GenSpectrum/dashboard-components/pull/639. Otherwise, we will have unexpected bar charts.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
