### PR TITLE
458 add advanced search for covid single variant page that offers variant query

### DIFF
--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -1,0 +1,18 @@
+import type { ChangeEventHandler } from 'react';
+
+export function AdvancedQueryFilter({
+    value,
+    onInput,
+}: {
+    value?: string;
+    onInput?: ChangeEventHandler<HTMLInputElement>;
+}) {
+    return (
+        <input
+            className='input input-bordered w-full'
+            placeholder={'Advanced query: A123T & ins_123:TA'}
+            value={value}
+            onInput={onInput}
+        ></input>
+    );
+}

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -20,7 +20,6 @@ export function CompareSideBySidePageStateSelector({
     pageState,
     organismViewKey,
     organismsConfig,
-    hideMutationFilter,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
@@ -29,7 +28,6 @@ export function CompareSideBySidePageStateSelector({
     pageState: CovidCompareSideBySideData;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareSideBySideViewKey}`;
     organismsConfig: OrganismsConfig;
-    hideMutationFilter?: boolean | undefined;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
     const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
@@ -66,7 +64,6 @@ export function CompareSideBySidePageStateSelector({
                     <VariantSelector
                         onVariantFilterChange={(variantFilter) => setVariantFilterConfigState(variantFilter)}
                         variantFilterConfig={variantFilterConfigState}
-                        hideMutationFilter={hideMutationFilter}
                     />
                 </div>
             </div>

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -54,8 +54,7 @@ export function SequencingEffortsPageStateSelector({
             <div>
                 <VariantSelector
                     onVariantFilterChange={setVariantFilterConfigState}
-                    variantFilterConfig={variantFilterConfigState}
-                    hideMutationFilter={true}
+                    variantFilterConfig={{ ...variantFilterConfigState, mutationFilterConfig: undefined }}
                 />
             </div>
             <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -55,6 +55,7 @@ export function SingleVariantPageStateSelector({
             </div>
             <div>
                 <SelectorHeadline>Variant Filter</SelectorHeadline>
+
                 <VariantSelector
                     onVariantFilterChange={setVariantFilterConfigState}
                     variantFilterConfig={variantFilterConfigState}

--- a/website/src/components/pageStateSelectors/VariantFilterConfig.ts
+++ b/website/src/components/pageStateSelectors/VariantFilterConfig.ts
@@ -3,15 +3,23 @@ import type { VariantFilter } from '../../views/View.ts';
 import type { LapisMutationQuery } from '../../views/helpers.ts';
 
 export type VariantFilterConfig = {
-    lineageFilterConfigs: LineageFilterConfig[];
-    mutationFilterConfig: LapisMutationQuery;
+    variantQueryConfig?: string;
+    lineageFilterConfigs?: LineageFilterConfig[];
+    mutationFilterConfig?: LapisMutationQuery;
+    isInVariantQueryMode?: boolean;
 };
 
 export function toVariantFilter(variantFilterConfig: VariantFilterConfig): VariantFilter {
-    return {
-        mutations: variantFilterConfig.mutationFilterConfig,
-        lineages: variantFilterConfig.lineageFilterConfigs.reduce((acc, lineageFilterConfig) => {
-            return { ...acc, [lineageFilterConfig.lapisField]: lineageFilterConfig.initialValue };
-        }, {}),
-    };
+    if (variantFilterConfig.isInVariantQueryMode) {
+        return {
+            variantQuery: variantFilterConfig.variantQueryConfig,
+        };
+    } else {
+        return {
+            mutations: variantFilterConfig.mutationFilterConfig,
+            lineages: variantFilterConfig.lineageFilterConfigs?.reduce((acc, lineageFilterConfig) => {
+                return { ...acc, [lineageFilterConfig.lapisField]: lineageFilterConfig.initialValue };
+            }, {}),
+        };
+    }
 }

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -1,51 +1,86 @@
 import { LineageFilterInput } from './LineageFilterInput.tsx';
 import type { VariantFilterConfig } from './VariantFilterConfig.ts';
 import { getMutationFilter } from '../../views/helpers.ts';
+import { AdvancedQueryFilter } from '../genspectrum/AdvancedQueryFilter.tsx';
 import { GsMutationFilter } from '../genspectrum/GsMutationFilter.tsx';
 
 export function VariantSelector({
     onVariantFilterChange,
     variantFilterConfig,
-    hideMutationFilter,
 }: {
     variantFilterConfig: VariantFilterConfig;
     onVariantFilterChange: (variantFilter: VariantFilterConfig) => void;
-    hideMutationFilter?: boolean | undefined;
 }) {
     return (
-        <div className='flex flex-col gap-2'>
-            {variantFilterConfig.lineageFilterConfigs.map((lineageFilterConfig) => (
-                <LineageFilterInput
-                    lineageFilterConfig={lineageFilterConfig}
-                    onLineageChange={(lineage) => {
-                        const newVariantFilterConfig = {
+        <div>
+            <label
+                className={`mb-1 flex cursor-pointer items-center gap-1 text-sm ${variantFilterConfig.isInVariantQueryMode === undefined ? 'hidden' : ''}`}
+            >
+                Advanced
+                <input
+                    type='checkbox'
+                    className='checkbox checkbox-xs'
+                    onChange={() => {
+                        onVariantFilterChange({
                             ...variantFilterConfig,
-                            lineageFilterConfigs: variantFilterConfig.lineageFilterConfigs.map((config) =>
-                                config.lapisField === lineageFilterConfig.lapisField
-                                    ? { ...config, initialValue: lineage }
-                                    : config,
-                            ),
-                        };
-                        onVariantFilterChange(newVariantFilterConfig);
+                            isInVariantQueryMode: !variantFilterConfig.isInVariantQueryMode,
+                        });
                     }}
-                    key={lineageFilterConfig.lapisField}
+                    checked={variantFilterConfig.isInVariantQueryMode}
                 />
-            ))}
-            {!hideMutationFilter && (
-                <GsMutationFilter
-                    initialValue={getMutationFilter(variantFilterConfig.mutationFilterConfig)}
-                    onMutationChange={(mutation) => {
-                        if (mutation === undefined) {
-                            return;
-                        }
-                        const newVariantFilterConfig = {
+            </label>
+
+            <div className={variantFilterConfig.isInVariantQueryMode ? '' : 'hidden'}>
+                <AdvancedQueryFilter
+                    onInput={(event) => {
+                        const newVariantQuery = {
+                            variantQueryConfig: event.target.value,
+                        };
+
+                        const newState = {
                             ...variantFilterConfig,
-                            mutationFilterConfig: mutation,
+                            ...newVariantQuery,
                         };
-                        onVariantFilterChange(newVariantFilterConfig);
+
+                        onVariantFilterChange(newState);
                     }}
+                    value={variantFilterConfig.variantQueryConfig ?? ''}
                 />
-            )}
+            </div>
+            <div className={`flex flex-col gap-2 ${variantFilterConfig.isInVariantQueryMode ? 'hidden' : ''}`}>
+                {variantFilterConfig.lineageFilterConfigs?.map((lineageFilterConfig) => (
+                    <LineageFilterInput
+                        lineageFilterConfig={lineageFilterConfig}
+                        onLineageChange={(lineage) => {
+                            const newVariantFilterConfig = {
+                                ...variantFilterConfig,
+                                lineageFilterConfigs: variantFilterConfig.lineageFilterConfigs?.map((config) =>
+                                    config.lapisField === lineageFilterConfig.lapisField
+                                        ? { ...config, initialValue: lineage }
+                                        : config,
+                                ),
+                            };
+                            onVariantFilterChange(newVariantFilterConfig);
+                        }}
+                        key={lineageFilterConfig.lapisField}
+                    />
+                ))}
+                {variantFilterConfig.mutationFilterConfig && (
+                    <GsMutationFilter
+                        initialValue={getMutationFilter(variantFilterConfig.mutationFilterConfig)}
+                        onMutationChange={(mutation) => {
+                            if (mutation === undefined) {
+                                return;
+                            }
+                            const newVariantFilterConfig = {
+                                ...variantFilterConfig,
+                                mutationFilterConfig: mutation,
+                            };
+                            onVariantFilterChange(newVariantFilterConfig);
+                        }}
+                    />
+                )}
+            </div>
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/VariantsSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantsSelector.tsx
@@ -34,18 +34,16 @@ export function VariantsSelector({
     };
 
     return (
-        <div className='flex flex-col gap-4'>
+        <div className='flex flex-col gap-3'>
             {Array.from(variantFilterConfigs).map(([id, filterConfig]) => (
                 <div key={id}>
-                    <div className='flex items-center justify-end'>
-                        <button className='btn btn-ghost btn-sm font-normal' onClick={() => removeVariant(id)}>
-                            Remove
-                        </button>
-                    </div>
                     <VariantSelector
                         variantFilterConfig={filterConfig}
                         onVariantFilterChange={(variantFilter) => updateVariantFilter(id, variantFilter)}
                     />
+                    <button className='text-sm hover:text-gray-500' onClick={() => removeVariant(id)}>
+                        Remove
+                    </button>
                 </div>
             ))}
             <button className='btn btn-sm max-w-32' onClick={addVariant}>

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -4,7 +4,7 @@ import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../../util/hasOnlyUndefinedValues';
-import { getLineageFilterConfigs, getLineageFilterFields } from '../../../views/View';
+import { getLineageFilterFields, getVariantFilterConfig } from '../../../views/View';
 import { getLocationSubdivision } from '../../../views/locationHelpers';
 import { toDisplayName } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
@@ -43,9 +43,10 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
     pageState.datasetFilter.location,
 );
 
-const lineageFilterConfigs = getLineageFilterConfigs(
+const variantFilterConfig = getVariantFilterConfig(
     view.organismConstants.lineageFilters,
-    pageState.variantFilter.lineages,
+    pageState.variantFilter,
+    view.organismConstants.useAdvancedQuery,
 );
 
 const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
@@ -76,10 +77,7 @@ const downloadLinks = noVariantSelected
             earliestDate: view.organismConstants.earliestDate,
             dateColumn: view.organismConstants.mainDateField,
         }}
-        variantFilterConfig={{
-            mutationFilterConfig: pageState.variantFilter.mutations,
-            lineageFilterConfigs,
-        }}
+        variantFilterConfig={variantFilterConfig}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -3,7 +3,8 @@ import { toDownloadLink } from './toDownloadLink';
 import { getDashboardsConfig, getLapisUrl } from '../../../config';
 import OrganismViewPageLayout from '../../../layouts/OrganismPage/OrganismViewPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
-import { getLineageFilterConfigs, getLineageFilterFields } from '../../../views/View';
+import { getLineageFilterFields, getVariantFilterConfig } from '../../../views/View';
+import { toLapisFilterWithoutVariant } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { compareSideBySideViewKey } from '../../../views/viewKeys';
@@ -16,10 +17,10 @@ import { CompareSideBySideSelectorFallback } from '../../pageStateSelectors/Fall
 type OrganismViewCompareVariant = OrganismWithViewKey<typeof compareSideBySideViewKey>;
 interface Props {
     organism: OrganismViewCompareVariant;
-    hideMutationFilter?: boolean;
+    hideMutationComponents?: boolean;
 }
 
-const { organism, hideMutationFilter } = Astro.props;
+const { organism, hideMutationComponents } = Astro.props;
 const organismViewKey = `${organism}.${compareSideBySideViewKey}` satisfies OrganismViewKey;
 const view = ServerSide.routing.getOrganismView(organismViewKey);
 
@@ -33,7 +34,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
         <div class='flex overflow-x-auto'>
             {
                 Array.from(pageState.filters).map(([id, { variantFilter, datasetFilter }]) => {
-                    const datasetLapisFilter = view.pageStateHandler.datasetFilterToLapisFilter(datasetFilter);
+                    const datasetLapisFilter = toLapisFilterWithoutVariant({ datasetFilter }, view.organismConstants);
                     const timeGranularity = chooseGranularityBasedOnDateRange(
                         datasetFilter.dateRange,
                         new Date(view.organismConstants.earliestDate),
@@ -42,9 +43,11 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                         datasetFilter,
                         variantFilter,
                     );
-                    const lineageFilterConfigs = getLineageFilterConfigs(
+                    const variantFilterConfig = getVariantFilterConfig(
                         view.organismConstants.lineageFilters,
-                        variantFilter.lineages,
+                        variantFilter,
+                        view.organismConstants.useAdvancedQuery,
+                        hideMutationComponents,
                     );
 
                     return (
@@ -72,15 +75,11 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                         earliestDate: view.organismConstants.earliestDate,
                                         dateColumn: view.organismConstants.mainDateField,
                                     }}
-                                    variantFilterConfig={{
-                                        mutationFilterConfig: variantFilter.mutations,
-                                        lineageFilterConfigs,
-                                    }}
+                                    variantFilterConfig={variantFilterConfig}
                                     filterId={id}
                                     pageState={pageState}
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
-                                    hideMutationFilter={hideMutationFilter}
                                     client:only='react'
                                 >
                                     <CompareSideBySideSelectorFallback
@@ -101,7 +100,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                 lapisDateField={view.organismConstants.mainDateField}
                                 granularity={timeGranularity}
                             />
-                            {!hideMutationFilter && (
+                            {!hideMutationComponents && (
                                 <>
                                     <GsMutations
                                         lapisFilter={numeratorFilter}
@@ -115,6 +114,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                     />
                                 </>
                             )}
+
                             <GsAggregate
                                 title='Sub-lineages'
                                 fields={getLineageFilterFields(view.organismConstants.lineageFilters)}

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -3,7 +3,7 @@ import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { ComponentHeight } from '../../../views/OrganismConstants';
-import { getLineageFilterConfigs, getLineageFilterFields } from '../../../views/View';
+import { getLineageFilterFields, getVariantFilterConfig } from '../../../views/View';
 import { getLocationDisplayConfig } from '../../../views/locationHelpers';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
@@ -35,9 +35,10 @@ const { locationField, mapName } = getLocationDisplayConfig(
     view.organismConstants.locationFields,
     pageState.datasetFilter.location,
 );
-const lineageFilterConfigs = getLineageFilterConfigs(
+const variantFilterConfig = getVariantFilterConfig(
     view.organismConstants.lineageFilters,
-    pageState.variantFilter.lineages,
+    pageState.variantFilter,
+    view.organismConstants.useAdvancedQuery,
 );
 ---
 
@@ -67,7 +68,7 @@ const lineageFilterConfigs = getLineageFilterConfigs(
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         client:only='react'
-        variantFilterConfig={{ mutationFilterConfig: pageState.variantFilter.mutations, lineageFilterConfigs }}
+        variantFilterConfig={variantFilterConfig}
     >
         <SequencingEffortsSelectorFallback slot='fallback' />
     </SequencingEffortsPageStateSelector>

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -9,7 +9,8 @@ import { toDownloadLink } from '../../components/views/compareSideBySide/toDownl
 import { getDashboardsConfig, getLapisUrl } from '../../config';
 import OrganismViewPageLayout from '../../layouts/OrganismPage/OrganismViewPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
-import { getLineageFilterConfigs, getLineageFilterFields } from '../../views/View';
+import { getLineageFilterFields, getVariantFilterConfig } from '../../views/View';
+import { toLapisFilterWithoutVariant } from '../../views/pageStateHandlers/PageStateHandler';
 import type { OrganismViewKey } from '../../views/routing';
 import { ServerSide } from '../../views/serverSideRouting';
 
@@ -28,7 +29,7 @@ const downloadLinks = [...pageState.filters.entries()].map(
         <div class='flex overflow-x-auto'>
             {
                 Array.from(pageState.filters).map(([id, { variantFilter, datasetFilter }]) => {
-                    const baselineLapisFilter = view.pageStateHandler.datasetFilterToLapisFilter(datasetFilter);
+                    const baselineLapisFilter = toLapisFilterWithoutVariant({ datasetFilter }, view.organismConstants);
                     const timeGranularity = chooseGranularityBasedOnDateRange(
                         datasetFilter.dateRange,
                         new Date(view.organismConstants.earliestDate),
@@ -39,9 +40,10 @@ const downloadLinks = [...pageState.filters.entries()].map(
                         variantQuery: variantFilter.variantQuery,
                         ...baselineLapisFilter,
                     };
-                    const lineageFilterConfigs = getLineageFilterConfigs(
+                    const variantFilterConfig = getVariantFilterConfig(
                         view.organismConstants.lineageFilters,
-                        variantFilter.lineages,
+                        variantFilter,
+                        view.organismConstants.useAdvancedQuery,
                     );
 
                     return (
@@ -69,10 +71,7 @@ const downloadLinks = [...pageState.filters.entries()].map(
                                         earliestDate: view.organismConstants.earliestDate,
                                         dateColumn: view.organismConstants.mainDateField,
                                     }}
-                                    variantFilterConfig={{
-                                        mutationFilterConfig: variantFilter.mutations,
-                                        lineageFilterConfigs,
-                                    }}
+                                    variantFilterConfig={variantFilterConfig}
                                     filterId={id}
                                     pageState={pageState}
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -15,7 +15,7 @@ import { getDashboardsConfig } from '../../config';
 import SingleVariantOrganismPageLayout from '../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../util/hasOnlyUndefinedValues';
-import { getLineageFilterConfigs, getLineageFilterFields } from '../../views/View';
+import { getLineageFilterFields, getVariantFilterConfig } from '../../views/View';
 import { getLocationSubdivision } from '../../views/locationHelpers';
 import { toDisplayName } from '../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey } from '../../views/routing';
@@ -37,9 +37,10 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
     pageState.datasetFilter.location,
 );
 
-const lineageFilterConfigs = getLineageFilterConfigs(
+const variantFilterConfig = getVariantFilterConfig(
     view.organismConstants.lineageFilters,
-    pageState.variantFilter.lineages,
+    pageState.variantFilter,
+    view.organismConstants.useAdvancedQuery,
 );
 
 const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
@@ -70,10 +71,7 @@ const downloadLinks = noVariantSelected
                 earliestDate: view.organismConstants.earliestDate,
                 dateColumn: view.organismConstants.mainDateField,
             }}
-            variantFilterConfig={{
-                mutationFilterConfig: pageState.variantFilter.mutations,
-                lineageFilterConfigs,
-            }}
+            variantFilterConfig={variantFilterConfig}
             organismViewKey={organismViewKey}
             organismsConfig={getDashboardsConfig().dashboards.organisms}
             client:only='react'

--- a/website/src/pages/flu/compare-side-by-side.astro
+++ b/website/src/pages/flu/compare-side-by-side.astro
@@ -3,4 +3,4 @@ import GenericCompareSideBySidePage from '../../components/views/compareSideBySi
 import { Organisms } from '../../types/Organism';
 ---
 
-<GenericCompareSideBySidePage organism={Organisms.flu} hideMutationFilter={true} />
+<GenericCompareSideBySidePage organism={Organisms.flu} hideMutationComponents={true} />

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -30,6 +30,7 @@ export interface ExtendedConstants extends OrganismConstants {
     readonly additionalFilters: Record<string, string> | undefined;
     readonly additionalSequencingEffortsFields: AdditionalSequencingEffortsField[];
     readonly lineageFilters: LineageFilterConfig[];
+    readonly useAdvancedQuery: boolean;
 }
 
 export function getAuthorRelatedSequencingEffortsFields(constants: {

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -5,6 +5,7 @@ import { type ViewConstants } from './ViewConstants';
 import type { LapisLineageQuery, LapisLocation, LapisMutationQuery } from './helpers.ts';
 import { type PageStateHandler } from './pageStateHandlers/PageStateHandler.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
+import type { VariantFilterConfig } from '../components/pageStateSelectors/VariantFilterConfig.ts';
 import { type BreadcrumbElement } from '../layouts/Breadcrumbs.tsx';
 
 export type DatasetFilter = {
@@ -17,8 +18,9 @@ export type Dataset = {
 };
 
 export type VariantFilter = {
-    mutations: LapisMutationQuery;
-    lineages: LapisLineageQuery;
+    mutations?: LapisMutationQuery;
+    lineages?: LapisLineageQuery;
+    variantQuery?: string;
 };
 
 export type VariantData<VariantFilterType = VariantFilter> = {
@@ -74,14 +76,30 @@ export function getLineageFilterFields(lineageFilters: LineageFilterConfig[]) {
     return lineageFilters.map((filter) => filter.lapisField);
 }
 
+export function getVariantFilterConfig(
+    lineageFilterConfigs: LineageFilterConfig[],
+    variantFilter: VariantFilter,
+    useAdvancedQuery: boolean,
+    hideMutationFilter?: boolean,
+): VariantFilterConfig {
+    const mutationFilterConfig = hideMutationFilter ? undefined : (variantFilter.mutations ?? {});
+
+    return {
+        variantQueryConfig: variantFilter.variantQuery,
+        mutationFilterConfig,
+        lineageFilterConfigs: getLineageFilterConfigs(lineageFilterConfigs, variantFilter.lineages),
+        isInVariantQueryMode: useAdvancedQuery ? variantFilter.variantQuery !== undefined : undefined,
+    };
+}
+
 export function getLineageFilterConfigs(
     lineageFilterConfigs: LineageFilterConfig[],
-    lineages: LapisLineageQuery,
+    lineages?: LapisLineageQuery,
 ): LineageFilterConfig[] {
     return lineageFilterConfigs.map((config) => {
         return {
             ...config,
-            initialValue: lineages[config.lapisField] ?? config.initialValue,
+            initialValue: (lineages ? lineages[config.lapisField] : undefined) ?? config.initialValue,
         };
     });
 }

--- a/website/src/views/flu.ts
+++ b/website/src/views/flu.ts
@@ -45,6 +45,7 @@ class FluConstants implements ExtendedConstants {
             initialValue: undefined,
         },
     ];
+    public readonly useAdvancedQuery = false;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -45,6 +45,7 @@ class H5n1Constants implements ExtendedConstants {
             initialValue: undefined,
         },
     ];
+    public readonly useAdvancedQuery = false;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -53,6 +53,7 @@ class MpoxConstants implements ExtendedConstants {
             initialValue: undefined,
         },
     ];
+    public readonly useAdvancedQuery = false;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import { Organisms } from '../../types/Organism.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { CompareSideBySideData, DatasetAndVariantData } from '../View.ts';
+import { GenericCompareSideBySideStateHandler } from './CompareSideBySidePageStateHandler.ts';
+
+const mockConstants: ExtendedConstants = {
+    organism: Organisms.covid,
+    dataOrigins: [],
+    locationFields: ['country', 'region'],
+    mainDateField: 'date',
+    dateRangeOptions: [{ label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' }],
+    defaultDateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+    additionalFilters: undefined,
+    lineageFilters: [
+        {
+            lapisField: 'lineage',
+            placeholderText: 'Lineage',
+            filterType: 'text',
+            initialValue: undefined,
+        },
+    ],
+    additionalSequencingEffortsFields: [],
+    accessionDownloadFields: [],
+    useAdvancedQuery: false,
+};
+
+const mockDefaultPageState: CompareSideBySideData = {
+    filters: new Map<number, DatasetAndVariantData>([
+        [
+            1,
+            {
+                datasetFilter: {
+                    location: {},
+                    dateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+                },
+                variantFilter: {
+                    lineages: {},
+                    mutations: {},
+                },
+            },
+        ],
+        [
+            2,
+            {
+                datasetFilter: {
+                    location: {},
+                    dateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+                },
+                variantFilter: {
+                    lineages: { lineage: 'B.1.1.7' },
+                    mutations: {},
+                },
+            },
+        ],
+    ]),
+};
+
+describe('GenericCompareSideBySideStateHandler', () => {
+    const handler = new GenericCompareSideBySideStateHandler(mockConstants, mockDefaultPageState, 'testPath');
+
+    it('should return the default page URL', () => {
+        const url = handler.getDefaultPageUrl();
+        expect(url).toBe(
+            '/testPath/compare-side-by-side?' +
+                'date%241=Last+7+Days' +
+                '&lineage%242=B.1.1.7&date%242=Last+7+Days' +
+                '&',
+        );
+    });
+
+    it('should parse page state from URL, including variants', () => {
+        const url = new URL(
+            'http://example.com/testPath/compare-side-by-side?' +
+                'date%241=Last+7+Days' +
+                '&lineage%242=B.1.1.7&date%242=Last+7+Days' +
+                '&variantQuery%243=C234G' +
+                '&',
+        );
+
+        const pageState = handler.parsePageStateFromUrl(url);
+
+        expect(pageState.filters.size).toBe(3);
+
+        expect(pageState.filters.get(1)).toEqual({
+            datasetFilter: {
+                dateRange: {
+                    label: 'Last 7 Days',
+                    dateFrom: '2024-11-22',
+                    dateTo: '2024-11-29',
+                },
+                location: {},
+            },
+            variantFilter: {
+                lineages: {},
+                mutations: {},
+            },
+        });
+
+        expect(pageState.filters.get(2)).toEqual({
+            datasetFilter: {
+                dateRange: {
+                    label: 'Last 7 Days',
+                    dateFrom: '2024-11-22',
+                    dateTo: '2024-11-29',
+                },
+                location: {},
+            },
+            variantFilter: {
+                lineages: {
+                    lineage: 'B.1.1.7',
+                },
+                mutations: {},
+            },
+        });
+
+        expect(pageState.filters.get(3)).toEqual({
+            datasetFilter: {
+                dateRange: {
+                    label: 'Last 7 Days',
+                    dateFrom: '2024-11-22',
+                    dateTo: '2024-11-29',
+                },
+                location: {},
+            },
+            variantFilter: {
+                variantQuery: 'C234G',
+            },
+        });
+    });
+
+    it('should convert page state to URL', () => {
+        const pageState: CompareSideBySideData = {
+            filters: new Map<number, DatasetAndVariantData>([
+                [
+                    1,
+                    {
+                        datasetFilter: {
+                            location: {},
+                            dateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+                        },
+                        variantFilter: {
+                            lineages: { lineage: 'B.1.1.7' },
+                            mutations: {},
+                        },
+                    },
+                ],
+                [
+                    2,
+                    {
+                        datasetFilter: {
+                            location: {},
+                            dateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+                        },
+                        variantFilter: {
+                            lineages: { lineage: 'B.1.1.7' },
+                            mutations: {},
+                            variantQuery: 'C234G',
+                        },
+                    },
+                ],
+            ]),
+        };
+
+        const url = handler.toUrl(pageState);
+        expect(url).toBe(
+            '/testPath/compare-side-by-side?' +
+                'lineage%241=B.1.1.7&date%241=Last+7+Days' +
+                '&variantQuery%242=C234G&date%242=Last+7+Days' +
+                '&',
+        );
+    });
+
+    it('should convert variant filter to Lapis filter', () => {
+        const lapisFilter = handler.variantFilterToLapisFilter(
+            {
+                dateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+                location: { country: 'US' },
+            },
+            {
+                lineages: { lineage: 'B.1.1.7' },
+                mutations: { nucleotideMutations: ['A123T'] },
+            },
+        );
+        expect(lapisFilter).toStrictEqual({
+            dateFrom: '2024-11-22',
+            dateTo: '2024-11-29',
+            country: 'US',
+            lineage: 'B.1.1.7',
+            nucleotideMutations: ['A123T'],
+        });
+    });
+
+    it('should convert variant filter with variantQuery to Lapis filter', () => {
+        const lapisFilter = handler.variantFilterToLapisFilter(
+            {
+                dateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+                location: { country: 'US' },
+            },
+            {
+                lineages: { lineage: 'B.1.1.7' },
+                mutations: {},
+                variantQuery: 'C234G',
+            },
+        );
+        expect(lapisFilter).toStrictEqual({
+            dateFrom: '2024-11-22',
+            dateTo: '2024-11-29',
+            country: 'US',
+            variantQuery: 'C234G',
+        });
+    });
+});

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
@@ -85,10 +85,6 @@ export abstract class CompareSideBySideStateHandler<ColumnData extends DatasetAn
         };
     }
 
-    public datasetFilterToLapisFilter(datasetFilter: ColumnData['datasetFilter']): LapisFilter {
-        return toLapisFilterWithoutVariant({ datasetFilter }, this.constants);
-    }
-
     public abstract variantFilterToLapisFilter(
         datasetFilter: ColumnData['datasetFilter'],
         variantFilter: ColumnData['variantFilter'],
@@ -144,10 +140,17 @@ export class GenericCompareSideBySideStateHandler extends CompareSideBySideState
         datasetFilter: DatasetAndVariantData['datasetFilter'],
         variantFilter: DatasetAndVariantData['variantFilter'],
     ): LapisFilter {
-        return {
-            ...variantFilter.lineages,
-            ...variantFilter.mutations,
-            ...this.datasetFilterToLapisFilter(datasetFilter),
-        };
+        if (variantFilter.variantQuery) {
+            return {
+                variantQuery: variantFilter.variantQuery,
+                ...toLapisFilterWithoutVariant({ datasetFilter }, this.constants),
+            };
+        } else {
+            return {
+                ...variantFilter.lineages,
+                ...variantFilter.mutations,
+                ...toLapisFilterWithoutVariant({ datasetFilter }, this.constants),
+            };
+        }
     }
 }

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -23,6 +23,7 @@ const mockConstants: ExtendedConstants = {
     ],
     additionalSequencingEffortsFields: [],
     accessionDownloadFields: [],
+    useAdvancedQuery: true,
 };
 
 const mockDefaultPageState: CompareToBaselineData = {
@@ -52,6 +53,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                 '&lineage=B.2.3.4&nucleotideMutations=C234G' +
                 '&lineage$1=B.1.1.7&nucleotideMutations$1=D614G' +
                 '&lineage$2=A.1.2.3&aminoAcidMutations$2=S:A123T' +
+                '&variantQuery$3=A123T' +
                 '&',
         );
 
@@ -67,7 +69,7 @@ describe('CompareToBaselinePageStateHandler', () => {
             },
         });
 
-        expect(pageState.variants.size).toBe(2);
+        expect(pageState.variants.size).toBe(3);
         expect(pageState.variants.get(1)).toEqual({
             lineages: { lineage: 'B.1.1.7' },
             mutations: { nucleotideMutations: ['D614G'] },
@@ -75,6 +77,9 @@ describe('CompareToBaselinePageStateHandler', () => {
         expect(pageState.variants.get(2)).toEqual({
             lineages: { lineage: 'A.1.2.3' },
             mutations: { aminoAcidMutations: ['S:A123T'] },
+        });
+        expect(pageState.variants.get(3)).toEqual({
+            variantQuery: 'A123T',
         });
     });
 
@@ -93,6 +98,12 @@ describe('CompareToBaselinePageStateHandler', () => {
                     {
                         lineages: { lineage: 'A.1.2.3' },
                         mutations: { aminoAcidMutations: ['S:A123T'] },
+                    },
+                ],
+                [
+                    3,
+                    {
+                        variantQuery: 'C234G',
                     },
                 ],
             ]),
@@ -114,6 +125,7 @@ describe('CompareToBaselinePageStateHandler', () => {
             '/testPath/compare-to-baseline?' +
                 'nucleotideMutations%241=D614G&lineage%241=B.1.1.7' +
                 '&aminoAcidMutations%242=S%3AA123T&lineage%242=A.1.2.3' +
+                '&variantQuery%243=C234G' +
                 '&country=US' +
                 '&nucleotideMutations=C234G&lineage=B.2.3.4' +
                 '&',
@@ -144,6 +156,8 @@ describe('CompareToBaselinePageStateHandler', () => {
                 },
             ],
             mutationFilterConfig: {},
+            isInVariantQueryMode: false,
+            variantQueryConfig: undefined,
         });
     });
 
@@ -165,10 +179,16 @@ describe('CompareToBaselinePageStateHandler', () => {
                         mutations: { aminoAcidMutations: ['S:A123T'] },
                     },
                 ],
+                [
+                    3,
+                    {
+                        variantQuery: 'C234G',
+                    },
+                ],
             ]),
         };
         const variantFilterConfigs = handler.toVariantFilterConfigs(pageState);
-        expect(variantFilterConfigs.size).toBe(2);
+        expect(variantFilterConfigs.size).toBe(3);
         expect(variantFilterConfigs.get(1)).toStrictEqual({
             lineageFilterConfigs: [
                 {
@@ -181,6 +201,8 @@ describe('CompareToBaselinePageStateHandler', () => {
             mutationFilterConfig: {
                 nucleotideMutations: ['D614G'],
             },
+            isInVariantQueryMode: false,
+            variantQueryConfig: undefined,
         });
 
         expect(variantFilterConfigs.get(2)).toStrictEqual({
@@ -195,6 +217,22 @@ describe('CompareToBaselinePageStateHandler', () => {
             mutationFilterConfig: {
                 aminoAcidMutations: ['S:A123T'],
             },
+            isInVariantQueryMode: false,
+            variantQueryConfig: undefined,
+        });
+
+        expect(variantFilterConfigs.get(3)).toStrictEqual({
+            lineageFilterConfigs: [
+                {
+                    lapisField: 'lineage',
+                    placeholderText: 'Lineage',
+                    filterType: 'text',
+                    initialValue: undefined,
+                },
+            ],
+            mutationFilterConfig: {},
+            isInVariantQueryMode: true,
+            variantQueryConfig: 'C234G',
         });
     });
 

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -23,6 +23,7 @@ const mockConstants: ExtendedConstants = {
     ],
     additionalSequencingEffortsFields: [],
     accessionDownloadFields: [],
+    useAdvancedQuery: true,
 };
 
 const mockDefaultPageState: CompareVariantsData = {
@@ -46,6 +47,7 @@ describe('CompareVariantsPageStateHandler', () => {
             'http://example.com/testPath/compareVariants?country=US&date=Last 7 Days' +
                 '&lineage$1=B.1.1.7&nucleotideMutations$1=D614G' +
                 '&lineage$2=A.1.2.3&aminoAcidMutations$2=S:A123T' +
+                '&variantQuery$3=C234G' +
                 '&',
         );
 
@@ -54,7 +56,7 @@ describe('CompareVariantsPageStateHandler', () => {
         expect(pageState.datasetFilter.location).toEqual({ country: 'US' });
         expect(pageState.datasetFilter.dateRange).toEqual(mockConstants.defaultDateRange);
 
-        expect(pageState.variants.size).toBe(2);
+        expect(pageState.variants.size).toBe(3);
         expect(pageState.variants.get(1)).toEqual({
             lineages: { lineage: 'B.1.1.7' },
             mutations: { nucleotideMutations: ['D614G'] },
@@ -62,6 +64,9 @@ describe('CompareVariantsPageStateHandler', () => {
         expect(pageState.variants.get(2)).toEqual({
             lineages: { lineage: 'A.1.2.3' },
             mutations: { aminoAcidMutations: ['S:A123T'] },
+        });
+        expect(pageState.variants.get(3)).toEqual({
+            variantQuery: 'C234G',
         });
     });
 
@@ -82,6 +87,12 @@ describe('CompareVariantsPageStateHandler', () => {
                         mutations: { aminoAcidMutations: ['S:A123T'] },
                     },
                 ],
+                [
+                    3,
+                    {
+                        variantQuery: 'C234G',
+                    },
+                ],
             ]),
             datasetFilter: {
                 location: { country: 'US' },
@@ -93,6 +104,7 @@ describe('CompareVariantsPageStateHandler', () => {
             '/testPath/compare-variants?' +
                 'nucleotideMutations%241=D614G&lineage%241=B.1.1.7' +
                 '&aminoAcidMutations%242=S%3AA123T&lineage%242=A.1.2.3' +
+                '&variantQuery%243=C234G' +
                 '&country=US' +
                 '&',
         );
@@ -122,6 +134,8 @@ describe('CompareVariantsPageStateHandler', () => {
                 },
             ],
             mutationFilterConfig: {},
+            isInVariantQueryMode: false,
+            variantQueryConfig: undefined,
         });
     });
 
@@ -143,10 +157,16 @@ describe('CompareVariantsPageStateHandler', () => {
                         mutations: { aminoAcidMutations: ['S:A123T'] },
                     },
                 ],
+                [
+                    3,
+                    {
+                        variantQuery: 'C234G',
+                    },
+                ],
             ]),
         };
         const variantFilterConfigs = handler.toVariantFilterConfigs(pageState);
-        expect(variantFilterConfigs.size).toBe(2);
+        expect(variantFilterConfigs.size).toBe(3);
         expect(variantFilterConfigs.get(1)).toStrictEqual({
             lineageFilterConfigs: [
                 {
@@ -159,6 +179,8 @@ describe('CompareVariantsPageStateHandler', () => {
             mutationFilterConfig: {
                 nucleotideMutations: ['D614G'],
             },
+            isInVariantQueryMode: false,
+            variantQueryConfig: undefined,
         });
 
         expect(variantFilterConfigs.get(2)).toStrictEqual({
@@ -173,6 +195,22 @@ describe('CompareVariantsPageStateHandler', () => {
             mutationFilterConfig: {
                 aminoAcidMutations: ['S:A123T'],
             },
+            isInVariantQueryMode: false,
+            variantQueryConfig: undefined,
+        });
+
+        expect(variantFilterConfigs.get(3)).toStrictEqual({
+            lineageFilterConfigs: [
+                {
+                    filterType: 'text',
+                    initialValue: undefined,
+                    lapisField: 'lineage',
+                    placeholderText: 'Lineage',
+                },
+            ],
+            mutationFilterConfig: {},
+            isInVariantQueryMode: true,
+            variantQueryConfig: 'C234G',
         });
     });
 
@@ -187,6 +225,12 @@ describe('CompareVariantsPageStateHandler', () => {
                         mutations: { nucleotideMutations: ['D614G'], aminoAcidMutations: ['S:A123T'] },
                     },
                 ],
+                [
+                    2,
+                    {
+                        variantQuery: 'C234G',
+                    },
+                ],
             ]),
         };
         const namedVariantFilter = handler.variantFiltersToNamedLapisFilters(pageState);
@@ -199,6 +243,14 @@ describe('CompareVariantsPageStateHandler', () => {
                     dateTo: '2024-11-29',
                     lineage: 'B.1.1.7',
                     nucleotideMutations: ['D614G'],
+                },
+            },
+            {
+                displayName: 'C234G',
+                lapisFilter: {
+                    dateFrom: '2024-11-22',
+                    dateTo: '2024-11-29',
+                    variantQuery: 'C234G',
                 },
             },
         ]);

--- a/website/src/views/pageStateHandlers/PageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.ts
@@ -1,8 +1,8 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import type { ExtendedConstants } from '../OrganismConstants.ts';
-import { type Dataset, type Id } from '../View.ts';
-import { type LapisCovidVariantFilter, type LapisLocation } from '../helpers.ts';
+import { type Dataset, type Id, type VariantFilter } from '../View.ts';
+import { type LapisLocation } from '../helpers.ts';
 
 export interface PageStateHandler<PageState extends object> {
     parsePageStateFromUrl(url: URL): PageState;
@@ -22,6 +22,17 @@ export function toLapisFilterWithoutVariant(
         [`${constants.mainDateField}To`]: pageState.datasetFilter.dateRange.dateTo,
         ...constants.additionalFilters,
     };
+}
+
+export function toLapisFilterFromVariant(variantFilter: VariantFilter) {
+    if (variantFilter.variantQuery) {
+        return { variantQuery: variantFilter.variantQuery };
+    } else {
+        return {
+            ...variantFilter.lineages,
+            ...variantFilter.mutations,
+        };
+    }
 }
 
 const variantFilterUrlDelimiter = '$';
@@ -81,13 +92,20 @@ export function searchParamsFromFilterMap<Entry>(
     return encodeMultipleFiltersToUrlSearchParam(searchParameterMap);
 }
 
-export function toDisplayName(variantFilter: LapisCovidVariantFilter) {
+export function toDisplayName(variantFilter: VariantFilter) {
+    if (variantFilter.variantQuery) {
+        return variantFilter.variantQuery;
+    }
+
+    const lineages = variantFilter.lineages
+        ? Object.values(variantFilter.lineages).filter((lineage) => lineage !== undefined)
+        : [];
+
     return [
-        ...Object.values(variantFilter.lineages).filter((lineage) => lineage !== undefined),
-        ...(variantFilter.mutations.nucleotideMutations ?? []),
-        ...(variantFilter.mutations.aminoAcidMutations ?? []),
-        ...(variantFilter.mutations.nucleotideInsertions ?? []),
-        ...(variantFilter.mutations.aminoAcidInsertions ?? []),
-        ...(variantFilter.variantQuery !== undefined ? [variantFilter.variantQuery] : []),
+        ...lineages,
+        ...(variantFilter.mutations?.nucleotideMutations ?? []),
+        ...(variantFilter.mutations?.aminoAcidMutations ?? []),
+        ...(variantFilter.mutations?.nucleotideInsertions ?? []),
+        ...(variantFilter.mutations?.aminoAcidInsertions ?? []),
     ].join(' + ');
 }

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -9,7 +9,7 @@ import {
     setSearchFromLapisVariantQuery,
     setSearchFromLocation,
 } from '../helpers.ts';
-import { type PageStateHandler, toLapisFilterWithoutVariant } from './PageStateHandler.ts';
+import { type PageStateHandler, toLapisFilterFromVariant, toLapisFilterWithoutVariant } from './PageStateHandler.ts';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantData = DatasetAndVariantData>
@@ -55,8 +55,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
     public toLapisFilter(pageState: DatasetAndVariantData) {
         return {
             ...toLapisFilterWithoutVariant(pageState, this.constants),
-            ...pageState.variantFilter.lineages,
-            ...pageState.variantFilter.mutations,
+            ...toLapisFilterFromVariant(pageState.variantFilter),
         };
     }
 

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { Organisms } from '../../types/Organism.ts';
+import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { DatasetAndVariantData } from '../View.ts';
+import { SingleVariantPageStateHandler } from './SingleVariantPageStateHandler.ts';
+
+const mockConstants: ExtendedConstants = {
+    organism: Organisms.covid,
+    dataOrigins: [],
+    locationFields: ['country', 'region'],
+    mainDateField: 'date',
+    dateRangeOptions: [{ label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' }],
+    defaultDateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+    additionalFilters: undefined,
+    lineageFilters: [
+        {
+            lapisField: 'lineage',
+            placeholderText: 'Lineage',
+            filterType: 'text',
+            initialValue: undefined,
+        },
+    ],
+    additionalSequencingEffortsFields: [],
+    accessionDownloadFields: [],
+    useAdvancedQuery: false,
+};
+
+const mockDefaultPageState: DatasetAndVariantData = {
+    datasetFilter: {
+        location: {},
+        dateRange: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+    },
+    variantFilter: {
+        lineages: {},
+        mutations: {},
+    },
+};
+
+describe('SingleVariantPageStateHandler', () => {
+    const handler = new SingleVariantPageStateHandler(mockConstants, mockDefaultPageState, 'testPath');
+
+    it('should return the default page URL', () => {
+        const url = handler.getDefaultPageUrl();
+        expect(url).toBe('/testPath/single-variant?date=Last+7+Days&');
+    });
+
+    it('should parse page state from URL, including variants', () => {
+        const url = new URL(
+            'http://example.com/testPath/single-variant?' +
+                'country=US&date=Last 7 Days' +
+                '&lineage=B.2.3.4&nucleotideMutations=C234G' +
+                '&',
+        );
+
+        const pageState = handler.parsePageStateFromUrl(url);
+
+        expect(pageState.datasetFilter.location).toEqual({ country: 'US' });
+        expect(pageState.datasetFilter.dateRange).toEqual(mockConstants.defaultDateRange);
+
+        expect(pageState.variantFilter).toEqual({
+            lineages: { lineage: 'B.2.3.4' },
+            mutations: {
+                nucleotideMutations: ['C234G'],
+            },
+            variantQuery: undefined,
+        });
+    });
+
+    it('should convert page state to URL', () => {
+        const pageState: DatasetAndVariantData = {
+            variantFilter: {
+                lineages: { lineage: 'B.1.1.7' },
+                mutations: { nucleotideMutations: ['D614G'] },
+            },
+            datasetFilter: {
+                location: { country: 'US' },
+                dateRange: mockConstants.defaultDateRange,
+            },
+        };
+        const url = handler.toUrl(pageState);
+        expect(url).toBe(
+            '/testPath/single-variant?' + 'country=US' + '&nucleotideMutations=D614G&lineage=B.1.1.7' + '&',
+        );
+    });
+
+    it('should convert pageState to Lapis filter', () => {
+        const lapisFilter = handler.toLapisFilter({
+            ...mockDefaultPageState,
+            variantFilter: {
+                lineages: { lineage: 'B.1.1.7' },
+                mutations: { nucleotideMutations: ['D614G'] },
+            },
+        });
+        expect(lapisFilter).toStrictEqual({
+            dateFrom: '2024-11-22',
+            dateTo: '2024-11-29',
+            lineage: 'B.1.1.7',
+            nucleotideMutations: ['D614G'],
+        });
+    });
+
+    it('should convert pageState with variantQuery to Lapis filter', () => {
+        const lapisFilter = handler.toLapisFilter({
+            ...mockDefaultPageState,
+            variantFilter: {
+                lineages: { lineage: 'B.1.1.7' },
+                mutations: { nucleotideMutations: ['D614G'] },
+                variantQuery: 'C234G',
+            },
+        });
+        expect(lapisFilter).toStrictEqual({
+            dateFrom: '2024-11-22',
+            dateTo: '2024-11-29',
+            variantQuery: 'C234G',
+        });
+    });
+
+    it('should convert pageState to Lapis filter without variant', () => {
+        const lapisFilter = handler.toLapisFilterWithoutVariant({
+            ...mockDefaultPageState,
+            variantFilter: {
+                lineages: { lineage: 'B.1.1.7' },
+                mutations: { nucleotideMutations: ['D614G'] },
+            },
+        });
+        expect(lapisFilter).toStrictEqual({
+            dateFrom: '2024-11-22',
+            dateTo: '2024-11-29',
+        });
+    });
+});

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -1,7 +1,7 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import type { ExtendedConstants } from '../OrganismConstants.ts';
-import { type Dataset, type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
+import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { singleVariantViewConstants } from '../ViewConstants.ts';
 import {
     getDateRangeFromSearch,
@@ -12,7 +12,7 @@ import {
     setSearchFromLapisVariantQuery,
     setSearchFromLocation,
 } from '../helpers.ts';
-import { type PageStateHandler, toLapisFilterWithoutVariant } from './PageStateHandler.ts';
+import { type PageStateHandler, toLapisFilterFromVariant, toLapisFilterWithoutVariant } from './PageStateHandler.ts';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantData = DatasetAndVariantData>
@@ -58,12 +58,11 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
     public toLapisFilter(pageState: DatasetAndVariantData) {
         return {
             ...toLapisFilterWithoutVariant(pageState, this.constants),
-            ...pageState.variantFilter.lineages,
-            ...pageState.variantFilter.mutations,
+            ...toLapisFilterFromVariant(pageState.variantFilter),
         };
     }
 
-    public toLapisFilterWithoutVariant(pageState: Dataset): LapisFilter & LapisLocation {
+    public toLapisFilterWithoutVariant(pageState: DatasetAndVariantData): LapisFilter & LapisLocation {
         return toLapisFilterWithoutVariant(pageState, this.constants);
     }
 

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -43,6 +43,7 @@ class RsvAConstants implements ExtendedConstants {
             initialValue: undefined,
         },
     ];
+    public readonly useAdvancedQuery = false;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -43,6 +43,7 @@ class RsvBConstants implements ExtendedConstants {
             initialValue: undefined,
         },
     ];
+    public readonly useAdvancedQuery = false;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -43,6 +43,7 @@ class WestNileConstants implements ExtendedConstants {
             initialValue: undefined,
         },
     ];
+    public readonly useAdvancedQuery = false;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #458

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Adds the option to use variantQueries for covid. Since we are in the process of supporting variantQueries for other organisms, it is implemented for all organisms and only toggled off for all except covid. 

This also removes the boolean parameter "hideMutationFilter". Similar to the lineage filters, it is dependent, if there is an option for mutation filters provided. If not, it is not rendered.

### Screenshot

In regular mode:
![grafik](https://github.com/user-attachments/assets/cdf600b3-3ea6-4d76-b6f6-4db35a7207f1)



Using variant queries (on single variant page):
![grafik](https://github.com/user-attachments/assets/e7a12671-76f7-4fd2-8a42-c28b056acf70)



Using variant queries (on compare variants page):
![grafik](https://github.com/user-attachments/assets/816367fc-823a-4a84-9057-f618b646b322)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
