### PR TITLE
refactor(website): move values from the config to the organism constants

### DIFF
--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
@@ -19,11 +19,6 @@ data class OrganismConfig(
 data class LapisConfig(
     val url: String,
     val mainDateField: String,
-    val locationFields: List<String>,
-    val authorsField: String?,
-    val authorAffiliationsField: String?,
-    val originatingLabField: String?,
-    val submittingLabField: String?,
     val additionalFilters: Map<String, String>?,
 )
 

--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -4,14 +4,6 @@ dashboards:
       lapis:
         url: "https://lapis.cov-spectrum.org/open/v2"
         mainDateField: "date"
-        locationFields:
-          - "region"
-          - "country"
-          - "division"
-        originatingLabField: "originatingLab"
-        submittingLabField: "submittingLab"
-        accessionDownloadFields:
-          - "strain"
       externalNavigationLinks:
         - url: "https://cov-spectrum.org"
           label: "CoV-Spectrum"
@@ -20,23 +12,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/h5n1"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/h5n1"
           label: "Browse data"
@@ -45,23 +23,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/h1n1pdm"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/h1n1pdm"
           label: "Browse data"
@@ -70,23 +34,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/h3n2"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/h3n2"
           label: "Browse data"
@@ -95,23 +45,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/influenza-a"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/influenza-a"
           label: "Browse data"
@@ -120,23 +56,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/influenza-b"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/influenza-b"
           label: "Browse data"
@@ -145,23 +67,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/b-victoria"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/b-victoria"
           label: "Browse data"
@@ -170,20 +78,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/mpox"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/mpox"
           label: "Browse data"
@@ -192,20 +89,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/west-nile"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/west-nile"
           label: "Browse data"
@@ -214,16 +100,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/rsv-a"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/rsv-a"
           label: "Browse data"
@@ -232,16 +111,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/rsv-b"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.genspectrum.org/rsv-b"
           label: "Browse data"
@@ -250,20 +122,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/ebola-sudan"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/ebola-sudan"
           label: "Browse data"
@@ -272,20 +133,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/ebola-zaire"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/ebola-zaire"
           label: "Browse data"
@@ -294,20 +144,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/cchf"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/cchf"
           label: "Browse data"

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -4,14 +4,6 @@ dashboards:
       lapis:
         url: "https://lapis.cov-spectrum.org/open/v2"
         mainDateField: "date"
-        locationFields:
-          - "region"
-          - "country"
-          - "division"
-        originatingLabField: "originatingLab"
-        submittingLabField: "submittingLab"
-        accessionDownloadFields:
-          - "strain"
       externalNavigationLinks:
         - url: "https://cov-spectrum.org"
           label: "CoV-Spectrum"
@@ -20,23 +12,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h5n1"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/h5n1"
           label: "Browse data"
@@ -45,23 +23,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h1n1pdm"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/h1n1pdm"
           label: "Browse data"
@@ -70,23 +34,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h3n2"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/h3n2"
           label: "Browse data"
@@ -95,23 +45,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/influenza-a"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/influenza-a"
           label: "Browse data"
@@ -120,23 +56,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/influenza-b"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/influenza-b"
           label: "Browse data"
@@ -153,15 +75,6 @@ dashboards:
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull_seg1"
-          - "insdcAccessionFull_seg2"
-          - "insdcAccessionFull_seg3"
-          - "insdcAccessionFull_seg4"
-          - "insdcAccessionFull_seg5"
-          - "insdcAccessionFull_seg6"
-          - "insdcAccessionFull_seg7"
-          - "insdcAccessionFull_seg8"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/b-victoria"
           label: "Browse data"
@@ -170,20 +83,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/mpox"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/mpox"
           label: "Browse data"
@@ -192,20 +94,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/west-nile"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/west-nile"
           label: "Browse data"
@@ -214,16 +105,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/rsv-a"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/rsv-a"
           label: "Browse data"
@@ -232,16 +116,9 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/rsv-b"
         mainDateField: "sampleCollectionDate"
-        locationFields:
-          - "country"
-          - "division"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
       externalNavigationLinks:
         - url: "https://loculus.staging.genspectrum.org/rsv-b"
           label: "Browse data"
@@ -250,20 +127,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/ebola-sudan"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/ebola-sudan"
           label: "Browse data"
@@ -272,20 +138,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/ebola-zaire"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/ebola-zaire"
           label: "Browse data"
@@ -294,20 +149,9 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/cchf"
         mainDateField: "sampleCollectionDateRangeLower"
-        locationFields:
-          - "geoLocCountry"
-          - "geoLocAdmin1"
-        authorAffiliationsField: "authorAffiliations"
-        authorsField: "authors"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
-        accessionDownloadFields:
-          - "insdcAccessionFull"
-          - "accessionVersion"
-          - "dataUseTerms"
-          - "dataUseTermsUrl"
-          - "dataUseTermsRestrictedUntil"
       externalNavigationLinks:
         - url: "https://pathoplexus.org/cchf"
           label: "Browse data"

--- a/backend/src/test/resources/application.yaml
+++ b/backend/src/test/resources/application.yaml
@@ -11,72 +11,35 @@ dashboards:
       lapis:
         url: "https://covid.lapis.dummy"
         mainDateField: "covid_date"
-        locationFields:
-          - "covid_region"
-          - "covid_country"
-          - "covid_division"
-        lineageField: "covid_lineage"
-        originatingLabField: "covid_originating_lab"
-        submittingLabField: "covid_submitting_lab"
         additionalFilters:
           someAdditionalFilter: "covid_additional_filter"
     h5n1:
       lapis:
         url: "https://h5n1.lapis.dummy"
         mainDateField: "h5n1_date"
-        locationFields:
-          - "h5n1_geo_loc_country"
-          - "h5n1_geo_loc_admin_1"
-        lineageField: "h5n1_lineage"
-        authorAffiliationsField: "h5n1_author_affiliations"
-        authorsField: "h5n1_authors"
         additionalFilters:
           someAdditionalFilter: "h5n1_additional_filter"
     mpox:
       lapis:
         url: "https://mpox.lapis.dummy"
         mainDateField: "mpox_date"
-        locationFields:
-          - "mpox_geo_loc_country"
-          - "mpox_geo_loc_admin_1"
-        lineageField: "mpox_lineage"
-        authorAffiliationsField: "mpox_author_affiliations"
-        authorsField: "mpox_authors"
         additionalFilters:
           someAdditionalFilter: "mpox_additional_filter"
     westNile:
       lapis:
         url: "https://westNile.lapis.dummy"
         mainDateField: "westnile_date"
-        locationFields:
-          - "westNile_geo_loc_country"
-          - "westNile_geo_loc_admin_1"
-        lineageField: "westNile_lineage"
-        authorAffiliationsField: "westNile_author_affiliations"
-        authorsField: "westNile_authors"
         additionalFilters:
           someAdditionalFilter: "westnile_additional_filter"
     rsvA:
       lapis:
         url: "https://rsvA.lapis.dummy"
         mainDateField: "rsva_date"
-        locationFields:
-          - "rsvA_geo_loc_country"
-          - "rsvA_geo_loc_admin_1"
-        lineageField: "rsvA_lineage"
-        authorAffiliationsField: "rsvA_author_affiliations"
-        authorsField: "rsvA_authors"
         additionalFilters:
           someAdditionalFilter: "rsva_additional_filter"
     rsvB:
       lapis:
         url: "https://rsvB.lapis.dummy"
         mainDateField: "rsvb_date"
-        locationFields:
-          - "rsvB_geo_loc_country"
-          - "rsvB_geo_loc_admin_1"
-        lineageField: "rsvB_lineage"
-        authorAffiliationsField: "rsvB_author_affiliations"
-        authorsField: "rsvB_authors"
         additionalFilters:
           someAdditionalFilter: "rsvb_additional_filter"

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -10,13 +10,7 @@ import { allOrganisms, type Organism } from './types/Organism.ts';
 const lapisConfigSchema = z.object({
     url: z.string(),
     mainDateField: z.string(),
-    locationFields: z.array(z.string()),
-    authorsField: z.optional(z.string()),
-    authorAffiliationsField: z.optional(z.string()),
-    originatingLabField: z.optional(z.string()),
-    submittingLabField: z.optional(z.string()),
     additionalFilters: z.optional(z.record(z.string())),
-    accessionDownloadFields: z.array(z.string()),
 });
 
 const externalNavigationLinkSchema = z.object({

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -102,3 +102,28 @@ export function getPathoplexusAdditionalSequencingEffortsFields(
         },
     ];
 }
+
+export const PATHOPLEXUS_COMMON_DOWNLOAD_FIELDS = [
+    'accessionVersion',
+    'dataUseTerms',
+    'dataUseTermsUrl',
+    'dataUseTermsRestrictedUntil',
+];
+export const PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS = ['insdcAccessionFull', ...PATHOPLEXUS_COMMON_DOWNLOAD_FIELDS];
+
+export const LOCULUS_AUTHORS_FIELD = 'authors';
+export const LOCULUS_AUTHORS_AFFILIATIONS_FIELD = 'authorAffiliations';
+
+export const PATHOPLEXUS_LOCATION_FIELDS = ['geoLocCountry', 'geoLocAdmin1'];
+export const GENSPECTRUM_LOCULUS_LOCATION_FIELDS = ['country', 'division'];
+
+export const INFLUENZA_ACCESSION_DOWNLOAD_FIELDS = [
+    'insdcAccessionFull_seg1',
+    'insdcAccessionFull_seg2',
+    'insdcAccessionFull_seg3',
+    'insdcAccessionFull_seg4',
+    'insdcAccessionFull_seg5',
+    'insdcAccessionFull_seg6',
+    'insdcAccessionFull_seg7',
+    'insdcAccessionFull_seg8',
+];

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    getPathoplexusAdditionalSequencingEffortsFields,
+    type OrganismConstants,
+    LOCULUS_AUTHORS_FIELD,
+    PATHOPLEXUS_COMMON_DOWNLOAD_FIELDS,
+    PATHOPLEXUS_LOCATION_FIELDS,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -56,13 +63,18 @@ class CchfConstants implements OrganismConstants {
         },
     ];
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
     public readonly useAdvancedQuery = false;
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
-    public readonly accessionDownloadFields;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
+    public readonly accessionDownloadFields = [
+        'insdcAccessionFull_L',
+        'insdcAccessionFull_M',
+        'insdcAccessionFull_S',
+        ...PATHOPLEXUS_COMMON_DOWNLOAD_FIELDS,
+    ];
     public readonly predefinedVariants = [
         {
             mutations: {
@@ -91,11 +103,7 @@ class CchfConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.cchf.lapis.mainDateField;
-        this.locationFields = organismsConfig.cchf.lapis.locationFields;
-        this.authorsField = organismsConfig.cchf.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.cchf.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.cchf.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.cchf.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -49,7 +49,7 @@ class CovidConstants implements OrganismConstants {
     public readonly organism = Organisms.covid;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = ['region', 'country', 'division'];
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: nextcladePangoLineage,
@@ -94,44 +94,31 @@ class CovidConstants implements OrganismConstants {
         },
     ];
     public readonly hostField: string = hostField;
-    public readonly originatingLabField: string | undefined;
-    public readonly submittingLabField: string | undefined;
+    public readonly originatingLabField = 'originatingLab';
+    public readonly submittingLabField = 'submittingLab';
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.nextstrain];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = ['strain'];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
     public get additionalSequencingEffortsFields() {
-        const originatingLab =
-            this.originatingLabField === undefined
-                ? []
-                : [
-                      {
-                          label: 'Originating lab',
-                          fields: [this.originatingLabField],
-                          views: [views.table],
-                      },
-                  ];
-        const submittingLab =
-            this.submittingLabField === undefined
-                ? []
-                : [
-                      {
-                          label: 'Submitting lab ',
-                          fields: [this.submittingLabField],
-                          views: [views.table],
-                      },
-                  ];
-        return [...originatingLab, ...submittingLab];
+        return [
+            {
+                label: 'Originating lab',
+                fields: [this.originatingLabField],
+                views: [views.table],
+            },
+            {
+                label: 'Submitting lab ',
+                fields: [this.submittingLabField],
+                views: [views.table],
+            },
+        ];
     }
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.covid.lapis.mainDateField;
-        this.locationFields = organismsConfig.covid.lapis.locationFields;
-        this.originatingLabField = organismsConfig.covid.lapis.originatingLabField;
-        this.submittingLabField = organismsConfig.covid.lapis.submittingLabField;
         this.additionalFilters = organismsConfig.covid.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.covid.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getPathoplexusAdditionalSequencingEffortsFields,
+    PATHOPLEXUS_LOCATION_FIELDS,
+    PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -56,13 +63,13 @@ class EbolaSudanConstants implements OrganismConstants {
         },
     ];
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
     public readonly useAdvancedQuery = false;
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
-    public readonly accessionDownloadFields;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
+    public readonly accessionDownloadFields = PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
             mutations: {
@@ -91,11 +98,7 @@ class EbolaSudanConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.ebolaSudan.lapis.mainDateField;
-        this.locationFields = organismsConfig.ebolaSudan.lapis.locationFields;
-        this.authorsField = organismsConfig.ebolaSudan.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.ebolaSudan.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.ebolaSudan.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.ebolaSudan.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getPathoplexusAdditionalSequencingEffortsFields,
+    PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS,
+    PATHOPLEXUS_LOCATION_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -56,13 +63,13 @@ class EbolaZaireConstants implements OrganismConstants {
         },
     ];
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
     public readonly useAdvancedQuery = false;
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
-    public readonly accessionDownloadFields;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
+    public readonly accessionDownloadFields = PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
             mutations: {
@@ -91,11 +98,7 @@ class EbolaZaireConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.ebolaZaire.lapis.mainDateField;
-        this.locationFields = organismsConfig.ebolaZaire.lapis.locationFields;
-        this.authorsField = organismsConfig.ebolaZaire.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.ebolaZaire.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.ebolaZaire.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.ebolaZaire.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getAuthorRelatedSequencingEffortsFields,
+    GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+    INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -32,7 +39,7 @@ class H1n1pdmConstants implements OrganismConstants {
     public readonly organism = Organisms.h1n1pdm;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'cladeHA',
@@ -74,11 +81,11 @@ class H1n1pdmConstants implements OrganismConstants {
         },
     ];
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
             lineages: { cladeHA: '6B.1A.5a.2a.1', cladeNA: 'C.5.3' },
@@ -95,11 +102,7 @@ class H1n1pdmConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.h1n1pdm.lapis.mainDateField;
-        this.locationFields = organismsConfig.h1n1pdm.lapis.locationFields;
-        this.authorsField = organismsConfig.h1n1pdm.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.h1n1pdm.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.h1n1pdm.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.h1n1pdm.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getAuthorRelatedSequencingEffortsFields,
+    GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+    INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -32,7 +39,7 @@ class H3n2Constants implements OrganismConstants {
     public readonly organism = Organisms.h3n2;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'cladeHA',
@@ -74,11 +81,11 @@ class H3n2Constants implements OrganismConstants {
         },
     ];
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
             lineages: { cladeHA: '3C.2a1b.2a.2a.3a.1' },
@@ -95,11 +102,7 @@ class H3n2Constants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.h3n2.lapis.mainDateField;
-        this.locationFields = organismsConfig.h3n2.lapis.locationFields;
-        this.authorsField = organismsConfig.h3n2.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.h3n2.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.h3n2.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.h3n2.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getAuthorRelatedSequencingEffortsFields,
+    GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+    INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -32,7 +39,7 @@ class H5n1Constants implements OrganismConstants {
     public readonly organism = Organisms.h5n1;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'clade',
@@ -69,11 +76,11 @@ class H5n1Constants implements OrganismConstants {
         },
     ];
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
             lineages: { clade: '2.3.4.4b' },
@@ -135,11 +142,7 @@ class H5n1Constants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.h5n1.lapis.mainDateField;
-        this.locationFields = organismsConfig.h5n1.lapis.locationFields;
-        this.authorsField = organismsConfig.h5n1.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.h5n1.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.h5n1.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.h5n1.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -9,7 +9,14 @@ import {
 } from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getAuthorRelatedSequencingEffortsFields,
+    GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+    INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -24,7 +31,7 @@ class InfluenzaAConstants implements OrganismConstants {
     public readonly organism = Organisms.influenzaA;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'subtypeHA',
@@ -66,11 +73,11 @@ class InfluenzaAConstants implements OrganismConstants {
     ];
     public readonly useAdvancedQuery = false;
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
     public get additionalSequencingEffortsFields() {
@@ -79,11 +86,7 @@ class InfluenzaAConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.influenzaA.lapis.mainDateField;
-        this.locationFields = organismsConfig.influenzaA.lapis.locationFields;
-        this.authorsField = organismsConfig.influenzaA.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.influenzaA.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.influenzaA.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.influenzaA.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -9,7 +9,14 @@ import {
 } from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getAuthorRelatedSequencingEffortsFields,
+    GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+    INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -24,7 +31,7 @@ class InfluenzaBConstants implements OrganismConstants {
     public readonly organism = Organisms.influenzaB;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'lineageHA',
@@ -61,11 +68,11 @@ class InfluenzaBConstants implements OrganismConstants {
     ];
     public readonly useAdvancedQuery = false;
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
     public get additionalSequencingEffortsFields() {
@@ -74,11 +81,7 @@ class InfluenzaBConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.influenzaB.lapis.mainDateField;
-        this.locationFields = organismsConfig.influenzaB.lapis.locationFields;
-        this.authorsField = organismsConfig.influenzaB.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.influenzaB.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.influenzaB.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.influenzaB.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getPathoplexusAdditionalSequencingEffortsFields,
+    PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS,
+    PATHOPLEXUS_LOCATION_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -32,7 +39,7 @@ class MpoxConstants implements OrganismConstants {
     public readonly organism = Organisms.mpox;
     public readonly mainDateField: string;
     public readonly earliestDate = earliestDate;
-    public readonly locationFields: string[];
+    public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'lineage',
@@ -78,9 +85,9 @@ class MpoxConstants implements OrganismConstants {
         },
     ];
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
-    public readonly accessionDownloadFields;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
+    public readonly accessionDownloadFields = PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
             lineages: { lineage: 'F.1' },
@@ -103,11 +110,7 @@ class MpoxConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.mpox.lapis.mainDateField;
-        this.locationFields = organismsConfig.mpox.lapis.locationFields;
-        this.authorsField = organismsConfig.mpox.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.mpox.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.mpox.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.mpox.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -17,7 +17,13 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getAuthorRelatedSequencingEffortsFields,
+    GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -32,7 +38,7 @@ class RsvAConstants implements OrganismConstants {
     public readonly organism = Organisms.rsvA;
     public readonly mainDateField: string;
     public readonly earliestDate = earliestDate;
-    public readonly locationFields: string[];
+    public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'lineage',
@@ -69,11 +75,11 @@ class RsvAConstants implements OrganismConstants {
         },
     ];
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = ['insdcAccessionFull'];
     public readonly predefinedVariants = [
         {
             lineages: { lineage: 'A.D.3' },
@@ -93,11 +99,7 @@ class RsvAConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.rsvA.lapis.mainDateField;
-        this.locationFields = organismsConfig.rsvA.lapis.locationFields;
-        this.authorsField = organismsConfig.rsvA.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.rsvA.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.rsvA.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.rsvA.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -17,7 +17,13 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getAuthorRelatedSequencingEffortsFields,
+    GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -32,7 +38,7 @@ class RsvBConstants implements OrganismConstants {
     public readonly organism = Organisms.rsvB;
     public readonly mainDateField: string;
     public readonly earliestDate = earliestDate;
-    public readonly locationFields: string[];
+    public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'lineage',
@@ -69,11 +75,11 @@ class RsvBConstants implements OrganismConstants {
         },
     ];
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = ['insdcAccessionFull'];
     public readonly predefinedVariants = [
         {
             lineages: { lineage: 'B.D.E.1' },
@@ -93,11 +99,7 @@ class RsvBConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.rsvB.lapis.mainDateField;
-        this.locationFields = organismsConfig.rsvB.lapis.locationFields;
-        this.authorsField = organismsConfig.rsvB.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.rsvB.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.rsvB.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.rsvB.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getAuthorRelatedSequencingEffortsFields,
+    GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+    INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -32,7 +39,7 @@ class VictoriaConstants implements OrganismConstants {
     public readonly organism = Organisms.victoria;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;
-    public readonly locationFields: string[];
+    public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'cladeHA',
@@ -74,11 +81,11 @@ class VictoriaConstants implements OrganismConstants {
         },
     ];
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
     public readonly additionalFilters: Record<string, string> | undefined;
     public readonly dataOrigins: DataOrigin[] = [dataOrigins.insdc];
-    public readonly accessionDownloadFields;
+    public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
             lineages: { cladeHA: 'V1A.3a.2' },
@@ -94,11 +101,7 @@ class VictoriaConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.victoria.lapis.mainDateField;
-        this.locationFields = organismsConfig.victoria.lapis.locationFields;
-        this.authorsField = organismsConfig.victoria.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.victoria.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.victoria.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.victoria.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -17,7 +17,14 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
+import {
+    type OrganismConstants,
+    getPathoplexusAdditionalSequencingEffortsFields,
+    PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS,
+    PATHOPLEXUS_LOCATION_FIELDS,
+    LOCULUS_AUTHORS_FIELD,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+} from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -32,7 +39,7 @@ class WestNileConstants implements OrganismConstants {
     public readonly organism = Organisms.westNile;
     public readonly mainDateField: string;
     public readonly earliestDate = earliestDate;
-    public readonly locationFields: string[];
+    public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: 'lineage',
@@ -69,9 +76,9 @@ class WestNileConstants implements OrganismConstants {
     ];
     public readonly useAdvancedQuery = false;
     public readonly hostField: string = hostField;
-    public readonly authorsField: string | undefined;
-    public readonly authorAffiliationsField: string | undefined;
-    public readonly accessionDownloadFields;
+    public readonly authorsField = LOCULUS_AUTHORS_FIELD;
+    public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;
+    public readonly accessionDownloadFields = PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
             lineages: { lineage: '1A' },
@@ -94,11 +101,7 @@ class WestNileConstants implements OrganismConstants {
 
     constructor(organismsConfig: OrganismsConfig) {
         this.mainDateField = organismsConfig.westNile.lapis.mainDateField;
-        this.locationFields = organismsConfig.westNile.lapis.locationFields;
-        this.authorsField = organismsConfig.westNile.lapis.authorsField;
-        this.authorAffiliationsField = organismsConfig.westNile.lapis.authorAffiliationsField;
         this.additionalFilters = organismsConfig.westNile.lapis.additionalFilters;
-        this.accessionDownloadFields = organismsConfig.westNile.lapis.accessionDownloadFields;
     }
 }
 

--- a/website/vitest.setup.ts
+++ b/website/vitest.setup.ts
@@ -165,374 +165,136 @@ export const testOrganismsConfig = {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'date',
-            locationFields: ['region', 'country', 'division'],
-            originatingLabField: 'originatingLab',
-            submittingLabField: 'submittingLab',
-            accessionDownloadFields: ['strain'],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://cov-spectrum.org',
-                label: 'CoV-Spectrum',
-                menuIcon: 'virus',
-            },
-        ],
     },
     influenzaA: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDate',
-            locationFields: ['country', 'division'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull_seg1',
-                'insdcAccessionFull_seg2',
-                'insdcAccessionFull_seg3',
-                'insdcAccessionFull_seg4',
-                'insdcAccessionFull_seg5',
-                'insdcAccessionFull_seg6',
-                'insdcAccessionFull_seg7',
-                'insdcAccessionFull_seg8',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://loculus.genspectrum.org/influenza-a',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     h3n2: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDate',
-            locationFields: ['country', 'division'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull_seg1',
-                'insdcAccessionFull_seg2',
-                'insdcAccessionFull_seg3',
-                'insdcAccessionFull_seg4',
-                'insdcAccessionFull_seg5',
-                'insdcAccessionFull_seg6',
-                'insdcAccessionFull_seg7',
-                'insdcAccessionFull_seg8',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://loculus.genspectrum.org/h3n2',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     h1n1pdm: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDate',
-            locationFields: ['country', 'division'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull_seg1',
-                'insdcAccessionFull_seg2',
-                'insdcAccessionFull_seg3',
-                'insdcAccessionFull_seg4',
-                'insdcAccessionFull_seg5',
-                'insdcAccessionFull_seg6',
-                'insdcAccessionFull_seg7',
-                'insdcAccessionFull_seg8',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://loculus.genspectrum.org/h1n1pdm',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     h5n1: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDate',
-            locationFields: ['country', 'division'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull_seg1',
-                'insdcAccessionFull_seg2',
-                'insdcAccessionFull_seg3',
-                'insdcAccessionFull_seg4',
-                'insdcAccessionFull_seg5',
-                'insdcAccessionFull_seg6',
-                'insdcAccessionFull_seg7',
-                'insdcAccessionFull_seg8',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://loculus.genspectrum.org/h5n1',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     influenzaB: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDate',
-            locationFields: ['country', 'division'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull_seg1',
-                'insdcAccessionFull_seg2',
-                'insdcAccessionFull_seg3',
-                'insdcAccessionFull_seg4',
-                'insdcAccessionFull_seg5',
-                'insdcAccessionFull_seg6',
-                'insdcAccessionFull_seg7',
-                'insdcAccessionFull_seg8',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://loculus.genspectrum.org/influenza-b',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     victoria: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDate',
-            locationFields: ['country', 'division'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull_seg1',
-                'insdcAccessionFull_seg2',
-                'insdcAccessionFull_seg3',
-                'insdcAccessionFull_seg4',
-                'insdcAccessionFull_seg5',
-                'insdcAccessionFull_seg6',
-                'insdcAccessionFull_seg7',
-                'insdcAccessionFull_seg8',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://loculus.genspectrum.org/b-victoria',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     westNile: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDateRangeLower',
-            locationFields: ['geoLocCountry', 'geoLocAdmin1'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull',
-                'accessionVersion',
-                'dataUseTerms',
-                'dataUseTermsUrl',
-                'dataUseTermsRestrictedUntil',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://pathoplexus.org/west-nile',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     rsvA: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDate',
-            locationFields: ['country', 'division'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: ['insdcAccessionFull'],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://loculus.genspectrum.org/rsv-a',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     rsvB: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDate',
-            locationFields: ['country', 'division'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: ['insdcAccessionFull'],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://loculus.genspectrum.org/rsv-b',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     mpox: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDateRangeLower',
-            locationFields: ['geoLocCountry', 'geoLocAdmin1'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull',
-                'accessionVersion',
-                'dataUseTerms',
-                'dataUseTermsUrl',
-                'dataUseTermsRestrictedUntil',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://pathoplexus.org/mpox',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     ebolaSudan: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDateRangeLower',
-            locationFields: ['geoLocCountry', 'geoLocAdmin1'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull',
-                'accessionVersion',
-                'dataUseTerms',
-                'dataUseTermsUrl',
-                'dataUseTermsRestrictedUntil',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://pathoplexus.org/ebola-sudan',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     ebolaZaire: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDateRangeLower',
-            locationFields: ['geoLocCountry', 'geoLocAdmin1'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull',
-                'accessionVersion',
-                'dataUseTerms',
-                'dataUseTermsUrl',
-                'dataUseTermsRestrictedUntil',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://pathoplexus.org/ebola-zaire',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
     cchf: {
         lapis: {
             url: DUMMY_LAPIS_URL,
             mainDateField: 'sampleCollectionDateRangeLower',
-            locationFields: ['geoLocCountry', 'geoLocAdmin1'],
-            authorsField: 'authors',
-            authorAffiliationsField: 'authorAffiliations',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
             },
-            accessionDownloadFields: [
-                'insdcAccessionFull',
-                'accessionVersion',
-                'dataUseTerms',
-                'dataUseTermsUrl',
-                'dataUseTermsRestrictedUntil',
-            ],
         },
-        externalNavigationLinks: [
-            {
-                url: 'https://pathoplexus.org/cchf',
-                label: 'Browse data',
-                menuIcon: 'database',
-            },
-        ],
     },
 } satisfies OrganismsConfig;


### PR DESCRIPTION

resolves #593


### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
We only need values in the config that both website and backend need to access.
### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
