### PR TITLE
feat(website): add 'Sub-lineages Neststrain Clade' for Sars-Cov-2

### DIFF
--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -127,8 +127,15 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
                 pageSize={10}
             />
             <GsAggregate
-                title='Sub-lineages'
+                title='Nextclade pango lineage'
                 fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
+                lapisFilter={variantFilter}
+                views={[views.table, views.bar]}
+                pageSize={10}
+            />
+            <GsAggregate
+                title='Nextstrain Clade'
+                fields={getLineageFilterFields(view.organismConstants.nextstrainCladeLineageFilters)}
                 lapisFilter={variantFilter}
                 views={[views.table, views.bar]}
                 pageSize={10}

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -45,6 +45,15 @@ class CovidConstants implements OrganismConstants {
             initialValue: undefined,
         },
     ];
+    // Same as `lineageFilters` but for Nextstrain Clade, used for 'Sub-lineages Nextstrain Clade'
+    public readonly nextstrainCladeLineageFilters: LineageFilterConfig[] = [
+        {
+            lapisField: 'nextstrainClade',
+            placeholderText: 'Nextstrain clade',
+            filterType: 'lineage' as const,
+            initialValue: undefined,
+        },
+    ];
     public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         {


### PR DESCRIPTION
The reason to implement it using a separate component instantiation rather than adding another `LineageFilterConfig` to `CovidConstants.lineageFilters` (which adds another column to the existing output) is that the ~corresponding Nextstrain Clade for a Nextclade pango lineage is not actually associated with the same data, thus it would be wrong. Also, the bar chart currently only shows the first column, thus would not show the Nextstrain Clade names.

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #559

