### PR TITLE
use aggregates bar chart

### DIFF
--- a/website/src/components/genspectrum/GsAggregate.astro
+++ b/website/src/components/genspectrum/GsAggregate.astro
@@ -1,5 +1,5 @@
 ---
-import { type LapisFilter, views } from '@genspectrum/dashboard-components/util';
+import { type AggregateView, type LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import { defaultTablePageSize } from '../../views/View';
 import ComponentWrapper from '../ComponentWrapper.astro';
@@ -9,14 +9,15 @@ interface Props {
     height?: string;
     fields: string[];
     lapisFilter: LapisFilter;
+    views: AggregateView[];
 }
 
-const { title, height, fields, lapisFilter } = Astro.props;
+const { title, height, fields, lapisFilter, views } = Astro.props;
 ---
 
 <ComponentWrapper title={title} height={height}>
     <gs-aggregate
-        views={JSON.stringify([views.table])}
+        views={JSON.stringify(views)}
         fields={JSON.stringify(fields)}
         lapisFilter={JSON.stringify(lapisFilter)}
         pageSize={defaultTablePageSize}

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -1,4 +1,6 @@
 ---
+import { views } from '@genspectrum/dashboard-components/util';
+
 import SelectVariant from './SelectVariant.astro';
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
@@ -116,17 +118,20 @@ const downloadLinks = noVariantSelected
                             title={subdivisionLabel}
                             fields={[subdivisionField]}
                             lapisFilter={variantLapisFilter}
+                            views={[views.table, views.bar]}
                         />
                     )}
                     <GsAggregate
                         title='Clades and lineages'
                         fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
                         lapisFilter={variantLapisFilter}
+                        views={[views.table, views.bar]}
                     />
                     <GsAggregate
                         title='Hosts'
                         fields={[view.organismConstants.hostField]}
                         lapisFilter={variantLapisFilter}
+                        views={[views.table, views.bar]}
                     />
                 </ComponentsGrid>
                 <GsMutationsOverTime

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -1,4 +1,6 @@
 ---
+import { views } from '@genspectrum/dashboard-components/util';
+
 import { toDownloadLink } from './toDownloadLink';
 import { getDashboardsConfig, getLapisUrl } from '../../../config';
 import OrganismViewPageLayout from '../../../layouts/OrganismPage/OrganismViewPageLayout.astro';
@@ -117,11 +119,13 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                 title='Sub-lineages'
                                 fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
                                 lapisFilter={numeratorFilter}
+                                views={[views.table, views.bar]}
                             />
                             <GsAggregate
                                 title='Hosts'
                                 fields={[view.organismConstants.hostField]}
                                 lapisFilter={numeratorFilter}
+                                views={[views.table, views.bar]}
                             />
                         </div>
                     );

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -1,4 +1,6 @@
 ---
+import { views } from '@genspectrum/dashboard-components/util';
+
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
@@ -96,15 +98,17 @@ const variantFilterConfig = getVariantFilterConfig(
             height={ComponentHeight.large}
             fields={[view.organismConstants.hostField]}
             lapisFilter={lapisFilter}
+            views={[views.table, views.bar]}
         />
         <GsAggregate
             title='Sub-lineages'
             fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
             lapisFilter={lapisFilter}
+            views={[views.table, views.bar]}
         />
         {
-            view.organismConstants.additionalSequencingEffortsFields.map(({ label, fields, height }) => (
-                <GsAggregate title={label} height={height} fields={fields} lapisFilter={lapisFilter} />
+            view.organismConstants.additionalSequencingEffortsFields.map(({ label, fields, height, views }) => (
+                <GsAggregate title={label} height={height} fields={fields} lapisFilter={lapisFilter} views={views} />
             ))
         }
     </ComponentsGrid>

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -1,4 +1,6 @@
 ---
+import { views } from '@genspectrum/dashboard-components/util';
+
 import GsAggregate from '../../components/genspectrum/GsAggregate.astro';
 import GsMutations from '../../components/genspectrum/GsMutations.astro';
 import GsPrevalenceOverTime from '../../components/genspectrum/GsPrevalenceOverTime.astro';
@@ -113,11 +115,13 @@ const downloadLinks = [...pageState.filters.entries()].map(
                                 title='Sub-lineages'
                                 fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
                                 lapisFilter={numeratorFilter}
+                                views={[views.table, views.bar]}
                             />
                             <GsAggregate
                                 title='Hosts'
                                 fields={[view.organismConstants.hostField]}
                                 lapisFilter={numeratorFilter}
+                                views={[views.table, views.bar]}
                             />
                         </div>
                     );

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -1,4 +1,6 @@
 ---
+import { views } from '@genspectrum/dashboard-components/util';
+
 import ComponentsGrid from '../../components/ComponentsGrid.astro';
 import GsAggregate from '../../components/genspectrum/GsAggregate.astro';
 import GsMutations from '../../components/genspectrum/GsMutations.astro';
@@ -125,14 +127,21 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
                         title='Sub-lineages'
                         fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
                         lapisFilter={variantFilter}
+                        views={[views.table, views.bar]}
                     />
                     {subdivisionField !== undefined && (
-                        <GsAggregate title={subdivisionLabel} fields={[subdivisionField]} lapisFilter={variantFilter} />
+                        <GsAggregate
+                            title={subdivisionLabel}
+                            fields={[subdivisionField]}
+                            lapisFilter={variantFilter}
+                            views={[views.table, views.bar]}
+                        />
                     )}
                     <GsAggregate
                         title='Hosts'
                         fields={[view.organismConstants.hostField]}
                         lapisFilter={variantFilter}
+                        views={[views.table, views.bar]}
                     />
                 </ComponentsGrid>
 

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -34,7 +34,7 @@ export interface ExtendedConstants extends OrganismConstants {
 export function getAuthorRelatedSequencingEffortsFields(constants: {
     authorsField: string | undefined;
     authorAffiliationsField: string | undefined;
-}) {
+}): AdditionalSequencingEffortsField[] {
     const authorAffiliations =
         constants.authorAffiliationsField === undefined
             ? []
@@ -60,7 +60,7 @@ export function getAuthorRelatedSequencingEffortsFields(constants: {
 
 export function getPathoplexusAdditionalSequencingEffortsFields(
     constants: Parameters<typeof getAuthorRelatedSequencingEffortsFields>[0],
-) {
+): AdditionalSequencingEffortsField[] {
     return [
         {
             label: 'Pathoplexus submitting groups',

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -1,3 +1,5 @@
+import { views, type AggregateView } from '@genspectrum/dashboard-components/util';
+
 import { pathoplexusGroupNameField } from './View.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -19,6 +21,7 @@ export interface AdditionalSequencingEffortsField {
     readonly label: string;
     readonly fields: string[];
     readonly height: (typeof ComponentHeight)[keyof typeof ComponentHeight];
+    readonly views: AggregateView[];
 }
 
 export interface ExtendedConstants extends OrganismConstants {
@@ -43,6 +46,7 @@ export function getAuthorRelatedSequencingEffortsFields(constants: {
                       label: 'Author affiliations',
                       fields: [constants.authorAffiliationsField],
                       height: ComponentHeight.large,
+                      views: [views.table],
                   },
               ];
     const authors =
@@ -53,6 +57,7 @@ export function getAuthorRelatedSequencingEffortsFields(constants: {
                       label: 'Authors',
                       fields: [constants.authorsField, constants.authorAffiliationsField],
                       height: ComponentHeight.large,
+                      views: [views.table],
                   },
               ];
     return [...authorAffiliations, ...authors];
@@ -66,17 +71,44 @@ export function getPathoplexusAdditionalSequencingEffortsFields(
             label: 'Pathoplexus submitting groups',
             fields: [pathoplexusGroupNameField],
             height: ComponentHeight.small,
+            views: [views.table],
         },
         ...getAuthorRelatedSequencingEffortsFields(constants),
-        { label: 'Collection device', fields: ['collectionDevice'], height: ComponentHeight.small },
-        { label: 'Collection method', fields: ['collectionMethod'], height: ComponentHeight.small },
-        { label: 'Purpose of sampling', fields: ['purposeOfSampling'], height: ComponentHeight.small },
-        { label: 'Sample type', fields: ['sampleType'], height: ComponentHeight.small },
+        {
+            label: 'Collection device',
+            fields: ['collectionDevice'],
+            height: ComponentHeight.small,
+            views: [views.table, views.bar],
+        },
+        {
+            label: 'Collection method',
+            fields: ['collectionMethod'],
+            height: ComponentHeight.small,
+            views: [views.table, views.bar],
+        },
+        {
+            label: 'Purpose of sampling',
+            fields: ['purposeOfSampling'],
+            height: ComponentHeight.small,
+            views: [views.table, views.bar],
+        },
+        {
+            label: 'Sample type',
+            fields: ['sampleType'],
+            height: ComponentHeight.small,
+            views: [views.table, views.bar],
+        },
         {
             label: 'Amplicon PCR primer scheme',
             fields: ['ampliconPcrPrimerScheme'],
             height: ComponentHeight.small,
+            views: [views.table, views.bar],
         },
-        { label: 'Sequencing protocol', fields: ['sequencingProtocol'], height: ComponentHeight.small },
+        {
+            label: 'Sequencing protocol',
+            fields: ['sequencingProtocol'],
+            height: ComponentHeight.small,
+            views: [views.table, views.bar],
+        },
     ];
 }

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -1,4 +1,4 @@
-import { dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';
+import { dateRangeOptionPresets, views } from '@genspectrum/dashboard-components/util';
 
 import {
     getIntegerFromSearch,
@@ -78,11 +78,25 @@ class CovidConstants implements ExtendedConstants {
         const originatingLab =
             this.originatingLabField === undefined
                 ? []
-                : [{ label: 'Originating lab', fields: [this.originatingLabField], height: ComponentHeight.large }];
+                : [
+                      {
+                          label: 'Originating lab',
+                          fields: [this.originatingLabField],
+                          height: ComponentHeight.large,
+                          views: [views.table],
+                      },
+                  ];
         const submittingLab =
             this.submittingLabField === undefined
                 ? []
-                : [{ label: 'Submitting lab ', fields: [this.submittingLabField], height: ComponentHeight.large }];
+                : [
+                      {
+                          label: 'Submitting lab ',
+                          fields: [this.submittingLabField],
+                          height: ComponentHeight.large,
+                          views: [views.table],
+                      },
+                  ];
         return [...originatingLab, ...submittingLab];
     }
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #476 

### Summary

- add some return type definitions (useful for catching the missing fields for the other changes)

- GsAggregate astro component: require a `views` argument.

- Add `views` field to `additionalSequencingEffortsFields`, to enable
  configuration per such entry.

- Add the `views` argument statically to the remaining GsAggregate
  call sites.
