### PR TITLE
fix(website): correctly handle deleting the value of a date range filter

### DIFF
--- a/website/src/components/genspectrum/GsDateRangeFilter.tsx
+++ b/website/src/components/genspectrum/GsDateRangeFilter.tsx
@@ -13,8 +13,8 @@ export function GsDateRangeFilter({
     width,
 }: {
     lapisDateField: string;
-    onDateRangeChange?: (dateRange: DateRangeOption) => void;
-    value?: DateRangeOption;
+    onDateRangeChange?: (dateRange: DateRangeOption | null) => void;
+    value?: DateRangeOption | null;
     dateRangeOptions?: DateRangeOption[];
     earliestDate?: string;
     width?: string;
@@ -25,7 +25,9 @@ export function GsDateRangeFilter({
         const handleDateRangeOptionChange = (event: DateRangeOptionChangedEvent) => {
             const dateRange = event.detail;
 
-            if (typeof dateRange === 'string') {
+            if (dateRange === null) {
+                onDateRangeChange(null);
+            } else if (typeof dateRange === 'string') {
                 const dateRangeOption = dateRangeOptions?.find((option) => option.label === dateRange);
                 if (dateRangeOption !== undefined) {
                     onDateRangeChange(dateRangeOption);

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -12,7 +12,6 @@ export type LocationFilterConfig = {
 };
 
 export type DateRangeFilterConfig = {
-    defaultDateRange?: DateRangeOption;
     dateRangeOptions: DateRangeOption[];
     earliestDate: string;
     dateColumn: string;

--- a/website/src/util/chooseGranularityBasedOnDateRange.spec.ts
+++ b/website/src/util/chooseGranularityBasedOnDateRange.spec.ts
@@ -42,4 +42,12 @@ describe('chooseGranularityBasedOnDateRange', () => {
 
         expect(chooseGranularityBasedOnDateRange({ earliestDate: earliestDate, dateRange: dateRange })).toBe('year');
     });
+
+    it('should use year when date range is undefined', () => {
+        expect(chooseGranularityBasedOnDateRange({ earliestDate: earliestDate, dateRange: undefined })).toBe('year');
+    });
+
+    it('should use year when date range is null', () => {
+        expect(chooseGranularityBasedOnDateRange({ earliestDate: earliestDate, dateRange: null })).toBe('year');
+    });
 });

--- a/website/src/util/chooseGranularityBasedOnDateRange.ts
+++ b/website/src/util/chooseGranularityBasedOnDateRange.ts
@@ -5,9 +5,9 @@ export const chooseGranularityBasedOnDateRange = ({
     dateRange,
 }: {
     earliestDate: Date;
-    dateRange?: DateRangeOption;
+    dateRange?: DateRangeOption | null;
 }): 'day' | 'week' | 'month' | 'year' => {
-    if (dateRange === undefined) {
+    if (dateRange === undefined || dateRange === null) {
         return 'year';
     }
 

--- a/website/src/views/BaseView.ts
+++ b/website/src/views/BaseView.ts
@@ -48,22 +48,12 @@ export class GenericSingleVariantView<Constants extends OrganismConstants> exten
     Constants,
     SingleVariantPageStateHandler
 > {
-    constructor(constants: Constants) {
+    constructor(constants: Constants, defaultPageState: DatasetAndVariantData) {
         super(
             constants,
             new SingleVariantPageStateHandler(
                 constants,
-                {
-                    datasetFilter: {
-                        location: {},
-                        dateFilters: {},
-                        textFilters: {},
-                    },
-                    variantFilter: {
-                        mutations: {},
-                        lineages: {},
-                    },
-                },
+                defaultPageState,
                 organismConfig[constants.organism].pathFragment,
             ),
             singleVariantViewConstants,
@@ -76,22 +66,12 @@ export class GenericSequencingEffortsView<Constants extends OrganismConstants> e
     Constants,
     SequencingEffortsStateHandler
 > {
-    constructor(constants: Constants) {
+    constructor(constants: Constants, defaultPageState: DatasetAndVariantData) {
         super(
             constants,
             new SequencingEffortsStateHandler(
                 constants,
-                {
-                    datasetFilter: {
-                        location: {},
-                        dateFilters: {},
-                        textFilters: {},
-                    },
-                    variantFilter: {
-                        mutations: {},
-                        lineages: {},
-                    },
-                },
+                defaultPageState,
                 organismConfig[constants.organism].pathFragment,
             ),
             sequencingEffortsViewConstants,
@@ -104,19 +84,12 @@ export class GenericCompareVariantsView<Constants extends OrganismConstants> ext
     Constants,
     CompareVariantsPageStateHandler
 > {
-    constructor(constants: Constants) {
+    constructor(constants: Constants, defaultPageState: CompareVariantsData) {
         super(
             constants,
             new CompareVariantsPageStateHandler(
                 constants,
-                {
-                    datasetFilter: {
-                        location: {},
-                        dateFilters: {},
-                        textFilters: {},
-                    },
-                    variants: new Map(),
-                },
+                defaultPageState,
                 organismConfig[constants.organism].pathFragment,
             ),
             compareVariantsViewConstants,
@@ -129,23 +102,12 @@ export class GenericCompareToBaselineView<Constants extends OrganismConstants> e
     Constants,
     CompareToBaselineStateHandler
 > {
-    constructor(constants: Constants) {
+    constructor(constants: Constants, defaultPageState: CompareToBaselineData) {
         super(
             constants,
             new CompareToBaselineStateHandler(
                 constants,
-                {
-                    datasetFilter: {
-                        location: {},
-                        dateFilters: {},
-                        textFilters: {},
-                    },
-                    variants: new Map(),
-                    baselineFilter: {
-                        mutations: {},
-                        lineages: {},
-                    },
-                },
+                defaultPageState,
                 organismConfig[constants.organism].pathFragment,
             ),
             compareToBaselineViewConstants,

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -14,7 +14,7 @@ export type DatasetFilter = {
 };
 
 export type DateFilterState = {
-    [key: string]: DateRangeOption | undefined;
+    [key: string]: DateRangeOption | null | undefined;
 };
 
 export type TextFilterState = {
@@ -41,6 +41,13 @@ export type BaselineData = {
 
 export type DatasetAndVariantData = Dataset & VariantData;
 
+export function makeDatasetAndVariantData(datasetFilter: DatasetFilter): DatasetAndVariantData {
+    return {
+        datasetFilter,
+        variantFilter: {},
+    };
+}
+
 export type Id = number;
 
 export type CompareSideBySideData<ColumnData extends DatasetAndVariantData = DatasetAndVariantData> = {
@@ -51,10 +58,25 @@ export type CompareVariantsData = {
     variants: Map<Id, VariantFilter>;
 } & Dataset;
 
+export function makeCompareVariantsData(datasetFilter: DatasetFilter): CompareVariantsData {
+    return {
+        datasetFilter,
+        variants: new Map(),
+    };
+}
+
 export type CompareToBaselineData = {
     variants: Map<Id, VariantFilter>;
 } & Dataset &
     BaselineData;
+
+export function makeCompareToBaselineData(datasetFilter: DatasetFilter): CompareToBaselineData {
+    return {
+        datasetFilter,
+        baselineFilter: {},
+        variants: new Map(),
+    };
+}
 
 /**
  * PageState is the state of the organism pages. It:
@@ -83,3 +105,6 @@ export const pathoplexusGroupNameField = 'groupName';
 export function getLineageFilterFields(lineageFilters: LineageFilterConfig[]) {
     return lineageFilters.map((filter) => filter.lapisField);
 }
+
+export const PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN = 'sampleCollectionDateRangeLower';
+export const GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN = 'sampleCollectionDate';

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -54,6 +54,25 @@ export type CompareSideBySideData<ColumnData extends DatasetAndVariantData = Dat
     filters: Map<Id, ColumnData>;
 };
 
+export function makeCompareSideBySideData(
+    datasetFilter: DatasetFilter,
+    variantFilters: VariantFilter[],
+): CompareSideBySideData {
+    const filters = new Map(
+        variantFilters.map((variantFilter, index) => [
+            index,
+            {
+                datasetFilter,
+                variantFilter,
+            },
+        ]),
+    );
+
+    return {
+        filters,
+    };
+}
+
 export type CompareVariantsData = {
     variants: Map<Id, VariantFilter>;
 } & Dataset;

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -126,11 +126,7 @@ export class CchfCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},
@@ -140,11 +136,7 @@ export class CchfCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -1,14 +1,13 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
 import {
-    makeDatasetAndVariantData,
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
-    type Id,
-    PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
-    makeCompareVariantsData,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+    PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
 } from './View.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
@@ -18,7 +17,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -121,30 +120,7 @@ export class CchfCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new CchfConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [{}, {}]);
 
         super(
             constants,

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    makeDatasetAndVariantData,
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    type Id,
+    PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
+    makeCompareVariantsData,
+    makeCompareToBaselineData,
+} from './View.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -37,8 +46,7 @@ class CchfConstants implements OrganismConstants {
                 dateRangeOptionPresets.allTimes,
             ],
             earliestDate,
-            defaultDateRange: dateRangeOptionPresets.allTimes,
-            dateColumn: 'sampleCollectionDateRangeLower',
+            dateColumn: PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -92,9 +100,17 @@ class CchfConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,
+    },
+};
+
 export class CchfAnalyzeSingleVariantView extends GenericSingleVariantView<CchfConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new CchfConstants(organismsConfig));
+        super(new CchfConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -152,18 +168,18 @@ export class CchfCompareSideBySideView extends BaseView<
 
 export class CchfSequencingEffortsView extends GenericSequencingEffortsView<CchfConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new CchfConstants(organismsConfig));
+        super(new CchfConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class CchfCompareVariantsView extends GenericCompareVariantsView<CchfConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new CchfConstants(organismsConfig));
+        super(new CchfConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class CchfCompareToBaselineView extends GenericCompareToBaselineView<CchfConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new CchfConstants(organismsConfig));
+        super(new CchfConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -1,4 +1,4 @@
-import { dateRangeOptionPresets, views, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
+import { dateRangeOptionPresets, type MutationAnnotation, views } from '@genspectrum/dashboard-components/util';
 
 import {
     getIntegerFromSearch,
@@ -14,7 +14,16 @@ import {
     GenericSequencingEffortsView,
 } from './BaseView.ts';
 import { type OrganismConstants } from './OrganismConstants.ts';
-import { type CompareSideBySideData, type DatasetAndVariantData, getLineageFilterFields, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    getLineageFilterFields,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+} from './View.ts';
 import { compareSideBySideViewConstants, singleVariantViewConstants } from './ViewConstants.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import {
@@ -31,6 +40,8 @@ import { formatUrl } from '../util/formatUrl.ts';
 
 const earliestDate = '2020-01-06';
 const hostField = 'host';
+
+const mainDateFilterColumn = 'date';
 
 class CovidConstants implements OrganismConstants {
     public readonly organism = Organisms.covid;
@@ -70,8 +81,7 @@ class CovidConstants implements OrganismConstants {
                 { label: 'All times', dateFrom: this.earliestDate },
             ],
             earliestDate: earliestDate,
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'date',
+            dateColumn: mainDateFilterColumn,
             label: 'Date',
         },
         {
@@ -123,6 +133,14 @@ class CovidConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [mainDateFilterColumn]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export type CovidVariantData = DatasetAndVariantData & { collectionId?: number };
 
 export class CovidAnalyzeSingleVariantView extends BaseView<
@@ -136,17 +154,7 @@ export class CovidAnalyzeSingleVariantView extends BaseView<
             constants,
             new CovidSingleVariantStateHandler(
                 constants,
-                {
-                    datasetFilter: {
-                        location: {},
-                        dateFilters: {},
-                        textFilters: {},
-                    },
-                    variantFilter: {
-                        lineages: {},
-                        mutations: {},
-                    },
-                },
+                makeDatasetAndVariantData(defaultDatasetFilter),
                 organismConfig[constants.organism].pathFragment,
             ),
             singleVariantViewConstants,
@@ -206,11 +214,7 @@ export class CovidCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 nextcladePangoLineage: 'JN.1*',
@@ -223,11 +227,7 @@ export class CovidCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 nextcladePangoLineage: 'XBB.1*',
@@ -254,18 +254,18 @@ export class CovidCompareSideBySideView extends BaseView<
 
 export class CovidSequencingEffortsView extends GenericSequencingEffortsView<CovidConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new CovidConstants(organismsConfig));
+        super(new CovidConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class CovidCompareVariantsView extends GenericCompareVariantsView<CovidConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new CovidConstants(organismsConfig));
+        super(new CovidConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class CovidCompareToBaselineView extends GenericCompareToBaselineView<CovidConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new CovidConstants(organismsConfig));
+        super(new CovidConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -19,7 +19,7 @@ import {
     type DatasetAndVariantData,
     type DatasetFilter,
     getLineageFilterFields,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -43,6 +43,8 @@ const hostField = 'host';
 
 const mainDateFilterColumn = 'date';
 
+const nextcladePangoLineage = 'nextcladePangoLineage';
+
 class CovidConstants implements OrganismConstants {
     public readonly organism = Organisms.covid;
     public readonly earliestDate = earliestDate;
@@ -50,7 +52,7 @@ class CovidConstants implements OrganismConstants {
     public readonly locationFields: string[];
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'nextcladePangoLineage',
+            lapisField: nextcladePangoLineage,
             placeholderText: 'Nextclade pango lineage',
             filterType: 'lineage' as const,
         },
@@ -209,36 +211,18 @@ export class CovidCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new CovidConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                nextcladePangoLineage: 'JN.1*',
-                            },
-                            mutations: {},
-                            variantQuery: undefined,
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                nextcladePangoLineage: 'XBB.1*',
-                            },
-                            mutations: {},
-                            variantQuery: undefined,
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {
+                lineages: {
+                    [nextcladePangoLineage]: 'JN.1*',
+                },
+            },
+            {
+                lineages: {
+                    [nextcladePangoLineage]: 'XBB.1*',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+    PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
+} from './View.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -9,7 +18,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -37,8 +46,7 @@ class EbolaSudanConstants implements OrganismConstants {
                 dateRangeOptionPresets.allTimes,
             ],
             earliestDate,
-            defaultDateRange: dateRangeOptionPresets.allTimes,
-            dateColumn: 'sampleCollectionDateRangeLower',
+            dateColumn: PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -92,9 +100,17 @@ class EbolaSudanConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,
+    },
+};
+
 export class EbolaSudanAnalyzeSingleVariantView extends GenericSingleVariantView<EbolaSudanConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new EbolaSudanConstants(organismsConfig));
+        super(new EbolaSudanConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -110,11 +126,7 @@ export class EbolaSudanCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             mutations: {},
                         },
@@ -123,11 +135,7 @@ export class EbolaSudanCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             mutations: {},
                         },
@@ -150,18 +158,18 @@ export class EbolaSudanCompareSideBySideView extends BaseView<
 
 export class EbolaSudanSequencingEffortsView extends GenericSequencingEffortsView<EbolaSudanConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new EbolaSudanConstants(organismsConfig));
+        super(new EbolaSudanConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class EbolaSudanCompareVariantsView extends GenericCompareVariantsView<EbolaSudanConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new EbolaSudanConstants(organismsConfig));
+        super(new EbolaSudanConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class EbolaSudanCompareToBaselineView extends GenericCompareToBaselineView<EbolaSudanConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new EbolaSudanConstants(organismsConfig));
+        super(new EbolaSudanConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -2,9 +2,8 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -121,28 +120,7 @@ export class EbolaSudanCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new EbolaSudanConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [{}, {}]);
 
         super(
             constants,

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+    PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
+} from './View.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -37,8 +46,7 @@ class EbolaZaireConstants implements OrganismConstants {
                 dateRangeOptionPresets.allTimes,
             ],
             earliestDate,
-            defaultDateRange: dateRangeOptionPresets.allTimes,
-            dateColumn: 'sampleCollectionDateRangeLower',
+            dateColumn: PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -92,9 +100,17 @@ class EbolaZaireConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,
+    },
+};
+
 export class EbolaZaireAnalyzeSingleVariantView extends GenericSingleVariantView<EbolaZaireConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new EbolaZaireConstants(organismsConfig));
+        super(new EbolaZaireConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -110,11 +126,7 @@ export class EbolaZaireCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             mutations: {},
                         },
@@ -123,11 +135,7 @@ export class EbolaZaireCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             mutations: {},
                         },
@@ -150,18 +158,18 @@ export class EbolaZaireCompareSideBySideView extends BaseView<
 
 export class EbolaZaireSequencingEffortsView extends GenericSequencingEffortsView<EbolaZaireConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new EbolaZaireConstants(organismsConfig));
+        super(new EbolaZaireConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class EbolaZaireCompareVariantsView extends GenericCompareVariantsView<EbolaZaireConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new EbolaZaireConstants(organismsConfig));
+        super(new EbolaZaireConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class EbolaZaireCompareToBaselineView extends GenericCompareToBaselineView<EbolaZaireConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new EbolaZaireConstants(organismsConfig));
+        super(new EbolaZaireConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -2,9 +2,8 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -18,7 +17,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -121,28 +120,7 @@ export class EbolaZaireCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new EbolaZaireConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [{}, {}]);
 
         super(
             constants,

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+} from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -9,7 +18,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -55,8 +64,7 @@ class H1n1pdmConstants implements OrganismConstants {
                 { label: 'All times', dateFrom: this.earliestDate },
             ],
             earliestDate,
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDate',
+            dateColumn: GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -96,9 +104,17 @@ class H1n1pdmConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class H1n1pdmAnalyzeSingleVariantView extends GenericSingleVariantView<H1n1pdmConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H1n1pdmConstants(organismsConfig));
+        super(new H1n1pdmConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -114,11 +130,7 @@ export class H1n1pdmCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},
@@ -128,11 +140,7 @@ export class H1n1pdmCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 cladeHA: '6B.1A.5a.2a.1',
@@ -159,18 +167,18 @@ export class H1n1pdmCompareSideBySideView extends BaseView<
 
 export class H1n1pdmSequencingEffortsView extends GenericSequencingEffortsView<H1n1pdmConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H1n1pdmConstants(organismsConfig));
+        super(new H1n1pdmConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class H1n1pdmCompareVariantsView extends GenericCompareVariantsView<H1n1pdmConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H1n1pdmConstants(organismsConfig));
+        super(new H1n1pdmConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class H1n1pdmCompareToBaselineView extends GenericCompareToBaselineView<H1n1pdmConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H1n1pdmConstants(organismsConfig));
+        super(new H1n1pdmConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -2,10 +2,9 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
     GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -125,33 +124,15 @@ export class H1n1pdmCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new H1n1pdmConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                cladeHA: '6B.1A.5a.2a.1',
-                                cladeNA: 'C.5.3',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {},
+            {
+                lineages: {
+                    cladeHA: '6B.1A.5a.2a.1',
+                    cladeNA: 'C.5.3',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -2,13 +2,12 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
     GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
-    type Id,
 } from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import {
@@ -18,7 +17,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -125,32 +124,14 @@ export class H3n2CompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new H3n2Constants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                cladeHA: '3C.2a1b.2a.2a.3a.1',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {},
+            {
+                lineages: {
+                    cladeHA: '3C.2a1b.2a.2a.3a.1',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+    type Id,
+} from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -55,8 +64,7 @@ class H3n2Constants implements OrganismConstants {
                 { label: 'All times', dateFrom: this.earliestDate },
             ],
             earliestDate,
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDate',
+            dateColumn: GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -96,9 +104,17 @@ class H3n2Constants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class H3n2AnalyzeSingleVariantView extends GenericSingleVariantView<H3n2Constants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H3n2Constants(organismsConfig));
+        super(new H3n2Constants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -114,11 +130,7 @@ export class H3n2CompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},
@@ -128,11 +140,7 @@ export class H3n2CompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 cladeHA: '3C.2a1b.2a.2a.3a.1',
@@ -158,18 +166,18 @@ export class H3n2CompareSideBySideView extends BaseView<
 
 export class H3n2SequencingEffortsView extends GenericSequencingEffortsView<H3n2Constants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H3n2Constants(organismsConfig));
+        super(new H3n2Constants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class H3n2CompareVariantsView extends GenericCompareVariantsView<H3n2Constants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H3n2Constants(organismsConfig));
+        super(new H3n2Constants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class H3n2CompareToBaselineView extends GenericCompareToBaselineView<H3n2Constants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H3n2Constants(organismsConfig));
+        super(new H3n2Constants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -2,10 +2,9 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
     GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -165,32 +164,14 @@ export class H5n1CompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new H5n1Constants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                clade: '2.3.4.4b',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {},
+            {
+                lineages: {
+                    clade: '2.3.4.4b',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+} from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -9,7 +18,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -50,8 +59,7 @@ class H5n1Constants implements OrganismConstants {
                 { label: 'All times', dateFrom: this.earliestDate },
             ],
             earliestDate,
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDate',
+            dateColumn: GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -136,9 +144,17 @@ class H5n1Constants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class H5n1AnalyzeSingleVariantView extends GenericSingleVariantView<H5n1Constants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H5n1Constants(organismsConfig));
+        super(new H5n1Constants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -154,11 +170,7 @@ export class H5n1CompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},
@@ -168,11 +180,7 @@ export class H5n1CompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 clade: '2.3.4.4b',
@@ -198,18 +206,18 @@ export class H5n1CompareSideBySideView extends BaseView<
 
 export class H5n1SequencingEffortsView extends GenericSequencingEffortsView<H5n1Constants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H5n1Constants(organismsConfig));
+        super(new H5n1Constants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class H5n1CompareVariantsView extends GenericCompareVariantsView<H5n1Constants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H5n1Constants(organismsConfig));
+        super(new H5n1Constants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class H5n1CompareToBaselineView extends GenericCompareToBaselineView<H5n1Constants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new H5n1Constants(organismsConfig));
+        super(new H5n1Constants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -2,10 +2,9 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
     GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
-    type Id,
+    makeCompareSideBySideData,
     makeDatasetAndVariantData,
 } from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
@@ -103,33 +102,20 @@ export class InfluenzaACompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new InfluenzaAConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: { subtypeHA: 'H5', subtypeNA: 'N1' },
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                subtypeHA: 'H3',
-                                subtypeNA: 'N2',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {
+                lineages: {
+                    subtypeHA: 'H5',
+                    subtypeNA: 'N1',
+                },
+            },
+            {
+                lineages: {
+                    subtypeHA: 'H3',
+                    subtypeNA: 'N2',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -1,9 +1,16 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    type Id,
+    makeDatasetAndVariantData,
+} from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
-import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -48,8 +55,7 @@ class InfluenzaAConstants implements OrganismConstants {
                 { label: 'All times', dateFrom: this.earliestDate },
             ],
             earliestDate: earliestDate,
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDate',
+            dateColumn: GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -82,6 +88,14 @@ class InfluenzaAConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class InfluenzaACompareSideBySideView extends BaseView<
     CompareSideBySideData,
     InfluenzaAConstants,
@@ -94,11 +108,7 @@ export class InfluenzaACompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: { subtypeHA: 'H5', subtypeNA: 'N1' },
                             mutations: {},
@@ -108,11 +118,7 @@ export class InfluenzaACompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 subtypeHA: 'H3',
@@ -139,6 +145,6 @@ export class InfluenzaACompareSideBySideView extends BaseView<
 
 export class InfluenzaASequencingEffortsView extends GenericSequencingEffortsView<InfluenzaAConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new InfluenzaAConstants(organismsConfig));
+        super(new InfluenzaAConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -1,9 +1,16 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    type Id,
+    makeDatasetAndVariantData,
+} from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
-import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -43,8 +50,7 @@ class InfluenzaBConstants implements OrganismConstants {
                 { label: 'All times', dateFrom: this.earliestDate },
             ],
             earliestDate: earliestDate,
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDate',
+            dateColumn: GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -77,6 +83,14 @@ class InfluenzaBConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class InfluenzaBCompareSideBySideView extends BaseView<
     CompareSideBySideData,
     InfluenzaBConstants,
@@ -89,11 +103,7 @@ export class InfluenzaBCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: { lineageHA: 'vic' },
                             mutations: {},
@@ -103,11 +113,7 @@ export class InfluenzaBCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 lineageHA: 'yam',
@@ -133,6 +139,6 @@ export class InfluenzaBCompareSideBySideView extends BaseView<
 
 export class InfluenzaBSequencingEffortsView extends GenericSequencingEffortsView<InfluenzaBConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new InfluenzaBConstants(organismsConfig));
+        super(new InfluenzaBConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -2,10 +2,9 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
     GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
-    type Id,
+    makeCompareSideBySideData,
     makeDatasetAndVariantData,
 } from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
@@ -98,32 +97,18 @@ export class InfluenzaBCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new InfluenzaBConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: { lineageHA: 'vic' },
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                lineageHA: 'yam',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {
+                lineages: {
+                    lineageHA: 'vic',
+                },
+            },
+            {
+                lineages: {
+                    lineageHA: 'yam',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+    PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
+} from './View.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -9,7 +18,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -59,8 +68,7 @@ class MpoxConstants implements OrganismConstants {
                 dateRangeOptionPresets.allTimes,
             ],
             earliestDate: '1960-01-01',
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDateRangeLower',
+            dateColumn: PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -104,9 +112,17 @@ class MpoxConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class MpoxAnalyzeSingleVariantView extends GenericSingleVariantView<MpoxConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new MpoxConstants(organismsConfig));
+        super(new MpoxConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -122,11 +138,7 @@ export class MpoxCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 lineage: 'F.1',
@@ -138,11 +150,7 @@ export class MpoxCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 lineage: 'F.2',
@@ -168,18 +176,18 @@ export class MpoxCompareSideBySideView extends BaseView<
 
 export class MpoxSequencingEffortsView extends GenericSequencingEffortsView<MpoxConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new MpoxConstants(organismsConfig));
+        super(new MpoxConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class MpoxCompareVariantsView extends GenericCompareVariantsView<MpoxConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new MpoxConstants(organismsConfig));
+        super(new MpoxConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class MpoxCompareToBaselineView extends GenericCompareToBaselineView<MpoxConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new MpoxConstants(organismsConfig));
+        super(new MpoxConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -2,9 +2,8 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -133,34 +132,18 @@ export class MpoxCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new MpoxConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                lineage: 'F.1',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                lineage: 'F.2',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {
+                lineages: {
+                    lineage: 'F.1',
+                },
+            },
+            {
+                lineages: {
+                    lineage: 'F.2',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -34,7 +34,6 @@ const mockConstants: OrganismConstants = {
             type: 'date',
             dateRangeOptions: [mockDateRangeOption],
             earliestDate: '1999-01-01',
-            defaultDateRange: mockDateRangeOption,
             dateColumn: 'date',
         },
     ],
@@ -101,9 +100,7 @@ describe('CompareSideBySideStateHandler', () => {
         expect(pageState.filters.get(0)).toEqual({
             datasetFilter: {
                 location: {},
-                dateFilters: {
-                    date: mockDateRangeOption,
-                },
+                dateFilters: {},
                 textFilters: {},
             },
             variantFilter: {
@@ -130,9 +127,7 @@ describe('CompareSideBySideStateHandler', () => {
 
         expect(pageState.filters.get(2)).toEqual({
             datasetFilter: {
-                dateFilters: {
-                    date: mockDateRangeOption,
-                },
+                dateFilters: {},
                 location: {},
                 textFilters: {},
             },

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -182,6 +182,27 @@ describe('CompareSideBySideStateHandler', () => {
         );
     });
 
+    it('should ignore date filters that are null when converting page state to URL', () => {
+        const pageState: CompareSideBySideData = {
+            filters: new Map<number, DatasetAndVariantData>([
+                [
+                    1,
+                    {
+                        datasetFilter: {
+                            location: {},
+                            dateFilters: { date: null },
+                            textFilters: {},
+                        },
+                        variantFilter: {},
+                    },
+                ],
+            ]),
+        };
+
+        const url = handler.toUrl(pageState);
+        expect(url).toBe('/testPath/compare-side-by-side?columns=1&');
+    });
+
     it('should convert variant filter to Lapis filter', () => {
         const lapisFilter = handler.variantFilterToLapisFilter(
             {

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -34,7 +34,6 @@ const mockConstants: OrganismConstants = {
             type: 'date',
             dateRangeOptions: [mockDateRangeOption],
             earliestDate: '1999-01-01',
-            defaultDateRange: mockDateRangeOption,
             dateColumn: 'date',
         },
     ],

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -149,6 +149,22 @@ describe('CompareToBaselinePageStateHandler', () => {
         );
     });
 
+    it('should ignore date filters that are null when converting page state to URL', () => {
+        const pageState: CompareToBaselineData = {
+            variants: new Map(),
+            datasetFilter: {
+                location: {},
+                dateFilters: { date: null },
+                textFilters: {},
+            },
+            baselineFilter: {},
+        };
+
+        const url = handler.toUrl(pageState);
+
+        expect(url).toBe('/testPath/compare-to-baseline');
+    });
+
     it('should convert page state with deleted id to URL', () => {
         const pageState: CompareToBaselineData = {
             variants: new Map([

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -34,7 +34,6 @@ const mockConstants: OrganismConstants = {
             type: 'date',
             dateRangeOptions: [mockDateRangeOption],
             earliestDate: '1999-01-01',
-            defaultDateRange: mockDateRangeOption,
             dateColumn: 'date',
         },
     ],

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -164,6 +164,21 @@ describe('CompareVariantsPageStateHandler', () => {
         );
     });
 
+    it('should ignore date filters that are null when converting page state to URL', () => {
+        const pageState: CompareVariantsData = {
+            variants: new Map(),
+            datasetFilter: {
+                location: {},
+                dateFilters: { date: null },
+                textFilters: {},
+            },
+        };
+
+        const url = handler.toUrl(pageState);
+
+        expect(url).toBe('/testPath/compare-variants');
+    });
+
     it('should convert dataset filter to Lapis filter', () => {
         const lapisFilter = handler.datasetFilterToLapisFilter({
             ...mockDefaultPageState.datasetFilter,

--- a/website/src/views/pageStateHandlers/PageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.ts
@@ -24,7 +24,7 @@ export function toLapisFilterWithoutVariant(
 ): LapisFilter & LapisLocation {
     const dateFilters = Object.entries(pageState.datasetFilter.dateFilters).reduce(
         (acc, [lapisField, dateRange]) => {
-            if (dateRange === undefined) {
+            if (dateRange === undefined || dateRange === null) {
                 return acc;
             }
 
@@ -79,9 +79,7 @@ export function parseDateRangesFromUrl(
     return (
         dateRangeFilterConfigs?.reduce(
             (acc, config) => {
-                const dateRange =
-                    getDateRangeFromSearch(search, config.dateColumn, config.dateRangeOptions) ??
-                    config.defaultDateRange;
+                const dateRange = getDateRangeFromSearch(search, config.dateColumn, config.dateRangeOptions);
                 return {
                     ...acc,
                     [config.dateColumn]: dateRange,

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -34,7 +34,6 @@ const mockConstants: OrganismConstants = {
             type: 'date',
             dateRangeOptions: [mockDateRangeOption],
             earliestDate: '1999-01-01',
-            defaultDateRange: mockDateRangeOption,
             dateColumn: 'date',
         },
     ],
@@ -104,6 +103,19 @@ describe('SingleVariantPageStateHandler', () => {
                 '&nucleotideMutations=D614G&lineage=B.1.1.7' +
                 '&',
         );
+    });
+
+    it('should ignore date filters that are null when converting page state to URL', () => {
+        const pageState: DatasetAndVariantData = {
+            variantFilter: {},
+            datasetFilter: {
+                location: {},
+                dateFilters: { date: null },
+                textFilters: {},
+            },
+        };
+        const url = handler.toUrl(pageState);
+        expect(url).toBe('/testPath/single-variant');
     });
 
     it('should convert pageState to Lapis filter', () => {

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+} from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -9,7 +18,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -50,8 +59,7 @@ class RsvAConstants implements OrganismConstants {
                 { label: 'All times', dateFrom: earliestDate },
             ],
             earliestDate: '1956-01-01',
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDate',
+            dateColumn: GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -94,9 +102,17 @@ class RsvAConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class RsvAAnalyzeSingleVariantView extends GenericSingleVariantView<RsvAConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvAConstants(organismsConfig));
+        super(new RsvAConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -112,11 +128,7 @@ export class RsvACompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},
@@ -126,11 +138,7 @@ export class RsvACompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 lineage: 'A.D.5.2',
@@ -156,18 +164,18 @@ export class RsvACompareSideBySideView extends BaseView<
 
 export class RsvASequencingEffortsView extends GenericSequencingEffortsView<RsvAConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvAConstants(organismsConfig));
+        super(new RsvAConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class RsvACompareVariantsView extends GenericCompareVariantsView<RsvAConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvAConstants(organismsConfig));
+        super(new RsvAConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class RsvACompareToBaselineView extends GenericCompareToBaselineView<RsvAConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvAConstants(organismsConfig));
+        super(new RsvAConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -2,10 +2,9 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
     GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -123,32 +122,14 @@ export class RsvACompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new RsvAConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                lineage: 'A.D.5.2',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {},
+            {
+                lineages: {
+                    lineage: 'A.D.5.2',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -2,10 +2,9 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
     GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -18,7 +17,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -123,32 +122,14 @@ export class RsvBCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new RsvBConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                lineage: 'B.D.E.1',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {},
+            {
+                lineages: {
+                    lineage: 'B.D.E.1',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+} from './View.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -50,8 +59,7 @@ class RsvBConstants implements OrganismConstants {
                 { label: 'All times', dateFrom: earliestDate },
             ],
             earliestDate: '1956-01-01',
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDate',
+            dateColumn: GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -94,9 +102,17 @@ class RsvBConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class RsvBAnalyzeSingleVariantView extends GenericSingleVariantView<RsvBConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvBConstants(organismsConfig));
+        super(new RsvBConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -112,11 +128,7 @@ export class RsvBCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},
@@ -126,11 +138,7 @@ export class RsvBCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 lineage: 'B.D.E.1',
@@ -156,18 +164,18 @@ export class RsvBCompareSideBySideView extends BaseView<
 
 export class RsvBSequencingEffortsView extends GenericSequencingEffortsView<RsvBConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvBConstants(organismsConfig));
+        super(new RsvBConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class RsvBCompareVariantsView extends GenericCompareVariantsView<RsvBConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvBConstants(organismsConfig));
+        super(new RsvBConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class RsvBCompareToBaselineView extends GenericCompareToBaselineView<RsvBConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new RsvBConstants(organismsConfig));
+        super(new RsvBConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -2,10 +2,9 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
     GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -124,32 +123,14 @@ export class VictoriaCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new VictoriaConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                cladeHA: 'V1A.3a.2',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {},
+            {
+                lineages: {
+                    cladeHA: 'V1A.3a.2',
+                },
+            },
+        ]);
 
         super(
             constants,

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+} from './View.ts';
 import type { OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -9,7 +18,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getAuthorRelatedSequencingEffortsFields } from './OrganismConstants.ts';
+import { getAuthorRelatedSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -55,8 +64,7 @@ class VictoriaConstants implements OrganismConstants {
                 { label: 'All times', dateFrom: this.earliestDate },
             ],
             earliestDate,
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDate',
+            dateColumn: GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -95,9 +103,17 @@ class VictoriaConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class VictoriaAnalyzeSingleVariantView extends GenericSingleVariantView<VictoriaConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new VictoriaConstants(organismsConfig));
+        super(new VictoriaConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -113,11 +129,7 @@ export class VictoriaCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},
@@ -127,11 +139,7 @@ export class VictoriaCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 cladeHA: 'V1A.3a.2',
@@ -157,18 +165,18 @@ export class VictoriaCompareSideBySideView extends BaseView<
 
 export class VictoriaSequencingEffortsView extends GenericSequencingEffortsView<VictoriaConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new VictoriaConstants(organismsConfig));
+        super(new VictoriaConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class VictoriaCompareVariantsView extends GenericCompareVariantsView<VictoriaConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new VictoriaConstants(organismsConfig));
+        super(new VictoriaConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class VictoriaCompareToBaselineView extends GenericCompareToBaselineView<VictoriaConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new VictoriaConstants(organismsConfig));
+        super(new VictoriaConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -1,6 +1,15 @@
 import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
 
-import { type CompareSideBySideData, type DatasetAndVariantData, type Id } from './View.ts';
+import {
+    type CompareSideBySideData,
+    type DatasetAndVariantData,
+    type DatasetFilter,
+    type Id,
+    makeCompareToBaselineData,
+    makeCompareVariantsData,
+    makeDatasetAndVariantData,
+    PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
+} from './View.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -9,7 +18,7 @@ import {
     GenericSequencingEffortsView,
     GenericSingleVariantView,
 } from './BaseView.ts';
-import { type OrganismConstants, getPathoplexusAdditionalSequencingEffortsFields } from './OrganismConstants.ts';
+import { getPathoplexusAdditionalSequencingEffortsFields, type OrganismConstants } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
 import { organismConfig, Organisms } from '../types/Organism.ts';
@@ -49,8 +58,7 @@ class WestNileConstants implements OrganismConstants {
                 dateRangeOptionPresets.allTimes,
             ],
             earliestDate: '1999-01-01',
-            defaultDateRange: dateRangeOptionPresets.lastYear,
-            dateColumn: 'sampleCollectionDateRangeLower',
+            dateColumn: PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN,
             label: 'Sample collection date',
         },
         {
@@ -95,9 +103,17 @@ class WestNileConstants implements OrganismConstants {
     }
 }
 
+const defaultDatasetFilter: DatasetFilter = {
+    location: {},
+    textFilters: {},
+    dateFilters: {
+        [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
+    },
+};
+
 export class WestNileAnalyzeSingleVariantView extends GenericSingleVariantView<WestNileConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new WestNileConstants(organismsConfig));
+        super(new WestNileConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
@@ -113,11 +129,7 @@ export class WestNileCompareSideBySideView extends BaseView<
                 [
                     0,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {
                                 lineage: '2',
@@ -129,11 +141,7 @@ export class WestNileCompareSideBySideView extends BaseView<
                 [
                     1,
                     {
-                        datasetFilter: {
-                            location: {},
-                            dateFilters: {},
-                            textFilters: {},
-                        },
+                        datasetFilter: defaultDatasetFilter,
                         variantFilter: {
                             lineages: {},
                             mutations: {},
@@ -157,18 +165,18 @@ export class WestNileCompareSideBySideView extends BaseView<
 
 export class WestNileSequencingEffortsView extends GenericSequencingEffortsView<WestNileConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new WestNileConstants(organismsConfig));
+        super(new WestNileConstants(organismsConfig), makeDatasetAndVariantData(defaultDatasetFilter));
     }
 }
 
 export class WestNileCompareVariantsView extends GenericCompareVariantsView<WestNileConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new WestNileConstants(organismsConfig));
+        super(new WestNileConstants(organismsConfig), makeCompareVariantsData(defaultDatasetFilter));
     }
 }
 
 export class WestNileCompareToBaselineView extends GenericCompareToBaselineView<WestNileConstants> {
     constructor(organismsConfig: OrganismsConfig) {
-        super(new WestNileConstants(organismsConfig));
+        super(new WestNileConstants(organismsConfig), makeCompareToBaselineData(defaultDatasetFilter));
     }
 }

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -2,9 +2,8 @@ import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/da
 
 import {
     type CompareSideBySideData,
-    type DatasetAndVariantData,
     type DatasetFilter,
-    type Id,
+    makeCompareSideBySideData,
     makeCompareToBaselineData,
     makeCompareVariantsData,
     makeDatasetAndVariantData,
@@ -124,32 +123,14 @@ export class WestNileCompareSideBySideView extends BaseView<
 > {
     constructor(organismsConfig: OrganismsConfig) {
         const constants = new WestNileConstants(organismsConfig);
-        const defaultPageState = {
-            filters: new Map<Id, DatasetAndVariantData>([
-                [
-                    0,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {
-                                lineage: '2',
-                            },
-                            mutations: {},
-                        },
-                    },
-                ],
-                [
-                    1,
-                    {
-                        datasetFilter: defaultDatasetFilter,
-                        variantFilter: {
-                            lineages: {},
-                            mutations: {},
-                        },
-                    },
-                ],
-            ]),
-        };
+        const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
+            {
+                lineages: {
+                    lineage: '2',
+                },
+            },
+            {},
+        ]);
 
         super(
             constants,


### PR DESCRIPTION


resolves #617


### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
When the user clicks the "x" button to delete the current input of a date range filter, then it will send an event with `event.detail = null`. Correctly handle that and make sure that we don't store those in the URL.
### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
