### PR TITLE
refactor(website): merge ExtendedConstants into OrganismConstants

### DIFF
--- a/website/src/views/BaseView.ts
+++ b/website/src/views/BaseView.ts
@@ -1,4 +1,4 @@
-import type { OrganismConstants, ExtendedConstants } from './OrganismConstants.ts';
+import type { OrganismConstants } from './OrganismConstants.ts';
 import type { CompareToBaselineData, CompareVariantsData, DatasetAndVariantData, View } from './View.ts';
 import {
     compareToBaselineViewConstants,
@@ -40,7 +40,7 @@ export abstract class BaseView<
     }
 }
 
-export class GenericSingleVariantView<Constants extends ExtendedConstants> extends BaseView<
+export class GenericSingleVariantView<Constants extends OrganismConstants> extends BaseView<
     DatasetAndVariantData,
     Constants,
     SingleVariantPageStateHandler
@@ -68,7 +68,7 @@ export class GenericSingleVariantView<Constants extends ExtendedConstants> exten
     }
 }
 
-export class GenericSequencingEffortsView<Constants extends ExtendedConstants> extends BaseView<
+export class GenericSequencingEffortsView<Constants extends OrganismConstants> extends BaseView<
     DatasetAndVariantData,
     Constants,
     SequencingEffortsStateHandler
@@ -96,7 +96,7 @@ export class GenericSequencingEffortsView<Constants extends ExtendedConstants> e
     }
 }
 
-export class GenericCompareVariantsView<Constants extends ExtendedConstants> extends BaseView<
+export class GenericCompareVariantsView<Constants extends OrganismConstants> extends BaseView<
     CompareVariantsData,
     Constants,
     CompareVariantsPageStateHandler
@@ -121,7 +121,7 @@ export class GenericCompareVariantsView<Constants extends ExtendedConstants> ext
     }
 }
 
-export class GenericCompareToBaselineView<Constants extends ExtendedConstants> extends BaseView<
+export class GenericCompareToBaselineView<Constants extends OrganismConstants> extends BaseView<
     CompareToBaselineData,
     Constants,
     CompareToBaselineStateHandler

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -10,6 +10,14 @@ export interface OrganismConstants {
     readonly organism: Organism;
     readonly dataOrigins: DataOrigin[];
     readonly accessionDownloadFields: string[];
+    readonly mainDateField: string;
+    readonly additionalFilters: Record<string, string> | undefined;
+    readonly additionalSequencingEffortsFields: AdditionalSequencingEffortsField[];
+    readonly useAdvancedQuery: boolean;
+    readonly locationFields: string[];
+    readonly baselineFilterConfigs: BaselineFilterConfig[];
+    readonly lineageFilters: LineageFilterConfig[];
+    readonly predefinedVariants?: VariantFilter[];
 }
 
 export const ComponentHeight = {
@@ -22,17 +30,6 @@ export interface AdditionalSequencingEffortsField {
     readonly fields: string[];
     readonly height?: (typeof ComponentHeight)[keyof typeof ComponentHeight];
     readonly views: AggregateView[];
-}
-
-export interface ExtendedConstants extends OrganismConstants {
-    readonly mainDateField: string;
-    readonly additionalFilters: Record<string, string> | undefined;
-    readonly additionalSequencingEffortsFields: AdditionalSequencingEffortsField[];
-    readonly useAdvancedQuery: boolean;
-    readonly locationFields: string[];
-    readonly baselineFilterConfigs: BaselineFilterConfig[];
-    readonly lineageFilters: LineageFilterConfig[];
-    readonly predefinedVariants?: VariantFilter[];
 }
 
 export function getAuthorRelatedSequencingEffortsFields(constants: {

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type ExtendedConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -19,7 +19,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 
 const earliestDate = '1956-01-01';
 
-class CchfConstants implements ExtendedConstants {
+class CchfConstants implements OrganismConstants {
     public readonly organism = Organisms.cchf;
     public readonly earliestDate = earliestDate;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -13,7 +13,7 @@ import {
     GenericCompareVariantsView,
     GenericSequencingEffortsView,
 } from './BaseView.ts';
-import { type ExtendedConstants } from './OrganismConstants.ts';
+import { type OrganismConstants } from './OrganismConstants.ts';
 import { type CompareSideBySideData, type DatasetAndVariantData, getLineageFilterFields, type Id } from './View.ts';
 import { compareSideBySideViewConstants, singleVariantViewConstants } from './ViewConstants.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
@@ -31,7 +31,7 @@ import { formatUrl } from '../util/formatUrl.ts';
 
 const earliestDate = '2020-01-06';
 
-class CovidConstants implements ExtendedConstants {
+class CovidConstants implements OrganismConstants {
     public readonly organism = Organisms.covid;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type ExtendedConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -19,7 +19,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 
 const earliestDate = '1975-01-01';
 
-class EbolaSudanConstants implements ExtendedConstants {
+class EbolaSudanConstants implements OrganismConstants {
     public readonly organism = Organisms.ebolaSudan;
     public readonly earliestDate = '1975-01-01';
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type ExtendedConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -19,7 +19,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 
 const earliestDate = '1975-01-01';
 
-class EbolaZaireConstants implements ExtendedConstants {
+class EbolaZaireConstants implements OrganismConstants {
     public readonly organism = Organisms.ebolaZaire;
     public readonly earliestDate = earliestDate;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [

--- a/website/src/views/flu.ts
+++ b/website/src/views/flu.ts
@@ -3,7 +3,7 @@ import { dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';
 import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
-import { type ExtendedConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -13,7 +13,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 
 const earliestDate = '1905-01-01';
 
-class FluConstants implements ExtendedConstants {
+class FluConstants implements OrganismConstants {
     public readonly organism = Organisms.flu;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type ExtendedConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -19,7 +19,7 @@ import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBy
 
 const earliestDate = '1905-01-01';
 
-class H5n1Constants implements ExtendedConstants {
+class H5n1Constants implements OrganismConstants {
     public readonly organism = Organisms.h5n1;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type ExtendedConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -19,7 +19,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 
 const earliestDate = '1960-01-01';
 
-class MpoxConstants implements ExtendedConstants {
+class MpoxConstants implements OrganismConstants {
     public readonly organism = Organisms.mpox;
     public readonly mainDateField: string;
     public readonly earliestDate = earliestDate;

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { Organisms } from '../../types/Organism.ts';
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import type { CompareSideBySideData, DatasetAndVariantData } from '../View.ts';
 import { CompareSideBySideStateHandler } from './CompareSideBySidePageStateHandler.ts';
 
 const mockDateRangeOption = { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' };
 
-const mockConstants: ExtendedConstants = {
+const mockConstants: OrganismConstants = {
     organism: Organisms.covid,
     dataOrigins: [],
     locationFields: ['country', 'region'],

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareSideBySideData, type DatasetAndVariantData, getLineageFilterFields, type Id } from '../View.ts';
 import { compareSideBySideViewConstants } from '../ViewConstants.ts';
 import {
@@ -25,7 +25,7 @@ export class CompareSideBySideStateHandler implements PageStateHandler<CompareSi
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: ExtendedConstants,
+        protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: CompareSideBySideData,
         pathFragment: string,
     ) {

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { Organisms } from '../../types/Organism.ts';
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import type { CompareToBaselineData } from '../View.ts';
 import { CompareToBaselineStateHandler } from './CompareToBaselinePageStateHandler.ts';
 
 const mockDateRangeOption = { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' };
 
-const mockConstants: ExtendedConstants = {
+const mockConstants: OrganismConstants = {
     organism: Organisms.covid,
     dataOrigins: [],
     locationFields: ['country', 'region'],

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter, NamedLapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import {
     type CompareToBaselineData,
     type DatasetFilter,
@@ -35,7 +35,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: ExtendedConstants,
+        protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: CompareToBaselineData,
         pathFragment: string,
     ) {

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { Organisms } from '../../types/Organism.ts';
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import type { CompareVariantsData } from '../View.ts';
 import { CompareVariantsPageStateHandler } from './CompareVariantsPageStateHandler.ts';
 
 const mockDateRangeOption = { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' };
 
-const mockConstants: ExtendedConstants = {
+const mockConstants: OrganismConstants = {
     organism: Organisms.covid,
     dataOrigins: [],
     locationFields: ['country', 'region'],

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter, NamedLapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import {
     type CompareVariantsData,
     type DatasetFilter,
@@ -35,7 +35,7 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: ExtendedConstants,
+        protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: CompareVariantsData,
         pathFragment: string,
     ) {

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -1,4 +1,4 @@
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { sequencingEffortsViewConstants } from '../ViewConstants.ts';
 import {
@@ -24,7 +24,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: ExtendedConstants,
+        protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: PageState,
         pathFragment: string,
     ) {

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { Organisms } from '../../types/Organism.ts';
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import type { DatasetAndVariantData } from '../View.ts';
 import { SingleVariantPageStateHandler } from './SingleVariantPageStateHandler.ts';
 
 const mockDateRangeOption = { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' };
 
-const mockConstants: ExtendedConstants = {
+const mockConstants: OrganismConstants = {
     organism: Organisms.covid,
     dataOrigins: [],
     locationFields: ['country', 'region'],

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -1,6 +1,6 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { ExtendedConstants } from '../OrganismConstants.ts';
+import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { singleVariantViewConstants } from '../ViewConstants.ts';
 import {
@@ -27,7 +27,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
     protected readonly pathname;
 
     constructor(
-        protected readonly constants: ExtendedConstants,
+        protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: PageState,
         pathFragment: string,
     ) {

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type ExtendedConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -19,7 +19,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 
 const earliestDate = '1956-01-01';
 
-class RsvAConstants implements ExtendedConstants {
+class RsvAConstants implements OrganismConstants {
     public readonly organism = Organisms.rsvA;
     public readonly mainDateField: string;
     public readonly earliestDate = earliestDate;

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type ExtendedConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -19,7 +19,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 
 const earliestDate = '1956-01-01';
 
-class RsvBConstants implements ExtendedConstants {
+class RsvBConstants implements OrganismConstants {
     public readonly organism = Organisms.rsvB;
     public readonly mainDateField: string;
     public readonly earliestDate = earliestDate;

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -9,7 +9,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type ExtendedConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -19,7 +19,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 
 const earliestDate = '1930-01-01';
 
-class WestNileConstants implements ExtendedConstants {
+class WestNileConstants implements OrganismConstants {
     public readonly organism = Organisms.westNile;
     public readonly mainDateField: string;
     public readonly earliestDate = earliestDate;


### PR DESCRIPTION


### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The original idea was to only have a minimal set of value in OrganismConstants and extend when necessary. Reality showed that we never use a minimal set, but always the full set instead. The separation became irrelevant, so let's remove it.
### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
