### PR TITLE
feat(website): gs-wastewater-mutations-over-time - show all mutations…

### DIFF
--- a/website/src/components/genspectrum/GsWastewaterMutationsOverTime.astro
+++ b/website/src/components/genspectrum/GsWastewaterMutationsOverTime.astro
@@ -19,6 +19,7 @@ const { title, lapisFilter, sequenceType, info } = Astro.props;
         sequenceType={sequenceType}
         width='100%'
         height='100%'
+        maxNumberOfGridRows='700'
     >
         <span slot='infoText'><Fragment set:html={info} /></span>
     </gs-wastewater-mutations-over-time>


### PR DESCRIPTION
… (max 700) for rsv

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

there are 586 mutations in the rsv graph - to see them all we must allow the max grid number to be set, this uses https://github.com/GenSpectrum/dashboard-components/pull/692. 

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
