### PR TITLE
feat(website): use auto height for tables and mutation over time

### DIFF
--- a/website/src/components/ComponentWrapper.astro
+++ b/website/src/components/ComponentWrapper.astro
@@ -5,7 +5,7 @@ interface Props {
     height?: string;
 }
 
-const { title, height = '400px' } = Astro.props;
+const { title, height } = Astro.props;
 ---
 
 <div>

--- a/website/src/components/genspectrum/GsAggregate.astro
+++ b/website/src/components/genspectrum/GsAggregate.astro
@@ -6,13 +6,14 @@ import ComponentWrapper from '../ComponentWrapper.astro';
 
 interface Props {
     title: string;
-    height?: string;
     fields: string[];
     lapisFilter: LapisFilter;
     views: AggregateView[];
+    height?: string;
+    pageSize?: number;
 }
 
-const { title, height, fields, lapisFilter, views } = Astro.props;
+const { title, height, fields, lapisFilter, views, pageSize } = Astro.props;
 ---
 
 <ComponentWrapper title={title} height={height}>
@@ -20,7 +21,7 @@ const { title, height, fields, lapisFilter, views } = Astro.props;
         views={JSON.stringify(views)}
         fields={JSON.stringify(fields)}
         lapisFilter={JSON.stringify(lapisFilter)}
-        pageSize={defaultTablePageSize}
+        pageSize={pageSize ?? defaultTablePageSize}
         width='100%'
-        height='100%'></gs-aggregate>
+        height={height ? '100%' : undefined}></gs-aggregate>
 </ComponentWrapper>

--- a/website/src/components/genspectrum/GsMutationComparison.astro
+++ b/website/src/components/genspectrum/GsMutationComparison.astro
@@ -7,17 +7,19 @@ import ComponentWrapper from '../ComponentWrapper.astro';
 interface Props {
     lapisFilters: NamedLapisFilter[];
     sequenceType: SequenceType;
+    height?: string;
+    pageSize?: number;
 }
 
-const { lapisFilters, sequenceType } = Astro.props;
+const { lapisFilters, sequenceType, height, pageSize } = Astro.props;
 ---
 
-<ComponentWrapper title={sequenceType === 'nucleotide' ? 'Nucleotide changes' : 'Amino acid changes'}>
+<ComponentWrapper title={sequenceType === 'nucleotide' ? 'Nucleotide changes' : 'Amino acid changes'} height={height}>
     <gs-mutation-comparison
         lapisFilters={JSON.stringify(lapisFilters)}
         sequenceType={sequenceType}
         views='["venn", "table"]'
-        pageSize={defaultTablePageSize}
+        pageSize={pageSize ?? defaultTablePageSize}
         width='100%'
-        height='100%'></gs-mutation-comparison>
+        height={height ? '100%' : undefined}></gs-mutation-comparison>
 </ComponentWrapper>

--- a/website/src/components/genspectrum/GsMutations.astro
+++ b/website/src/components/genspectrum/GsMutations.astro
@@ -8,18 +8,23 @@ interface Props {
     lapisFilter: LapisFilter;
     baselineLapisFilter?: LapisFilter;
     sequenceType: SequenceType;
+    pageSize?: number;
+    height?: string;
 }
 
-const { lapisFilter, baselineLapisFilter, sequenceType } = Astro.props;
+const { lapisFilter, baselineLapisFilter, sequenceType, pageSize, height } = Astro.props;
 ---
 
-<ComponentWrapper title={sequenceType === 'nucleotide' ? 'Nucleotide mutations' : 'Amino acid mutations'}>
+<ComponentWrapper
+    title={sequenceType === 'nucleotide' ? 'Nucleotide mutations' : 'Amino acid mutations'}
+    height={height}
+>
     <gs-mutations
         lapisFilter={JSON.stringify(lapisFilter)}
         baselineLapisFilter={JSON.stringify(baselineLapisFilter)}
         sequenceType={sequenceType}
         views='["grid", "table", "insertions"]'
-        pageSize={defaultTablePageSize}
+        pageSize={pageSize ?? defaultTablePageSize}
         width='100%'
-        height='100%'></gs-mutations>
+        height={height ? '100%' : undefined}></gs-mutations>
 </ComponentWrapper>

--- a/website/src/components/genspectrum/GsMutationsOverTime.astro
+++ b/website/src/components/genspectrum/GsMutationsOverTime.astro
@@ -1,7 +1,6 @@
 ---
 import type { TemporalGranularity, LapisFilter, SequenceType } from '@genspectrum/dashboard-components/util';
 
-import { ComponentHeight } from '../../views/OrganismConstants';
 import ComponentWrapper from '../ComponentWrapper.astro';
 
 interface Props {
@@ -9,18 +8,19 @@ interface Props {
     sequenceType: SequenceType;
     granularity: TemporalGranularity;
     lapisDateField: string;
+    height?: string;
 }
 
-const { lapisFilter, sequenceType, granularity, lapisDateField } = Astro.props;
+const { lapisFilter, sequenceType, granularity, lapisDateField, height } = Astro.props;
 ---
 
 <ComponentWrapper
     title={sequenceType === 'nucleotide' ? 'Nucleotide mutations over time' : 'Amino acid mutations over time'}
-    height={ComponentHeight.large}
+    height={height}
 >
     <gs-mutations-over-time
         width='100%'
-        height='100%'
+        height={height ? '100%' : undefined}
         lapisFilter={JSON.stringify(lapisFilter)}
         sequenceType={sequenceType}
         views='["grid"]'

--- a/website/src/components/genspectrum/GsNumberSequencesOverTime.astro
+++ b/website/src/components/genspectrum/GsNumberSequencesOverTime.astro
@@ -1,7 +1,6 @@
 ---
 import type { NamedLapisFilter } from '@genspectrum/dashboard-components/util';
 
-import { ComponentHeight } from '../../views/OrganismConstants';
 import { defaultTablePageSize } from '../../views/View';
 import ComponentWrapper from '../ComponentWrapper.astro';
 
@@ -9,18 +8,20 @@ interface Props {
     lapisFilters: NamedLapisFilter[];
     lapisDateField: string;
     granularity: string;
+    pageSize?: number;
+    height?: string;
 }
 
-const { lapisFilters, lapisDateField, granularity } = Astro.props;
+const { lapisFilters, lapisDateField, granularity, pageSize, height } = Astro.props;
 ---
 
-<ComponentWrapper title='Number sequences' height={ComponentHeight.large}>
+<ComponentWrapper title='Number sequences' height={height}>
     <gs-number-sequences-over-time
         lapisFilters={JSON.stringify(lapisFilters)}
         lapisDateField={lapisDateField}
         views='["bar", "line", "table"]'
-        pageSize={defaultTablePageSize}
+        pageSize={pageSize ?? defaultTablePageSize}
         width='100%'
-        height='100%'
+        height={height ? '100%' : undefined}
         granularity={granularity}></gs-number-sequences-over-time>
 </ComponentWrapper>

--- a/website/src/components/genspectrum/GsPrevalenceOverTime.astro
+++ b/website/src/components/genspectrum/GsPrevalenceOverTime.astro
@@ -15,6 +15,8 @@ interface Props {
     lapisDateField: string;
     granularity: TemporalGranularity;
     views?: PrevalenceOverTimeView[];
+    height?: string;
+    pageSize?: number;
 }
 
 const {
@@ -23,18 +25,20 @@ const {
     lapisDateField,
     granularity,
     views = ['bar', 'line', 'bubble', 'table'],
+    height,
+    pageSize,
 } = Astro.props;
 ---
 
-<ComponentWrapper title='Prevalence over time'>
+<ComponentWrapper title='Prevalence over time' height={height}>
     <gs-prevalence-over-time
         numeratorFilters={JSON.stringify(numeratorFilters)}
         denominatorFilter={JSON.stringify(denominatorFilter)}
         lapisDateField={lapisDateField}
         granularity={granularity}
         smoothingWindow='0'
-        pageSize={defaultTablePageSize}
+        pageSize={pageSize ?? defaultTablePageSize}
         views={JSON.stringify(views)}
         width='100%'
-        height='100%'></gs-prevalence-over-time>
+        height={height ? '100%' : undefined}></gs-prevalence-over-time>
 </ComponentWrapper>

--- a/website/src/components/genspectrum/GsRelativeGrowthAdvantage.astro
+++ b/website/src/components/genspectrum/GsRelativeGrowthAdvantage.astro
@@ -8,18 +8,19 @@ interface Props {
     numeratorFilter: LapisFilter;
     denominatorFilter: LapisFilter;
     lapisDateField: string;
+    height?: string;
 }
 
-const { numeratorFilter, denominatorFilter, lapisDateField } = Astro.props;
+const { numeratorFilter, denominatorFilter, lapisDateField, height } = Astro.props;
 ---
 
-<ComponentWrapper title='Relative growth advantage'>
+<ComponentWrapper title='Relative growth advantage' height={height}>
     <gs-relative-growth-advantage
         numeratorFilter={JSON.stringify(numeratorFilter)}
         denominatorFilter={JSON.stringify(denominatorFilter)}
         generationTime='7'
         pageSize={defaultTablePageSize}
         width='100%'
-        height='100%'
+        height={height ? '100%' : undefined}
         lapisDateField={lapisDateField}></gs-relative-growth-advantage>
 </ComponentWrapper>

--- a/website/src/components/genspectrum/GsSequencesByLocation.astro
+++ b/website/src/components/genspectrum/GsSequencesByLocation.astro
@@ -7,13 +7,14 @@ import ComponentWrapper from '../ComponentWrapper.astro';
 
 interface Props {
     title: string;
-    height?: string;
     lapisLocationField: string;
     lapisFilter: LapisFilter;
+    height?: string;
     mapName?: string;
+    pageSize?: number;
 }
 
-const { title, height, lapisLocationField, lapisFilter, mapName } = Astro.props;
+const { title, height, lapisLocationField, lapisFilter, mapName, pageSize } = Astro.props;
 
 const mapData = getSequencesByLocationMapData(mapName, Astro.url);
 ---
@@ -24,20 +25,20 @@ const mapData = getSequencesByLocationMapData(mapName, Astro.url);
             <gs-sequences-by-location
                 lapisLocationField={lapisLocationField}
                 lapisFilter={JSON.stringify(lapisFilter)}
-                pageSize={defaultTablePageSize}
+                pageSize={pageSize ?? defaultTablePageSize}
                 views={JSON.stringify(['table'])}
                 width='100%'
-                height='100%'
+                height={height ? '100%' : undefined}
             />
         ) : (
             <gs-sequences-by-location
                 lapisLocationField={lapisLocationField}
                 lapisFilter={JSON.stringify(lapisFilter)}
-                pageSize={defaultTablePageSize}
+                pageSize={pageSize ?? defaultTablePageSize}
                 views={JSON.stringify(['map', 'table'])}
                 mapSource={JSON.stringify(mapData.mapSource)}
                 width='100%'
-                height='100%'
+                height={height ? '100%' : undefined}
                 zoom={mapData.zoom}
                 offsetX={mapData.offsetX}
                 offsetY={mapData.offsetY}

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -107,16 +107,19 @@ const downloadLinks = noVariantSelected
                 denominatorFilter={datasetLapisFilter}
                 lapisDateField={view.organismConstants.mainDateField}
                 granularity={timeGranularity}
+                pageSize={10}
             />
             <GsMutations
                 lapisFilter={variantLapisFilter}
                 baselineLapisFilter={datasetLapisFilter}
                 sequenceType='nucleotide'
+                pageSize={10}
             />
             <GsMutations
                 lapisFilter={variantLapisFilter}
                 baselineLapisFilter={datasetLapisFilter}
                 sequenceType='amino acid'
+                pageSize={10}
             />
             {
                 subdivisionField !== undefined && (
@@ -125,6 +128,7 @@ const downloadLinks = noVariantSelected
                         fields={[subdivisionField]}
                         lapisFilter={variantLapisFilter}
                         views={[views.table, views.bar]}
+                        pageSize={10}
                     />
                 )
             }
@@ -136,6 +140,7 @@ const downloadLinks = noVariantSelected
                         fields={lineageFilterFields}
                         lapisFilter={variantLapisFilter}
                         views={[views.table, views.bar]}
+                        pageSize={10}
                     />
                 )
             }
@@ -144,6 +149,7 @@ const downloadLinks = noVariantSelected
                 fields={[view.organismConstants.hostField]}
                 lapisFilter={variantLapisFilter}
                 views={[views.table, views.bar]}
+                pageSize={10}
             />
         </ComponentsGrid>
         <GsMutationsOverTime

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -5,6 +5,7 @@ import { toDownloadLink } from './toDownloadLink';
 import { getDashboardsConfig, getLapisUrl } from '../../../config';
 import OrganismViewPageLayout from '../../../layouts/OrganismPage/OrganismViewPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
+import { ComponentHeight } from '../../../views/OrganismConstants';
 import { getLineageFilterFields, getVariantFilterConfig } from '../../../views/View';
 import { toLapisFilterWithoutVariant } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
@@ -101,6 +102,8 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                 denominatorFilter={datasetLapisFilter}
                                 lapisDateField={view.organismConstants.mainDateField}
                                 granularity={timeGranularity}
+                                height={ComponentHeight.large}
+                                pageSize={10}
                             />
                             {!hideMutationComponents && (
                                 <>
@@ -108,11 +111,13 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                         lapisFilter={numeratorFilter}
                                         baselineLapisFilter={datasetLapisFilter}
                                         sequenceType='nucleotide'
+                                        pageSize={10}
                                     />
                                     <GsMutations
                                         lapisFilter={numeratorFilter}
                                         baselineLapisFilter={datasetLapisFilter}
                                         sequenceType='amino acid'
+                                        pageSize={10}
                                     />
                                 </>
                             )}
@@ -123,6 +128,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                     fields={lineageFilterFields}
                                     lapisFilter={numeratorFilter}
                                     views={[views.table, views.bar]}
+                                    pageSize={10}
                                 />
                             )}
                             <GsAggregate
@@ -130,6 +136,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                 fields={[view.organismConstants.hostField]}
                                 lapisFilter={numeratorFilter}
                                 views={[views.table, views.bar]}
+                                pageSize={10}
                             />
                         </div>
                     );

--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
@@ -3,6 +3,7 @@ import SelectBaseline from './SelectBaseline.astro';
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
+import { ComponentHeight } from '../../../views/OrganismConstants';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { compareToBaselineViewKey } from '../../../views/viewKeys';
@@ -72,6 +73,8 @@ const downloadLinks = noVariantSelected
                     lapisDateField={view.organismConstants.mainDateField}
                     granularity={timeGranularity}
                     views={['line', 'table', 'bar']}
+                    height={ComponentHeight.large}
+                    pageSize={12}
                 />
             </ComponentsGrid>
         )

--- a/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
+++ b/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
@@ -43,6 +43,8 @@ const downloadLinks = notEnoughVariantsSelected
           filter: lapisFilter,
           downloadFileBasename: `${organism}_${sanitizeForFilename(displayName)}_accessions`,
       }));
+
+const componentHeight = '540px'; // prevalence over time table with 10 rows
 ---
 
 <SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
@@ -72,9 +74,21 @@ const downloadLinks = notEnoughVariantsSelected
                     lapisDateField={view.organismConstants.mainDateField}
                     granularity={timeGranularity}
                     views={['line', 'table', 'bar', 'bubble']}
+                    height={componentHeight}
+                    pageSize={10}
                 />
-                <GsMutationComparison lapisFilters={numeratorLapisFilters} sequenceType='nucleotide' />
-                <GsMutationComparison lapisFilters={numeratorLapisFilters} sequenceType='amino acid' />
+                <GsMutationComparison
+                    lapisFilters={numeratorLapisFilters}
+                    sequenceType='nucleotide'
+                    height={componentHeight}
+                    pageSize={10}
+                />
+                <GsMutationComparison
+                    lapisFilters={numeratorLapisFilters}
+                    sequenceType='amino acid'
+                    height={componentHeight}
+                    pageSize={10}
+                />
             </ComponentsGrid>
         )
     }

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -4,7 +4,6 @@ import { views } from '@genspectrum/dashboard-components/util';
 import { getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
-import { ComponentHeight } from '../../../views/OrganismConstants';
 import { getLineageFilterFields, getVariantFilterConfig } from '../../../views/View';
 import { getLocationDisplayConfig } from '../../../views/locationHelpers';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
@@ -83,24 +82,25 @@ const lineageFilterFields = getLineageFilterFields(view.organismConstants.lineag
             ]}
             lapisDateField={view.organismConstants.mainDateField}
             granularity={timeGranularity}
+            pageSize={10}
         />
         {
             locationField !== undefined && (
                 <GsSequencesByLocation
                     title='Sequences by location'
-                    height={ComponentHeight.large}
                     lapisLocationField={locationField}
                     lapisFilter={lapisFilter}
                     mapName={mapName}
+                    pageSize={10}
                 />
             )
         }
         <GsAggregate
             title='Hosts'
-            height={ComponentHeight.large}
             fields={[view.organismConstants.hostField]}
             lapisFilter={lapisFilter}
             views={[views.table, views.bar]}
+            pageSize={10}
         />
         {
             lineageFilterFields.length > 0 && (
@@ -109,12 +109,13 @@ const lineageFilterFields = getLineageFilterFields(view.organismConstants.lineag
                     fields={lineageFilterFields}
                     lapisFilter={lapisFilter}
                     views={[views.table, views.bar]}
+                    pageSize={10}
                 />
             )
         }
         {
-            view.organismConstants.additionalSequencingEffortsFields.map(({ label, fields, height, views }) => (
-                <GsAggregate title={label} height={height} fields={fields} lapisFilter={lapisFilter} views={views} />
+            view.organismConstants.additionalSequencingEffortsFields.map(({ label, fields, views }) => (
+                <GsAggregate title={label} fields={fields} lapisFilter={lapisFilter} views={views} pageSize={10} />
             ))
         }
     </ComponentsGrid>

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -11,6 +11,7 @@ import { toDownloadLink } from '../../components/views/compareSideBySide/toDownl
 import { getDashboardsConfig, getLapisUrl } from '../../config';
 import OrganismViewPageLayout from '../../layouts/OrganismPage/OrganismViewPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
+import { ComponentHeight } from '../../views/OrganismConstants';
 import { getLineageFilterFields, getVariantFilterConfig } from '../../views/View';
 import { toLapisFilterWithoutVariant } from '../../views/pageStateHandlers/PageStateHandler';
 import type { OrganismViewKey } from '../../views/routing';
@@ -95,33 +96,40 @@ const downloadLinks = [...pageState.filters.entries()].map(
                                 denominatorFilter={baselineLapisFilter}
                                 lapisDateField={view.organismConstants.mainDateField}
                                 granularity={timeGranularity}
+                                height={ComponentHeight.large}
+                                pageSize={10}
                             />
                             <GsRelativeGrowthAdvantage
                                 numeratorFilter={numeratorFilter}
                                 denominatorFilter={baselineLapisFilter}
                                 lapisDateField={view.organismConstants.mainDateField}
+                                height={ComponentHeight.large}
                             />
                             <GsMutations
                                 lapisFilter={numeratorFilter}
                                 baselineLapisFilter={baselineLapisFilter}
                                 sequenceType='nucleotide'
+                                pageSize={10}
                             />
                             <GsMutations
                                 lapisFilter={numeratorFilter}
                                 baselineLapisFilter={baselineLapisFilter}
                                 sequenceType='amino acid'
+                                pageSize={10}
                             />
                             <GsAggregate
                                 title='Sub-lineages'
                                 fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
                                 lapisFilter={numeratorFilter}
                                 views={[views.table, views.bar]}
+                                pageSize={10}
                             />
                             <GsAggregate
                                 title='Hosts'
                                 fields={[view.organismConstants.hostField]}
                                 lapisFilter={numeratorFilter}
                                 views={[views.table, views.bar]}
+                                pageSize={10}
                             />
                         </div>
                     );

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -115,6 +115,7 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
                 denominatorFilter={datasetLapisFilter}
                 lapisDateField={view.organismConstants.mainDateField}
                 granularity={timeGranularity}
+                pageSize={10}
             />
             <GsRelativeGrowthAdvantage
                 numeratorFilter={variantFilter}
@@ -125,17 +126,20 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
                 lapisFilter={variantFilter}
                 baselineLapisFilter={datasetLapisFilter}
                 sequenceType='nucleotide'
+                pageSize={10}
             />
             <GsMutations
                 lapisFilter={variantFilter}
                 baselineLapisFilter={datasetLapisFilter}
                 sequenceType='amino acid'
+                pageSize={10}
             />
             <GsAggregate
                 title='Sub-lineages'
                 fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
                 lapisFilter={variantFilter}
                 views={[views.table, views.bar]}
+                pageSize={10}
             />
             {
                 subdivisionField !== undefined && (
@@ -144,6 +148,7 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
                         fields={[subdivisionField]}
                         lapisFilter={variantFilter}
                         views={[views.table, views.bar]}
+                        pageSize={10}
                     />
                 )
             }
@@ -152,6 +157,7 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
                 fields={[view.organismConstants.hostField]}
                 lapisFilter={variantFilter}
                 views={[views.table, views.bar]}
+                pageSize={10}
             />
         </ComponentsGrid>
 

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -20,7 +20,7 @@ export const ComponentHeight = {
 export interface AdditionalSequencingEffortsField {
     readonly label: string;
     readonly fields: string[];
-    readonly height: (typeof ComponentHeight)[keyof typeof ComponentHeight];
+    readonly height?: (typeof ComponentHeight)[keyof typeof ComponentHeight];
     readonly views: AggregateView[];
 }
 
@@ -46,7 +46,6 @@ export function getAuthorRelatedSequencingEffortsFields(constants: {
                   {
                       label: 'Author affiliations',
                       fields: [constants.authorAffiliationsField],
-                      height: ComponentHeight.large,
                       views: [views.table],
                   },
               ];
@@ -57,7 +56,6 @@ export function getAuthorRelatedSequencingEffortsFields(constants: {
                   {
                       label: 'Authors',
                       fields: [constants.authorsField, constants.authorAffiliationsField],
-                      height: ComponentHeight.large,
                       views: [views.table],
                   },
               ];
@@ -71,44 +69,37 @@ export function getPathoplexusAdditionalSequencingEffortsFields(
         {
             label: 'Pathoplexus submitting groups',
             fields: [pathoplexusGroupNameField],
-            height: ComponentHeight.small,
             views: [views.table],
         },
         ...getAuthorRelatedSequencingEffortsFields(constants),
         {
             label: 'Collection device',
             fields: ['collectionDevice'],
-            height: ComponentHeight.small,
             views: [views.table, views.bar],
         },
         {
             label: 'Collection method',
             fields: ['collectionMethod'],
-            height: ComponentHeight.small,
             views: [views.table, views.bar],
         },
         {
             label: 'Purpose of sampling',
             fields: ['purposeOfSampling'],
-            height: ComponentHeight.small,
             views: [views.table, views.bar],
         },
         {
             label: 'Sample type',
             fields: ['sampleType'],
-            height: ComponentHeight.small,
             views: [views.table, views.bar],
         },
         {
             label: 'Amplicon PCR primer scheme',
             fields: ['ampliconPcrPrimerScheme'],
-            height: ComponentHeight.small,
             views: [views.table, views.bar],
         },
         {
             label: 'Sequencing protocol',
             fields: ['sequencingProtocol'],
-            height: ComponentHeight.small,
             views: [views.table, views.bar],
         },
     ];

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -13,7 +13,7 @@ import {
     GenericCompareVariantsView,
     GenericSequencingEffortsView,
 } from './BaseView.ts';
-import { ComponentHeight, type ExtendedConstants } from './OrganismConstants.ts';
+import { type ExtendedConstants } from './OrganismConstants.ts';
 import { type CompareSideBySideData, type DatasetAndVariantData, getLineageFilterFields, type Id } from './View.ts';
 import { compareSideBySideViewConstants, singleVariantViewConstants } from './ViewConstants.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
@@ -82,7 +82,6 @@ class CovidConstants implements ExtendedConstants {
                       {
                           label: 'Originating lab',
                           fields: [this.originatingLabField],
-                          height: ComponentHeight.large,
                           views: [views.table],
                       },
                   ];
@@ -93,7 +92,6 @@ class CovidConstants implements ExtendedConstants {
                       {
                           label: 'Submitting lab ',
                           fields: [this.submittingLabField],
-                          height: ComponentHeight.large,
                           views: [views.table],
                       },
                   ];


### PR DESCRIPTION
Resolves #567
Resolves #566

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary

Uses the new auto height feature for tables and mutations over time component. 

As discussed: We have still some whitespace below the tables, when there are too few entries (see also screenshot). We could try to use two columns instead of the grid. However, this would undermine the horizontal aligments of the tables. Therefore we keep it like this.

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

![grafik](https://github.com/user-attachments/assets/a2763a8d-2682-469b-bb44-5548c248899c)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
