### PR TITLE
Draft for more filters

### DIFF
--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -3,46 +3,144 @@ import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
 import type { LapisLocation } from '../../views/helpers.ts';
 import { GsDateRangeSelector } from '../genspectrum/GsDateRangeSelector.tsx';
 import { GsLocationFilter } from '../genspectrum/GsLocationFilter.tsx';
+import { GsTextInput } from '../genspectrum/GsTextInput.tsx';
 
 export type LocationFilterConfig = {
     locationFields: string[];
     initialLocation: LapisLocation;
     placeholderText: string;
+    label?: string;
 };
 
 export type DateRangeFilterConfig = {
-    initialDateRange: DateRangeOption;
+    defaultDateRange?: DateRangeOption;
+    initialDateRange?: DateRangeOption;
     dateRangeOptions: DateRangeOption[];
     earliestDate: string;
     dateColumn: string;
+    label?: string;
 };
+
+export type TextInputConfig = {
+    lapisField: string;
+    placeholderText?: string;
+    value?: string
+    label?: string;
+};
+
+export type BaselineFilterConfig =
+    | ({
+          type: 'date';
+      } & DateRangeFilterConfig)
+    | ({ type: 'text' } & TextInputConfig);
 
 export function BaselineSelector({
     locationFilterConfig,
     onLocationChange,
     dateRangeFilterConfig,
     onDateRangeChange,
+    baselineFilterConfigs,
+    onBaselineFilterConfigChange,
 }: {
     onLocationChange: (location: LapisLocation) => void;
     locationFilterConfig: LocationFilterConfig;
     onDateRangeChange: (dateRange: DateRangeOption) => void;
     dateRangeFilterConfig: DateRangeFilterConfig;
+    baselineFilterConfigs?: BaselineFilterConfig[];
+    onBaselineFilterConfigChange?: (baselineFilterConfigs: BaselineFilterConfig[]) => void;
 }) {
     return (
-        <div className='flex flex-col gap-2'>
-            <GsLocationFilter
-                fields={locationFilterConfig.locationFields}
-                onLocationChange={onLocationChange}
-                value={locationFilterConfig.initialLocation}
-                placeholderText={locationFilterConfig.placeholderText}
-            ></GsLocationFilter>
-            <GsDateRangeSelector
-                lapisDateField={dateRangeFilterConfig.dateColumn}
-                onDateRangeChange={onDateRangeChange}
-                earliestDate={dateRangeFilterConfig.earliestDate}
-                initialValue={dateRangeFilterConfig.initialDateRange}
-                dateRangeOptions={dateRangeFilterConfig.dateRangeOptions}
-            ></GsDateRangeSelector>
+        <div className={`flex flex-col gap-2`}>
+            <label className='form-control'>
+                <div className='label'>
+                    <span className='label-text'>
+                        {locationFilterConfig.label ?? locationFilterConfig.placeholderText}
+                    </span>
+                </div>
+                <GsLocationFilter
+                    fields={locationFilterConfig.locationFields}
+                    onLocationChange={onLocationChange}
+                    value={locationFilterConfig.initialLocation}
+                    placeholderText={locationFilterConfig.placeholderText}
+                ></GsLocationFilter>
+            </label>
+
+            <label className='form-control'>
+                <div className='label'>
+                    <span className='label-text'>{dateRangeFilterConfig.label ?? dateRangeFilterConfig.dateColumn}</span>
+                </div>
+                <GsDateRangeSelector
+                    lapisDateField={dateRangeFilterConfig.dateColumn}
+                    onDateRangeChange={onDateRangeChange}
+                    earliestDate={dateRangeFilterConfig.earliestDate}
+                    initialValue={dateRangeFilterConfig.initialDateRange}
+                    dateRangeOptions={dateRangeFilterConfig.dateRangeOptions}
+                ></GsDateRangeSelector>
+            </label>
+
+            <>
+                {baselineFilterConfigs?.map((config: BaselineFilterConfig) => {
+                    switch (config.type) {
+                        case 'date': {
+                            return (
+                                <label className='form-control' key={config.dateColumn}>
+                                    <div className='label'>
+                                        <span className='label-text'>{config.label ?? config.dateColumn}</span>
+                                    </div>
+                                    <GsDateRangeSelector
+                                        lapisDateField={config.dateColumn}
+                                        onDateRangeChange={(newDateRange) => {
+                                            const newBaselineFilterConfigs = baselineFilterConfigs.map((conf) => {
+                                                if (conf.type !== 'date') {
+                                                    return conf;
+                                                }
+
+                                                return conf.dateColumn === config.dateColumn
+                                                    ? { ...conf, initialDateRange: newDateRange }
+                                                    : conf;
+                                            });
+                                            if (onBaselineFilterConfigChange) {
+                                                onBaselineFilterConfigChange(newBaselineFilterConfigs);
+                                            }
+                                        }}
+                                        earliestDate={config.earliestDate}
+                                        initialValue={config.initialDateRange}
+                                        dateRangeOptions={config.dateRangeOptions}
+                                    ></GsDateRangeSelector>
+                                </label>
+                            );
+                        }
+                        case 'text': {
+                            return (
+                                <label className='form-control' key={config.lapisField}>
+                                    <div className='label'>
+                                        <span className='label-text'>{config.label ?? config.lapisField}</span>
+                                    </div>
+                                    <GsTextInput
+                                        value={config.value}
+                                        lapisField={config.lapisField}
+                                        placeholderText={config.placeholderText}
+                                        onInputChange={(input) => {
+                                            const newBaselineFilterConfigs = baselineFilterConfigs.map((conf) => {
+                                                if (conf.type !== 'text') {
+                                                    return conf;
+                                                }
+
+                                                return conf.lapisField === config.lapisField
+                                                    ? { ...conf, value: input[config.lapisField] }
+                                                    : conf;
+                                            });
+                                            if (onBaselineFilterConfigChange) {
+                                                onBaselineFilterConfigChange(newBaselineFilterConfigs);
+                                            }
+                                        }}
+                                    ></GsTextInput>
+                                </label>
+                            );
+                        }
+                    }
+                })}
+            </>
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/ButtonWithIcon.tsx
+++ b/website/src/components/pageStateSelectors/ButtonWithIcon.tsx
@@ -1,0 +1,10 @@
+import type {PropsWithChildren} from "react";
+
+export function ButtonWithIcon({children, icon}: PropsWithChildren<{icon: string}>) {
+    return (
+        <button className='flex items-center gap-1 hover:underline'>
+            <div className={`iconify ${icon}`}></div>
+            {children}
+        </button>
+    );
+}

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -11,6 +11,8 @@ import type { CovidCompareSideBySideData } from '../../views/covid.ts';
 import { type LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { compareSideBySideViewKey } from '../../views/viewKeys.ts';
+import { ButtonWithIcon } from './ButtonWithIcon.tsx';
+import { Inset } from '../../styles/Inset.tsx';
 
 export function CompareSideBySidePageStateSelector({
     locationFilterConfig,
@@ -30,7 +32,7 @@ export function CompareSideBySidePageStateSelector({
     organismsConfig: OrganismsConfig;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
-    const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
+    const [dateRange, setDateRange] = useState<DateRangeOption | undefined>(dateRangeFilterConfig.initialDateRange);
     const [variantFilterConfigState, setVariantFilterConfigState] = useState<VariantFilterConfig>(variantFilterConfig);
 
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
@@ -48,27 +50,46 @@ export function CompareSideBySidePageStateSelector({
     }, [location, dateRange, variantFilterConfigState, filterId, pageState]);
 
     return (
-        <div className='flex flex-col gap-4 bg-gray-50 p-2'>
-            <div className='flex gap-8'>
-                <div className='flex-0'>
-                    <SelectorHeadline>Filter dataset</SelectorHeadline>
-                    <BaselineSelector
-                        onLocationChange={(location) => setLocation(location)}
-                        locationFilterConfig={locationFilterConfig}
-                        onDateRangeChange={(dateRange) => setDateRange(dateRange)}
-                        dateRangeFilterConfig={dateRangeFilterConfig}
-                    />
-                </div>
-                <div className='flex-grow'>
-                    <SelectorHeadline>Variant Filter</SelectorHeadline>
-                    <VariantSelector
-                        onVariantFilterChange={(variantFilter) => setVariantFilterConfigState(variantFilter)}
-                        variantFilterConfig={variantFilterConfigState}
-                    />
-                </div>
+        <div>
+            <hr className='my-2 border-gray-200' />
+            <div className='mb-2 flex justify-end gap-4 text-sm'>
+                <ButtonWithIcon icon={'mdi--tooltip-help-outline'}>
+                    <div>Help</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--wrench'}>
+                    <div>Add filter fields</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--circle-arrows'}>
+                    <div>Reset</div>
+                </ButtonWithIcon>
             </div>
-            <div className='flex justify-end'>
-                <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
+            <div className='flex flex-col gap-4 p-2 shadow-lg'>
+                <div className='flex gap-8'>
+                    <div className='flex-0'>
+                        <SelectorHeadline>Filter dataset</SelectorHeadline>
+                        <Inset className='p-2'>
+                            <BaselineSelector
+                                onLocationChange={(location) => setLocation(location)}
+                                locationFilterConfig={locationFilterConfig}
+                                onDateRangeChange={(dateRange) => setDateRange(dateRange)}
+                                dateRangeFilterConfig={dateRangeFilterConfig}
+                            />
+                        </Inset>
+                    </div>
+                    <div className='flex-grow'>
+                        <SelectorHeadline>Variant Filter</SelectorHeadline>
+                        <Inset className='p-2'>
+                            <VariantSelector
+                                onVariantFilterChange={(variantFilter) => setVariantFilterConfigState(variantFilter)}
+                                variantFilterConfig={variantFilterConfigState}
+
+                            />
+                        </Inset>
+                    </div>
+                </div>
+                <div className='flex justify-end'>
+                    <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
+                </div>
             </div>
         </div>
     );

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -7,10 +7,12 @@ import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
 import { VariantsSelector } from './VariantsSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
+import { Inset } from '../../styles/Inset.tsx';
 import type { Id } from '../../views/View.ts';
 import { type LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { compareVariantsViewKey } from '../../views/viewKeys.ts';
+import { ButtonWithIcon } from './ButtonWithIcon.tsx';
 
 export function CompareVariantsPageStateSelector({
     locationFilterConfig,
@@ -52,25 +54,44 @@ export function CompareVariantsPageStateSelector({
     }, [location, dateRange, variantConfigs]);
 
     return (
-        <div className='flex flex-col gap-6'>
-            <div>
-                <SelectorHeadline>Filter dataset</SelectorHeadline>
-                <BaselineSelector
-                    onLocationChange={setLocation}
-                    locationFilterConfig={locationFilterConfig}
-                    onDateRangeChange={setDateRange}
-                    dateRangeFilterConfig={dateRangeFilterConfig}
-                />
+        <div>
+            <div className='mb-2 flex justify-end gap-4 text-sm'>
+                <ButtonWithIcon icon={'mdi--tooltip-help-outline'}>
+                    <div>Help</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--wrench'}>
+                    <div>Add filter fields</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--circle-arrows'}>
+                    <div>Reset</div>
+                </ButtonWithIcon>
             </div>
-            <div>
-                <SelectorHeadline>Variant Filters</SelectorHeadline>
-                <VariantsSelector
-                    variantFilterConfigs={variantConfigs}
-                    setVariantFilterConfigs={setVariantConfigs}
-                    emptyVariantFilterConfigProvider={() => view.pageStateHandler.getEmptyVariantFilterConfig()}
-                />
+            <hr className='my-2 border-gray-200' />
+
+            <div className='flex flex-col gap-4'>
+                <div>
+                    <SelectorHeadline>Filter dataset</SelectorHeadline>
+                    <Inset className='p-2'>
+                        <BaselineSelector
+                            onLocationChange={setLocation}
+                            locationFilterConfig={locationFilterConfig}
+                            onDateRangeChange={setDateRange}
+                            dateRangeFilterConfig={dateRangeFilterConfig}
+                        />
+                    </Inset>
+                </div>
+                <div>
+                    <SelectorHeadline>Variant Filters</SelectorHeadline>
+                    <Inset className='p-2'>
+                        <VariantsSelector
+                            variantFilterConfigs={variantConfigs}
+                            setVariantFilterConfigs={setVariantConfigs}
+                            emptyVariantFilterConfigProvider={() => view.pageStateHandler.getEmptyVariantFilterConfig()}
+                        />
+                    </Inset>
+                </div>
+                <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
             </div>
-            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -3,11 +3,13 @@ import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
+import { ButtonWithIcon } from './ButtonWithIcon.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
 import { VariantSelector } from './VariantSelector.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
+import { Inset } from '../../styles/Inset.tsx';
 import type { Id } from '../../views/View.ts';
 import { type LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
@@ -29,7 +31,7 @@ export function CompareVariantsToBaselineStateSelector({
     organismsConfig: OrganismsConfig;
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
-    const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
+    const [dateRange, setDateRange] = useState<DateRangeOption | undefined>(dateRangeFilterConfig.initialDateRange);
     const [baselineFilterConfigState, setBaselineFilterConfigState] =
         useState<VariantFilterConfig>(baselineFilterConfig);
 
@@ -58,32 +60,56 @@ export function CompareVariantsToBaselineStateSelector({
     }, [variantConfigs, location, dateRange, baselineFilterConfigState]);
 
     return (
-        <div className='flex flex-col gap-6'>
-            <div>
-                <SelectorHeadline>Filter dataset</SelectorHeadline>
-                <BaselineSelector
-                    onLocationChange={setLocation}
-                    locationFilterConfig={locationFilterConfig}
-                    onDateRangeChange={setDateRange}
-                    dateRangeFilterConfig={dateRangeFilterConfig}
-                />
+        <div>
+            <div className='mb-2 flex justify-end gap-4 text-sm'>
+                <ButtonWithIcon icon={'mdi--tooltip-help-outline'}>
+                    <div>Help</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--wrench'}>
+                    <div>Add filter fields</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--circle-arrows'}>
+                    <div>Reset</div>
+                </ButtonWithIcon>
             </div>
-            <div>
-                <SelectorHeadline>Baseline Filter</SelectorHeadline>
-                <VariantSelector
-                    onVariantFilterChange={setBaselineFilterConfigState}
-                    variantFilterConfig={baselineFilterConfigState}
-                />
+            <hr className='my-2 border-gray-200' />
+
+            <div className='flex flex-col gap-4'>
+                <div>
+                    <SelectorHeadline>Filter dataset</SelectorHeadline>
+                    <Inset>
+                        <div className='px-2'>
+                            <BaselineSelector
+                                onLocationChange={setLocation}
+                                locationFilterConfig={locationFilterConfig}
+                                onDateRangeChange={setDateRange}
+                                dateRangeFilterConfig={dateRangeFilterConfig}
+                            />
+                        </div>
+                    </Inset>
+                </div>
+                <div>
+                    <SelectorHeadline>Baseline Filter</SelectorHeadline>
+                    <Inset className='p-2'>
+                        <VariantSelector
+                            onVariantFilterChange={setBaselineFilterConfigState}
+                            variantFilterConfig={baselineFilterConfigState}
+                        />
+                    </Inset>
+                </div>
+
+                <div>
+                    <SelectorHeadline>Variant Filters</SelectorHeadline>
+                    <Inset className='p-2'>
+                        <VariantsSelector
+                            variantFilterConfigs={variantConfigs}
+                            setVariantFilterConfigs={setVariantConfigs}
+                            emptyVariantFilterConfigProvider={() => view.pageStateHandler.getEmptyVariantFilterConfig()}
+                        />
+                    </Inset>
+                </div>
+                <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
             </div>
-            <div>
-                <SelectorHeadline>Variant Filters</SelectorHeadline>
-                <VariantsSelector
-                    variantFilterConfigs={variantConfigs}
-                    setVariantFilterConfigs={setVariantConfigs}
-                    emptyVariantFilterConfigProvider={() => view.pageStateHandler.getEmptyVariantFilterConfig()}
-                />
-            </div>
-            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -3,10 +3,12 @@ import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
+import { ButtonWithIcon } from './ButtonWithIcon.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
 import { VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
+import { Inset } from '../../styles/Inset.tsx';
 import type { LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { sequencingEffortsViewKey } from '../../views/viewKeys.ts';
@@ -41,23 +43,38 @@ export function SequencingEffortsPageStateSelector({
     );
 
     return (
-        <div className='flex flex-col gap-6'>
-            <div>
-                <SelectorHeadline>Filter dataset</SelectorHeadline>
+        <div>
+            <div className='mb-2 flex justify-end gap-4 text-sm'>
+                <ButtonWithIcon icon={'mdi--tooltip-help-outline'}>
+                    <div>Help</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--wrench'}>
+                    <div>Add filter fields</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--circle-arrows'}>
+                    <div>Reset</div>
+                </ButtonWithIcon>
+            </div>
+            <hr className='my-2 border-gray-200' />
+
+            <SelectorHeadline>Filter dataset</SelectorHeadline>
+            <Inset className='flex flex-col gap-6 p-2'>
                 <BaselineSelector
                     onLocationChange={(location) => setLocation(location)}
                     locationFilterConfig={locationFilterConfig}
                     onDateRangeChange={(dateRange) => setDateRange(dateRange)}
                     dateRangeFilterConfig={dateRangeFilterConfig}
                 />
-            </div>
-            <div>
                 <VariantSelector
                     onVariantFilterChange={setVariantFilterConfigState}
                     variantFilterConfig={{ ...variantFilterConfigState, mutationFilterConfig: undefined }}
                 />
-            </div>
-            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
+            </Inset>
+            <ApplyFilterButton
+                className={'mt-4'}
+                pageStateHandler={view.pageStateHandler}
+                newPageState={newPageState}
+            />
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -2,11 +2,18 @@ import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, type DateRangeFilterConfig, type LocationFilterConfig } from './BaselineSelector.tsx';
+import {
+    type BaselineFilterConfig,
+    BaselineSelector,
+    type DateRangeFilterConfig,
+    type LocationFilterConfig,
+} from './BaselineSelector.tsx';
+import { ButtonWithIcon } from './ButtonWithIcon.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { toVariantFilter, type VariantFilterConfig } from './VariantFilterConfig.ts';
 import { VariantSelector } from './VariantSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
+import { Inset } from '../../styles/Inset.tsx';
 import { type LapisLocation } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { singleVariantViewKey } from '../../views/viewKeys.ts';
@@ -17,51 +24,103 @@ export function SingleVariantPageStateSelector({
     variantFilterConfig,
     organismViewKey,
     organismsConfig,
+    baselineFilterConfigs,
 }: {
     locationFilterConfig: LocationFilterConfig;
     dateRangeFilterConfig: DateRangeFilterConfig;
     variantFilterConfig: VariantFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof singleVariantViewKey}`;
     organismsConfig: OrganismsConfig;
+    baselineFilterConfigs?: BaselineFilterConfig[];
 }) {
     const [location, setLocation] = useState<LapisLocation>(locationFilterConfig.initialLocation);
-    const [dateRange, setDateRange] = useState<DateRangeOption>(dateRangeFilterConfig.initialDateRange);
+    const [dateRange, setDateRange] = useState<DateRangeOption | undefined>(dateRangeFilterConfig.initialDateRange);
 
+    const [baselineFilterConfigState, setBaselineFilterConfigState] = useState<BaselineFilterConfig[] | undefined>(
+        baselineFilterConfigs,
+    );
     const [variantFilterConfigState, setVariantFilterConfigState] = useState<VariantFilterConfig>(variantFilterConfig);
 
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
 
-    const newPageState = useMemo(
-        () => ({
+    const newPageState = useMemo(() => {
+        const additionalFilters = baselineFilterConfigState?.reduce(
+            (acc, config) => {
+                switch (config.type) {
+                    case 'date': {
+                        acc[config.dateColumn] = config.initialDateRange;
+                        break;
+                    }
+                    case 'text': {
+                        acc[config.lapisField] = config.value;
+                        break;
+                    }
+                }
+                return acc;
+            },
+            {} as {
+                [key: string]: DateRangeOption | string | undefined;
+            },
+        );
+        return {
             datasetFilter: {
                 location,
                 dateRange,
+                ...additionalFilters,
             },
             variantFilter: toVariantFilter(variantFilterConfigState),
-        }),
-        [location, dateRange, variantFilterConfigState],
-    );
+        };
+    }, [location, dateRange, variantFilterConfigState, baselineFilterConfigState]);
 
     return (
-        <div className='flex flex-col gap-6'>
-            <div>
-                <SelectorHeadline>Filter dataset</SelectorHeadline>
-                <BaselineSelector
-                    onLocationChange={setLocation}
-                    locationFilterConfig={locationFilterConfig}
-                    onDateRangeChange={setDateRange}
-                    dateRangeFilterConfig={dateRangeFilterConfig}
-                />
+        <div>
+            <div className='mb-2 flex justify-end gap-4 text-sm'>
+                <ButtonWithIcon icon={'mdi--tooltip-help-outline'}>
+                    <div>Help</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--wrench'}>
+                    <div>Add filter fields</div>
+                </ButtonWithIcon>
+                <ButtonWithIcon icon={'mdi--circle-arrows'}>
+                    <div>Reset</div>
+                </ButtonWithIcon>
             </div>
-            <div>
-                <SelectorHeadline>Variant Filter</SelectorHeadline>
+            <hr className='my-2 border-gray-200' />
 
-                <VariantSelector
-                    onVariantFilterChange={setVariantFilterConfigState}
-                    variantFilterConfig={variantFilterConfigState}
+            <div className='flex flex-col gap-4'>
+                <div>
+                    <SelectorHeadline>Filter dataset</SelectorHeadline>
+                    <Inset className={'p-2'}>
+                        <BaselineSelector
+                            onLocationChange={setLocation}
+                            locationFilterConfig={locationFilterConfig}
+                            onDateRangeChange={setDateRange}
+                            dateRangeFilterConfig={dateRangeFilterConfig}
+                            baselineFilterConfigs={baselineFilterConfigState}
+                            onBaselineFilterConfigChange={setBaselineFilterConfigState}
+                        />
+                    </Inset>
+                </div>
+
+                <div>
+                    <SelectorHeadline>Variant Filter</SelectorHeadline>
+                    <Inset className={'p-2'}>
+                        <VariantSelector
+                            onVariantFilterChange={setVariantFilterConfigState}
+                            variantFilterConfig={variantFilterConfigState}
+                        />
+                    </Inset>
+                </div>
+
+                <div className='pb-5 w-full backdrop-blur-sm sticky bottom-0 z-10'>
+
+                <ApplyFilterButton
+                    className='w-full'
+                    pageStateHandler={view.pageStateHandler}
+                    newPageState={newPageState}
                 />
+                </div>
             </div>
-            <ApplyFilterButton pageStateHandler={view.pageStateHandler} newPageState={newPageState} />
         </div>
     );
 }

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -4,7 +4,7 @@ import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../../util/hasOnlyUndefinedValues';
-import { getLineageFilterFields, getVariantFilterConfig } from '../../../views/View';
+import { getBaselineFilterConfigs, getLineageFilterFields, getVariantFilterConfig } from '../../../views/View';
 import { getLocationSubdivision } from '../../../views/locationHelpers';
 import { toDisplayName } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
@@ -48,6 +48,10 @@ const variantFilterConfig = getVariantFilterConfig(
     pageState.variantFilter,
     view.organismConstants.useAdvancedQuery,
 );
+const baselineFilterConfigs = getBaselineFilterConfigs(
+    pageState.datasetFilter,
+    view.organismConstants.baselineFilterConfigs
+);
 
 const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
 
@@ -80,6 +84,7 @@ const downloadLinks = noVariantSelected
         variantFilterConfig={variantFilterConfig}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
+        baselineFilterConfigs={baselineFilterConfigs}
         client:only='react'
     >
         <AnalyzeSingleVariantSelectorFallback slot='fallback' />
@@ -87,7 +92,9 @@ const downloadLinks = noVariantSelected
 
     {
         noVariantSelected ? (
-            <SelectVariant slot='dataDisplay' />
+            <div class='mx-auto'>
+                <SelectVariant slot='dataDisplay' />
+            </div>
         ) : (
             <div class='mx-[8px] flex flex-col gap-y-6' slot='dataDisplay'>
                 <GsStatistics numeratorFilter={variantLapisFilter} denominatorFilter={datasetLapisFilter} />

--- a/website/src/components/views/analyzeSingleVariant/SelectVariant.astro
+++ b/website/src/components/views/analyzeSingleVariant/SelectVariant.astro
@@ -1,11 +1,15 @@
 ---
 import { PageHeadline } from '../../../styles/containers/PageHeadline';
+import { type OrganismsConfig } from '../../../config';
+
 ---
 
-<div class='mx-4 mt-20 flex min-h-64 flex-col items-center'>
-    <PageHeadline>Analyze a single variant</PageHeadline>
-    <div class='max-w-xl'>
-        <p class='mb-2'>To proceed, please select a variant filter.</p>
+<div class='mt-20 max-w-xl flex flex-col'>
+    <div class='mx-auto'>
+        <PageHeadline>Analyze a single variant</PageHeadline>
+    </div>
+    <div class='max-w-xl flex flex-col gap-2 mx-2 text-center'>
+        <p>Which variant would you like to explore? Select it from the filter on the left.</p>
         <p>
             Note that the dataset filter is applied to the entire dataset. Adjust the dataset filter as needed to refine
             your selection.

--- a/website/src/layouts/OrganismPage/SingleVariantOrganismPageLayout.astro
+++ b/website/src/layouts/OrganismPage/SingleVariantOrganismPageLayout.astro
@@ -19,7 +19,7 @@ const { view, downloadLinks } = Astro.props;
 <OrganismViewPageLayout view={view} downloadLinks={downloadLinks}>
     <gs-app lapis={getLapisUrl(view.organismConstants.organism)}>
         <div class='grid-cols-[300px_1fr] gap-x-4 lg:grid'>
-            <div class='h-fit bg-gray-50 p-2'>
+            <div class='h-fit  p-2 shadow-lg'>
                 <slot name='filters' />
             </div>
             <slot name='dataDisplay' />

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -20,6 +20,7 @@ import { getLocationSubdivision } from '../../views/locationHelpers';
 import { toDisplayName } from '../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey } from '../../views/routing';
 import { ServerSide } from '../../views/serverSideRouting';
+import { SelectorHeadline } from '../../components/pageStateSelectors/SelectorHeadline';
 
 const organismViewKey: OrganismViewKey = 'covid.singleVariantView';
 const view = ServerSide.routing.getOrganismView(organismViewKey);
@@ -55,6 +56,7 @@ const downloadLinks = noVariantSelected
               downloadFileBasename: `${view.organismConstants.organism}_${sanitizeForFilename(displayName)}_accessions`,
           },
       ];
+const organismConfig = getDashboardsConfig().dashboards.organisms;
 ---
 
 <SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
@@ -73,16 +75,17 @@ const downloadLinks = noVariantSelected
             }}
             variantFilterConfig={variantFilterConfig}
             organismViewKey={organismViewKey}
-            organismsConfig={getDashboardsConfig().dashboards.organisms}
+            organismsConfig={organismConfig}
             client:only='react'
         >
             <AnalyzeSingleVariantSelectorFallback slot='fallback' />
         </SingleVariantPageStateSelector>
-        <div class='p-2'>
-            <h2 class='my-2'>Or select a known variant:</h2>
+        <hr class='my-4 border-gray-200' />
+        <div class='mt-4'>
+            <SelectorHeadline> Collections </SelectorHeadline>
             <CollectionsList
                 initialCollectionId={pageState.collectionId}
-                organismsConfig={getDashboardsConfig().dashboards.organisms}
+                organismsConfig={organismConfig}
                 client:load
             />
         </div>
@@ -90,7 +93,9 @@ const downloadLinks = noVariantSelected
 
     {
         noVariantSelected ? (
-            <SelectVariant slot='dataDisplay' />
+            <div class='mx-auto'>
+                <SelectVariant slot='dataDisplay' />
+            </div>
         ) : (
             <div class='mx-[8px] flex flex-col gap-y-6' slot='dataDisplay'>
                 <GsStatistics numeratorFilter={variantFilter} denominatorFilter={datasetLapisFilter} />

--- a/website/src/styles/Expandable.tsx
+++ b/website/src/styles/Expandable.tsx
@@ -1,0 +1,27 @@
+import {type PropsWithChildren, useState} from 'react';
+
+export function Expandable({ children, maxHeightBeforeExpand }: PropsWithChildren<{maxHeightBeforeExpand: string}>) {
+    const [openLarge, setOpenLarge] = useState(false);
+
+    return (
+        <div>
+            <div className={`overflow-y-scroll ${openLarge ? '' : maxHeightBeforeExpand} rounded-md pb-2`}>
+                {children}
+            </div>
+
+            <button className='px-2' onClick={() => setOpenLarge(!openLarge)}>
+                {openLarge ? (
+                    <>
+                        <span className='iconify mdi--keyboard-arrow-up'></span>
+                        <span className='text-sm text-gray-500'>Collapse</span>
+                    </>
+                ) : (
+                    <>
+                        <span className='iconify mdi--keyboard-arrow-down'></span>
+                        <span className='text-sm text-gray-500'>Expand</span>
+                    </>
+                )}
+            </button>
+        </div>
+    );
+}

--- a/website/src/styles/Inset.tsx
+++ b/website/src/styles/Inset.tsx
@@ -1,0 +1,7 @@
+import type { PropsWithChildren } from 'react';
+
+import type { WithClassName } from '../types/WithClassName.ts';
+
+export function Inset({ children, className }: WithClassName<PropsWithChildren>) {
+    return <div className={`rounded-md border-[1px] shadow-inner ${className}`}>{children}</div>;
+}

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -1,6 +1,7 @@
 import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
 
 import { pathoplexusGroupNameField } from './View.ts';
+import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import type { Organism } from '../types/Organism.ts';
 import type { DataOrigin } from '../types/dataOrigins.ts';
@@ -31,6 +32,8 @@ export interface ExtendedConstants extends OrganismConstants {
     readonly additionalSequencingEffortsFields: AdditionalSequencingEffortsField[];
     readonly lineageFilters: LineageFilterConfig[];
     readonly useAdvancedQuery: boolean;
+
+    readonly baselineFilterConfigs?: BaselineFilterConfig[];
 }
 
 export function getAuthorRelatedSequencingEffortsFields(constants: {

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -7,10 +7,13 @@ import { type PageStateHandler } from './pageStateHandlers/PageStateHandler.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import type { VariantFilterConfig } from '../components/pageStateSelectors/VariantFilterConfig.ts';
 import { type BreadcrumbElement } from '../layouts/Breadcrumbs.tsx';
+import type {BaselineFilterConfig} from "../components/pageStateSelectors/BaselineSelector.tsx";
 
 export type DatasetFilter = {
     location: LapisLocation;
     dateRange: DateRangeOption;
+} & {
+    [key: string]: DateRangeOption | string | LapisLocation | undefined;
 };
 
 export type Dataset = {
@@ -102,4 +105,25 @@ export function getLineageFilterConfigs(
             initialValue: (lineages ? lineages[config.lapisField] : undefined) ?? config.initialValue,
         };
     });
+}
+
+export function getBaselineFilterConfigs(
+    dataset: DatasetFilter,
+    baselineFilterConfigs: BaselineFilterConfig[] | undefined
+): BaselineFilterConfig[] | undefined {
+    return baselineFilterConfigs?.map(config => {
+        switch (config.type) {
+            case 'date': {
+                return {
+                    ...config,
+                    initialDateRange: dataset[config.dateColumn] as DateRangeOption | undefined,
+                };
+            }
+            case 'text': {
+                return {
+                    ...config, value: dataset[config.lapisField] as string | undefined,
+                }
+            }
+        }
+    })
 }

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -63,6 +63,7 @@ class CovidConstants implements ExtendedConstants {
         },
     ];
     public readonly useAdvancedQuery = true;
+    public readonly baselineFilterConfigs = undefined;
     public readonly hostField: string;
     public readonly originatingLabField: string | undefined;
     public readonly submittingLabField: string | undefined;

--- a/website/src/views/flu.ts
+++ b/website/src/views/flu.ts
@@ -45,6 +45,7 @@ class FluConstants implements ExtendedConstants {
             initialValue: undefined,
         },
     ];
+    public readonly baselineFilterConfigs = undefined;
     public readonly useAdvancedQuery = false;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -46,6 +46,7 @@ class H5n1Constants implements ExtendedConstants {
         },
     ];
     public readonly useAdvancedQuery = false;
+    public readonly baselineFilterConfigs = undefined;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/helpers.ts
+++ b/website/src/views/helpers.ts
@@ -3,6 +3,7 @@ import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
 import type { VariantFilter } from './View.ts';
 import type { MutationFilter } from '../components/genspectrum/GsMutationFilter.tsx';
 import { CustomDateRangeLabel } from '../types/DateWindow.ts';
+import type {BaselineFilterConfig} from "../components/pageStateSelectors/BaselineSelector.tsx";
 
 /**
  * Sets the value to the search params if the value is not empty, not undefined and not null

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -54,6 +54,7 @@ class MpoxConstants implements ExtendedConstants {
         },
     ];
     public readonly useAdvancedQuery = false;
+    public readonly baselineFilterConfigs = undefined;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/pageStateHandlers/PageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.ts
@@ -1,4 +1,4 @@
-import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import type { ExtendedConstants } from '../OrganismConstants.ts';
 import { type Dataset, type Id, type VariantFilter } from '../View.ts';
@@ -16,10 +16,43 @@ export function toLapisFilterWithoutVariant(
     pageState: Dataset,
     constants: ExtendedConstants,
 ): LapisFilter & LapisLocation {
+    const baselineFilters = constants.baselineFilterConfigs?.reduce(
+        (acc, config) => {
+            switch (config.type) {
+                case 'date': {
+                    const value = pageState.datasetFilter[config.dateColumn] as DateRangeOption | undefined;
+                    if (value === undefined) {
+                        return acc;
+                    }
+
+                    return {
+                        ...acc,
+                        [`${config.dateColumn}From`]: value.dateFrom,
+                        [`${config.dateColumn}To`]: value.dateTo,
+                    };
+                }
+                case 'text': {
+                    const value = pageState.datasetFilter[config.lapisField] as string | undefined;
+                    if (value === undefined) {
+                        return acc;
+                    }
+
+                    return {
+                        ...acc,
+                        [config.lapisField]: value,
+                        [config.lapisField]: value,
+                    };
+                }
+            }
+        },
+        {} as { [key: string]: string | undefined },
+    );
+
     return {
         ...pageState.datasetFilter.location,
         [`${constants.mainDateField}From`]: pageState.datasetFilter.dateRange.dateFrom,
         [`${constants.mainDateField}To`]: pageState.datasetFilter.dateRange.dateTo,
+        ...baselineFilters,
         ...constants.additionalFilters,
     };
 }

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -1,4 +1,4 @@
-import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import type { ExtendedConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
@@ -7,10 +7,12 @@ import {
     getDateRangeFromSearch,
     getLapisLocationFromSearch,
     getLapisVariantQuery,
+    getStringFromSearch,
     type LapisLocation,
     setSearchFromDateRange,
     setSearchFromLapisVariantQuery,
     setSearchFromLocation,
+    setSearchFromString,
 } from '../helpers.ts';
 import { type PageStateHandler, toLapisFilterFromVariant, toLapisFilterWithoutVariant } from './PageStateHandler.ts';
 import { formatUrl } from '../../util/formatUrl.ts';
@@ -30,12 +32,35 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
 
     public parsePageStateFromUrl(url: URL): DatasetAndVariantData {
         const search = url.searchParams;
+
+        const baselineFilterConfigs = this.constants.baselineFilterConfigs?.reduce(
+            (acc, config) => {
+                switch (config.type) {
+                    case 'date': {
+                        return {
+                            ...acc,
+                            [config.dateColumn]:
+                                getDateRangeFromSearch(search, config.dateColumn, config.dateRangeOptions) ??
+                                config.defaultDateRange,
+                        };
+                    }
+                    case 'text': {
+                        return { ...acc, [config.lapisField]: getStringFromSearch(search, config.lapisField) };
+                    }
+                }
+            },
+            {} as {
+                [key: string]: DateRangeOption | string | undefined;
+            },
+        );
+
         return {
             datasetFilter: {
                 location: getLapisLocationFromSearch(search, this.constants.locationFields),
                 dateRange:
                     getDateRangeFromSearch(search, this.constants.mainDateField, this.constants.dateRangeOptions) ??
                     this.constants.defaultDateRange,
+                ...baselineFilterConfigs,
             },
             variantFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
         };
@@ -44,9 +69,26 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
     public toUrl(pageState: DatasetAndVariantData): string {
         const search = new URLSearchParams();
         setSearchFromLocation(search, pageState.datasetFilter.location);
-        if (pageState.datasetFilter.dateRange !== this.constants.defaultDateRange) {
+        if (JSON.stringify(pageState.datasetFilter.dateRange) !== JSON.stringify(this.constants.defaultDateRange)) {
             setSearchFromDateRange(search, this.constants.mainDateField, pageState.datasetFilter.dateRange);
         }
+        this.constants.baselineFilterConfigs?.map((config) => {
+            switch (config.type) {
+                case 'date': {
+                    const value = pageState.datasetFilter[config.dateColumn] as DateRangeOption | undefined;
+                    if (JSON.stringify(value) !== JSON.stringify(config.defaultDateRange)) {
+                        setSearchFromDateRange(search, config.dateColumn, value);
+                    }
+                    break;
+                }
+                case 'text': {
+                    const value = pageState.datasetFilter[config.lapisField] as string | undefined;
+                    setSearchFromString(search, config.lapisField, value);
+                    break;
+                }
+            }
+        });
+
         setSearchFromLapisVariantQuery(
             search,
             pageState.variantFilter,

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -44,6 +44,7 @@ class RsvAConstants implements ExtendedConstants {
         },
     ];
     public readonly useAdvancedQuery = false;
+    public readonly baselineFilterConfigs = undefined;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -44,6 +44,7 @@ class RsvBConstants implements ExtendedConstants {
         },
     ];
     public readonly useAdvancedQuery = false;
+    public readonly baselineFilterConfigs = undefined;
     public readonly hostField: string;
     public readonly authorsField: string | undefined;
     public readonly authorAffiliationsField: string | undefined;

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -9,12 +9,13 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getPathoplexusAdditionalSequencingEffortsFields, type ExtendedConstants } from './OrganismConstants.ts';
+import { type ExtendedConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { GenericCompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
+import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 
 class WestNileConstants implements ExtendedConstants {
     public readonly organism = Organisms.westNile;
@@ -41,6 +42,40 @@ class WestNileConstants implements ExtendedConstants {
             placeholderText: 'Lineage',
             filterType: 'text' as const,
             initialValue: undefined,
+        },
+    ];
+    public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
+        { type: 'text', lapisField: 'submitter', placeholderText: 'Submitter' },
+        {
+            type: 'text',
+            lapisField: 'hostNameScientific',
+            placeholderText: 'Host name scientific',
+            label: 'Host name scientific',
+        },
+        {
+            type: 'text',
+            lapisField: 'hostGender',
+            placeholderText: 'Host gender',
+            label: 'Host gender',
+        },
+        {
+            type: 'text',
+            lapisField: 'hostGender',
+            placeholderText: 'Host gender',
+            label: 'Host gender',
+        },
+        {
+            type: 'text',
+            lapisField: 'hostGender',
+            placeholderText: 'Host gender',
+            label: 'Host gender',
+        },
+        {
+            type: 'date',
+            dateRangeOptions: [dateRangeOptionPresets.lastMonth, dateRangeOptionPresets.last2Months],
+            earliestDate: '1999-01-01',
+            defaultDateRange: dateRangeOptionPresets.lastMonth,
+            dateColumn: 'sampleCollectionDateRangeUpper',
         },
     ];
     public readonly useAdvancedQuery = false;


### PR DESCRIPTION
### Summary

In this draft, the new design of the filters is shown. The design is used for all pages, but only on the `/west-nile/single-variant` page, it is connected to config values.
Before updating also the other views, it would be nice to get some feedback on the implementation and design. 

Possible future extensions:
  - add color to baseline and variant filter in conjuction wtih a describing grafic wtih the same colors 
 
After mockup:
  - add functionality to "Reset" button
  - add functionality to "Add filter fields" button
  - add functionality to "Help" button
  - specify the filter fields in config 


<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

![grafik](https://github.com/user-attachments/assets/f643aff6-c861-43c0-994a-b58533220183)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
