### PR TITLE
chore: website/.gitignore: add logs/

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -11,7 +11,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
-
+logs/
 
 # environment variables
 .env


### PR DESCRIPTION
So that running `npm check` from within the `website` directory will know to exclude json files in the logs subdirectory.

### Summary

`npm check` stops processing when encountering a warning while checking json files, and it did find the json file in the logs/ directory below website/ because it was not in the .gitignore there. That prevented it from reporting TypeScript or Astra failures.

