### PR TITLE
bar chart as default for sub lineages for influenza a sequencing efforts

### DIFF
--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -8,7 +8,6 @@ import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/Singl
 import { Organisms } from '../../../types/Organism';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../../util/hasOnlyUndefinedValues';
-import { getLineageFilterFields } from '../../../views/View';
 import { getLocationSubdivision } from '../../../views/locationHelpers';
 import { toDisplayName } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
@@ -48,8 +47,6 @@ const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivis
 );
 
 const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
-
-const lineageFilterFields = getLineageFilterFields(view.organismConstants.lineageFilters);
 
 const displayName = toDisplayName(pageState.variantFilter);
 const downloadLinks = noVariantSelected
@@ -126,23 +123,16 @@ const downloadLinks = noVariantSelected
             }
 
             {
-                lineageFilterFields.length > 0 && (
+                view.organismConstants.aggregatedVisualizations.singleVariant.map(({ label, fields, views }) => (
                     <GsAggregate
-                        title='Sub-lineages'
-                        fields={lineageFilterFields}
+                        title={label}
+                        fields={fields}
                         lapisFilter={variantLapisFilter}
-                        views={[views.table, views.bar]}
+                        views={views}
                         pageSize={10}
                     />
-                )
+                ))
             }
-            <GsAggregate
-                title='Hosts'
-                fields={[view.organismConstants.hostField]}
-                lapisFilter={variantLapisFilter}
-                views={[views.table, views.bar]}
-                pageSize={10}
-            />
         </ComponentsGrid>
         <GsMutationsOverTime
             lapisFilter={variantLapisFilter}

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -1,12 +1,9 @@
 ---
-import { views } from '@genspectrum/dashboard-components/util';
-
 import { toDownloadLink } from './toDownloadLink';
 import { getDashboardsConfig, getLapisUrl } from '../../../config';
 import OrganismViewPageLayout from '../../../layouts/OrganismPage/OrganismViewPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { ComponentHeight } from '../../../views/OrganismConstants';
-import { getLineageFilterFields } from '../../../views/View';
 import { toLapisFilterWithoutVariant } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
@@ -49,8 +46,6 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                         datasetFilter,
                         variantFilter,
                     );
-
-                    const lineageFilterFields = getLineageFilterFields(view.organismConstants.lineageFilters);
 
                     return (
                         <div class='flex min-w-[500px] flex-1 flex-col gap-4 border-r-2 border-gray-200 px-2'>
@@ -113,22 +108,17 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                 </>
                             )}
 
-                            {lineageFilterFields.length > 0 && (
-                                <GsAggregate
-                                    title='Sub-lineages'
-                                    fields={lineageFilterFields}
-                                    lapisFilter={numeratorFilter}
-                                    views={[views.table, views.bar]}
-                                    pageSize={10}
-                                />
+                            {view.organismConstants.aggregatedVisualizations.compareSideBySide.map(
+                                ({ label, fields, views }) => (
+                                    <GsAggregate
+                                        title={label}
+                                        fields={fields}
+                                        lapisFilter={numeratorFilter}
+                                        views={views}
+                                        pageSize={10}
+                                    />
+                                ),
                             )}
-                            <GsAggregate
-                                title='Hosts'
-                                fields={[view.organismConstants.hostField]}
-                                lapisFilter={numeratorFilter}
-                                views={[views.table, views.bar]}
-                                pageSize={10}
-                            />
                         </div>
                     );
                 })

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -1,11 +1,8 @@
 ---
-import { views } from '@genspectrum/dashboard-components/util';
-
 import CountStatistics from './CountStatistics.astro';
 import { getDashboardsConfig, getLapisUrl } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
-import { getLineageFilterFields } from '../../../views/View';
 import { getLocationDisplayConfig } from '../../../views/locationHelpers';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
@@ -37,8 +34,6 @@ const { locationField, mapName } = getLocationDisplayConfig(
     view.organismConstants.locationFields,
     pageState.datasetFilter.location,
 );
-
-const lineageFilterFields = getLineageFilterFields(view.organismConstants.lineageFilters);
 ---
 
 <SingleVariantOrganismPageLayout
@@ -91,26 +86,8 @@ const lineageFilterFields = getLineageFilterFields(view.organismConstants.lineag
                     />
                 )
             }
-            <GsAggregate
-                title='Hosts'
-                fields={[view.organismConstants.hostField]}
-                lapisFilter={lapisFilter}
-                views={[views.table, views.bar]}
-                pageSize={10}
-            />
             {
-                lineageFilterFields.length > 0 && (
-                    <GsAggregate
-                        title='Sub-lineages'
-                        fields={lineageFilterFields}
-                        lapisFilter={lapisFilter}
-                        views={[views.table, views.bar]}
-                        pageSize={10}
-                    />
-                )
-            }
-            {
-                view.organismConstants.additionalSequencingEffortsFields.map(({ label, fields, views }) => (
+                view.organismConstants.sequencingEffortsAggregatedVisualizations.map(({ label, fields, views }) => (
                     <GsAggregate title={label} fields={fields} lapisFilter={lapisFilter} views={views} pageSize={10} />
                 ))
             }

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -87,7 +87,7 @@ const { locationField, mapName } = getLocationDisplayConfig(
                 )
             }
             {
-                view.organismConstants.sequencingEffortsAggregatedVisualizations.map(({ label, fields, views }) => (
+                view.organismConstants.aggregatedVisualizations.sequencingEfforts.map(({ label, fields, views }) => (
                     <GsAggregate title={label} fields={fields} lapisFilter={lapisFilter} views={views} pageSize={10} />
                 ))
             }

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -1,6 +1,4 @@
 ---
-import { views } from '@genspectrum/dashboard-components/util';
-
 import GsAggregate from '../../components/genspectrum/GsAggregate.astro';
 import GsMutations from '../../components/genspectrum/GsMutations.astro';
 import GsPrevalenceOverTime from '../../components/genspectrum/GsPrevalenceOverTime.astro';
@@ -12,7 +10,6 @@ import { getDashboardsConfig, getLapisUrl } from '../../config';
 import OrganismViewPageLayout from '../../layouts/OrganismPage/OrganismViewPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
 import { ComponentHeight } from '../../views/OrganismConstants';
-import { getLineageFilterFields } from '../../views/View';
 import { toLapisFilterWithoutVariant } from '../../views/pageStateHandlers/PageStateHandler';
 import type { OrganismViewKey } from '../../views/routing';
 import { ServerSide } from '../../views/serverSideRouting';
@@ -109,20 +106,17 @@ const downloadLinks = [...pageState.filters.entries()].map(
                                 sequenceType='amino acid'
                                 pageSize={10}
                             />
-                            <GsAggregate
-                                title='Sub-lineages'
-                                fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
-                                lapisFilter={numeratorFilter}
-                                views={[views.table, views.bar]}
-                                pageSize={10}
-                            />
-                            <GsAggregate
-                                title='Hosts'
-                                fields={[view.organismConstants.hostField]}
-                                lapisFilter={numeratorFilter}
-                                views={[views.table, views.bar]}
-                                pageSize={10}
-                            />
+                            {view.organismConstants.aggregatedVisualizations.compareSideBySide.map(
+                                ({ label, fields, views }) => (
+                                    <GsAggregate
+                                        title={label}
+                                        fields={fields}
+                                        lapisFilter={numeratorFilter}
+                                        views={views}
+                                        pageSize={10}
+                                    />
+                                ),
+                            )}
                         </div>
                     );
                 })

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -18,7 +18,6 @@ import { getDashboardsConfig } from '../../config';
 import SingleVariantOrganismPageLayout from '../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../util/hasOnlyUndefinedValues';
-import { getLineageFilterFields } from '../../views/View';
 import { getLocationSubdivision } from '../../views/locationHelpers';
 import { toDisplayName } from '../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey } from '../../views/routing';
@@ -126,20 +125,6 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
                 sequenceType='amino acid'
                 pageSize={10}
             />
-            <GsAggregate
-                title='Nextclade pango lineage'
-                fields={getLineageFilterFields(view.organismConstants.lineageFilters)}
-                lapisFilter={variantFilter}
-                views={[views.table, views.bar]}
-                pageSize={10}
-            />
-            <GsAggregate
-                title='Nextstrain Clade'
-                fields={getLineageFilterFields(view.organismConstants.nextstrainCladeLineageFilters)}
-                lapisFilter={variantFilter}
-                views={[views.table, views.bar]}
-                pageSize={10}
-            />
             {
                 subdivisionField !== undefined && (
                     <GsAggregate
@@ -151,13 +136,18 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
                     />
                 )
             }
-            <GsAggregate
-                title='Hosts'
-                fields={[view.organismConstants.hostField]}
-                lapisFilter={variantFilter}
-                views={[views.table, views.bar]}
-                pageSize={10}
-            />
+
+            {
+                view.organismConstants.aggregatedVisualizations.singleVariant.map(({ label, fields, views }) => (
+                    <GsAggregate
+                        title={label}
+                        fields={fields}
+                        lapisFilter={variantFilter}
+                        views={views}
+                        pageSize={10}
+                    />
+                ))
+            }
         </ComponentsGrid>
 
         <GsMutationsOverTime

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -16,13 +16,19 @@ import type { LineageFilterConfig } from '../components/pageStateSelectors/Linea
 import type { Organism } from '../types/Organism.ts';
 import type { DataOrigin } from '../types/dataOrigins.ts';
 
+type AggregatedVisualizations = {
+    sequencingEfforts: GsAggregatedConfig[];
+    singleVariant: GsAggregatedConfig[];
+    compareSideBySide: GsAggregatedConfig[];
+};
+
 export interface OrganismConstants {
     readonly organism: Organism;
     readonly dataOrigins: DataOrigin[];
     readonly accessionDownloadFields: string[];
     readonly mainDateField: string;
     readonly additionalFilters: Record<string, string> | undefined;
-    readonly sequencingEffortsAggregatedVisualizations: GsAggregatedConfig[];
+    readonly aggregatedVisualizations: AggregatedVisualizations;
     readonly useAdvancedQuery: boolean;
     readonly locationFields: string[];
     readonly baselineFilterConfigs: BaselineFilterConfig[];
@@ -81,18 +87,21 @@ export function getAuthorRelatedAggregatedVisualizations(constants: {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we need to use the type restriction that Parameters also uses
 type FirstParameter<T extends (...args: any) => any> = Parameters<T>[0];
 
-export function getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(
+export function getGenSpectrumLoculusAggregatedVisualizations(
     constants: FirstParameter<typeof getAuthorRelatedAggregatedVisualizations> &
         FirstParameter<typeof getHostsAggregatedVisualization>,
     options: {
         sublineages?: FirstParameter<typeof getLineagesAggregatedVisualizations>;
     } = {},
-) {
-    return [
-        getHostsAggregatedVisualization(constants),
-        ...getLineagesAggregatedVisualizations(options.sublineages),
-        ...getAuthorRelatedAggregatedVisualizations(constants),
-    ];
+): AggregatedVisualizations {
+    const hosts = getHostsAggregatedVisualization(constants);
+    const lineages = getLineagesAggregatedVisualizations(options.sublineages);
+
+    return {
+        sequencingEfforts: [hosts, ...lineages, ...getAuthorRelatedAggregatedVisualizations(constants)],
+        singleVariant: [...lineages, hosts],
+        compareSideBySide: [...lineages, hosts],
+    };
 }
 
 export function getPathoplexusSequencingEffortsAggregatedVisualizations(
@@ -101,47 +110,53 @@ export function getPathoplexusSequencingEffortsAggregatedVisualizations(
     options: {
         sublineages?: FirstParameter<typeof getLineagesAggregatedVisualizations>;
     } = {},
-): GsAggregatedConfig[] {
-    return [
-        getHostsAggregatedVisualization(constants),
-        ...getLineagesAggregatedVisualizations(options.sublineages),
-        {
-            label: 'Pathoplexus submitting groups',
-            fields: [pathoplexusGroupNameField],
-            views: [views.table],
-        },
-        ...getAuthorRelatedAggregatedVisualizations(constants),
-        {
-            label: 'Collection device',
-            fields: ['collectionDevice'],
-            views: [views.table, views.bar],
-        },
-        {
-            label: 'Collection method',
-            fields: ['collectionMethod'],
-            views: [views.table, views.bar],
-        },
-        {
-            label: 'Purpose of sampling',
-            fields: ['purposeOfSampling'],
-            views: [views.table, views.bar],
-        },
-        {
-            label: 'Sample type',
-            fields: ['sampleType'],
-            views: [views.table, views.bar],
-        },
-        {
-            label: 'Amplicon PCR primer scheme',
-            fields: ['ampliconPcrPrimerScheme'],
-            views: [views.table, views.bar],
-        },
-        {
-            label: 'Sequencing protocol',
-            fields: ['sequencingProtocol'],
-            views: [views.table, views.bar],
-        },
-    ];
+): AggregatedVisualizations {
+    const hosts = getHostsAggregatedVisualization(constants);
+    const lineages = getLineagesAggregatedVisualizations(options.sublineages);
+    return {
+        sequencingEfforts: [
+            hosts,
+            ...lineages,
+            {
+                label: 'Pathoplexus submitting groups',
+                fields: [pathoplexusGroupNameField],
+                views: [views.table],
+            },
+            ...getAuthorRelatedAggregatedVisualizations(constants),
+            {
+                label: 'Collection device',
+                fields: ['collectionDevice'],
+                views: [views.table, views.bar],
+            },
+            {
+                label: 'Collection method',
+                fields: ['collectionMethod'],
+                views: [views.table, views.bar],
+            },
+            {
+                label: 'Purpose of sampling',
+                fields: ['purposeOfSampling'],
+                views: [views.table, views.bar],
+            },
+            {
+                label: 'Sample type',
+                fields: ['sampleType'],
+                views: [views.table, views.bar],
+            },
+            {
+                label: 'Amplicon PCR primer scheme',
+                fields: ['ampliconPcrPrimerScheme'],
+                views: [views.table, views.bar],
+            },
+            {
+                label: 'Sequencing protocol',
+                fields: ['sequencingProtocol'],
+                views: [views.table, views.bar],
+            },
+        ],
+        singleVariant: [...lineages, hosts],
+        compareSideBySide: [...lineages, hosts],
+    };
 }
 
 export function getLineagesAggregatedVisualizations(

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -78,7 +78,7 @@ class CchfConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
+    public get aggregatedVisualizations() {
         return getPathoplexusSequencingEffortsAggregatedVisualizations(this);
     }
 

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -18,7 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    getPathoplexusAdditionalSequencingEffortsFields,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     getPathoplexusFilters,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -78,8 +78,8 @@ class CchfConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getPathoplexusAdditionalSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getPathoplexusSequencingEffortsAggregatedVisualizations(this);
     }
 
     public readonly additionalFilters: Record<string, string> | undefined;

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -13,7 +13,11 @@ import {
     GenericCompareVariantsView,
     GenericSequencingEffortsView,
 } from './BaseView.ts';
-import { type OrganismConstants } from './OrganismConstants.ts';
+import {
+    getHostsAggregatedVisualization,
+    getLineagesAggregatedVisualizations,
+    type OrganismConstants,
+} from './OrganismConstants.ts';
 import {
     type CompareSideBySideData,
     type DatasetAndVariantData,
@@ -44,7 +48,8 @@ const hostField = 'host';
 
 const mainDateFilterColumn = 'date';
 
-const nextcladePangoLineage = 'nextcladePangoLineage';
+const NEXTCLADE_PANGO_LINEAGE_FIELD_NAME = 'nextcladePangoLineage';
+const NEXTSTRAIN_CLADE_FIELD_NAME = 'nextstrainClade';
 
 const dateRangeOptions = [
     dateRangeOptionPresets.lastMonth,
@@ -67,7 +72,7 @@ class CovidConstants implements OrganismConstants {
     public readonly locationFields = ['region', 'country', 'division'];
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: nextcladePangoLineage,
+            lapisField: NEXTCLADE_PANGO_LINEAGE_FIELD_NAME,
             placeholderText: 'Nextclade pango lineage',
             filterType: 'lineage' as const,
         },
@@ -75,7 +80,7 @@ class CovidConstants implements OrganismConstants {
     // Same as `lineageFilters` but for Nextstrain Clade, used for 'Sub-lineages Nextstrain Clade'
     public readonly nextstrainCladeLineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'nextstrainClade',
+            lapisField: NEXTSTRAIN_CLADE_FIELD_NAME,
             placeholderText: 'Nextstrain clade',
             filterType: 'lineage' as const,
         },
@@ -135,8 +140,17 @@ class CovidConstants implements OrganismConstants {
     public readonly accessionDownloadFields = ['strain'];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
+    public get sequencingEffortsAggregatedVisualizations() {
         return [
+            getHostsAggregatedVisualization(this),
+            ...getLineagesAggregatedVisualizations({
+                label: 'Nextclade pango lineage',
+                fields: [NEXTCLADE_PANGO_LINEAGE_FIELD_NAME],
+            }),
+            ...getLineagesAggregatedVisualizations({
+                label: 'Nextstrain clade',
+                fields: [NEXTSTRAIN_CLADE_FIELD_NAME],
+            }),
             {
                 label: 'Originating lab',
                 fields: [this.originatingLabField],
@@ -235,12 +249,12 @@ export class CovidCompareSideBySideView extends BaseView<
         const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
             {
                 lineages: {
-                    [nextcladePangoLineage]: 'JN.1*',
+                    [NEXTCLADE_PANGO_LINEAGE_FIELD_NAME]: 'JN.1*',
                 },
             },
             {
                 lineages: {
-                    [nextcladePangoLineage]: 'XBB.1*',
+                    [NEXTCLADE_PANGO_LINEAGE_FIELD_NAME]: 'XBB.1*',
                 },
             },
         ]);

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -77,14 +77,6 @@ class CovidConstants implements OrganismConstants {
             filterType: 'lineage' as const,
         },
     ];
-    // Same as `lineageFilters` but for Nextstrain Clade, used for 'Sub-lineages Nextstrain Clade'
-    public readonly nextstrainCladeLineageFilters: LineageFilterConfig[] = [
-        {
-            lapisField: NEXTSTRAIN_CLADE_FIELD_NAME,
-            placeholderText: 'Nextstrain clade',
-            filterType: 'lineage' as const,
-        },
-    ];
     public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         {
@@ -140,9 +132,9 @@ class CovidConstants implements OrganismConstants {
     public readonly accessionDownloadFields = ['strain'];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return [
-            getHostsAggregatedVisualization(this),
+    public get aggregatedVisualizations() {
+        const hosts = getHostsAggregatedVisualization(this);
+        const lineages = [
             ...getLineagesAggregatedVisualizations({
                 label: 'Nextclade pango lineage',
                 fields: [NEXTCLADE_PANGO_LINEAGE_FIELD_NAME],
@@ -151,17 +143,26 @@ class CovidConstants implements OrganismConstants {
                 label: 'Nextstrain clade',
                 fields: [NEXTSTRAIN_CLADE_FIELD_NAME],
             }),
-            {
-                label: 'Originating lab',
-                fields: [this.originatingLabField],
-                views: [views.table],
-            },
-            {
-                label: 'Submitting lab ',
-                fields: [this.submittingLabField],
-                views: [views.table],
-            },
         ];
+
+        return {
+            sequencingEfforts: [
+                hosts,
+                ...lineages,
+                {
+                    label: 'Originating lab',
+                    fields: [this.originatingLabField],
+                    views: [views.table],
+                },
+                {
+                    label: 'Submitting lab',
+                    fields: [this.submittingLabField],
+                    views: [views.table],
+                },
+            ],
+            singleVariant: [...lineages, hosts],
+            compareSideBySide: [...lineages, hosts],
+        };
     }
 
     constructor(organismsConfig: OrganismsConfig) {

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -18,7 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    getPathoplexusAdditionalSequencingEffortsFields,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     getPathoplexusFilters,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -73,8 +73,8 @@ class EbolaSudanConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getPathoplexusAdditionalSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getPathoplexusSequencingEffortsAggregatedVisualizations(this);
     }
 
     public readonly additionalFilters: Record<string, string> | undefined;

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -73,7 +73,7 @@ class EbolaSudanConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
+    public get aggregatedVisualizations() {
         return getPathoplexusSequencingEffortsAggregatedVisualizations(this);
     }
 

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -74,7 +74,7 @@ class EbolaZaireConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
+    public get aggregatedVisualizations() {
         return getPathoplexusSequencingEffortsAggregatedVisualizations(this);
     }
 

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -18,7 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    getPathoplexusAdditionalSequencingEffortsFields,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     getPathoplexusFilters,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -74,8 +74,8 @@ class EbolaZaireConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getPathoplexusAdditionalSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getPathoplexusSequencingEffortsAggregatedVisualizations(this);
     }
 
     public readonly additionalFilters: Record<string, string> | undefined;

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -21,7 +21,7 @@ import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenspectrumLoculusFilters,
-    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
+    getGenSpectrumLoculusAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -80,8 +80,8 @@ class H1n1pdmConstants implements OrganismConstants {
     // Antiviral susceptibility mutations have been compiled here: https://www.who.int/teams/global-influenza-programme/laboratory-network/quality-assurance/antiviral-susceptibility-influenza/neuraminidase-inhibitor.
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+    public get aggregatedVisualizations() {
+        return getGenSpectrumLoculusAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Clades',
                 fields: [CLADE_HA_FIELD_NAME, CLADE_NA_FIELD_NAME],

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getAuthorRelatedSequencingEffortsFields,
     getGenspectrumLoculusFilters,
+    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -37,6 +37,9 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1900-01-01';
 
+const CLADE_HA_FIELD_NAME = 'cladeHA';
+const CLADE_NA_FIELD_NAME = 'cladeNA';
+
 class H1n1pdmConstants implements OrganismConstants {
     public readonly organism = Organisms.h1n1pdm;
     public readonly earliestDate = earliestDate;
@@ -44,12 +47,12 @@ class H1n1pdmConstants implements OrganismConstants {
     public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'cladeHA',
+            lapisField: CLADE_HA_FIELD_NAME,
             placeholderText: 'Clade HA',
             filterType: 'text' as const,
         },
         {
-            lapisField: 'cladeNA',
+            lapisField: CLADE_NA_FIELD_NAME,
             placeholderText: 'Clade NA',
             filterType: 'text' as const,
         },
@@ -77,8 +80,13 @@ class H1n1pdmConstants implements OrganismConstants {
     // Antiviral susceptibility mutations have been compiled here: https://www.who.int/teams/global-influenza-programme/laboratory-network/quality-assurance/antiviral-susceptibility-influenza/neuraminidase-inhibitor.
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getAuthorRelatedSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Clades',
+                fields: [CLADE_HA_FIELD_NAME, CLADE_NA_FIELD_NAME],
+            },
+        });
     }
 
     constructor(organismsConfig: OrganismsConfig) {
@@ -112,8 +120,8 @@ export class H1n1pdmCompareSideBySideView extends BaseView<
             {},
             {
                 lineages: {
-                    cladeHA: '6B.1A.5a.2a.1',
-                    cladeNA: 'C.5.3',
+                    [CLADE_HA_FIELD_NAME]: '6B.1A.5a.2a.1',
+                    [CLADE_NA_FIELD_NAME]: 'C.5.3',
                 },
             },
         ]);

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getAuthorRelatedSequencingEffortsFields,
     getGenspectrumLoculusFilters,
+    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -37,6 +37,9 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1905-01-01';
 
+const CLADE_HA_FIELD_NAME = 'cladeHA';
+const CLADE_NA_FIELD_NAME = 'cladeNA';
+
 class H3n2Constants implements OrganismConstants {
     public readonly organism = Organisms.h3n2;
     public readonly earliestDate = earliestDate;
@@ -44,12 +47,12 @@ class H3n2Constants implements OrganismConstants {
     public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'cladeHA',
+            lapisField: CLADE_HA_FIELD_NAME,
             placeholderText: 'Clade HA',
             filterType: 'text' as const,
         },
         {
-            lapisField: 'cladeNA',
+            lapisField: CLADE_NA_FIELD_NAME,
             placeholderText: 'Clade NA',
             filterType: 'text' as const,
         },
@@ -77,8 +80,13 @@ class H3n2Constants implements OrganismConstants {
     // Antiviral susceptibility mutations have been compiled here: https://www.who.int/teams/global-influenza-programme/laboratory-network/quality-assurance/antiviral-susceptibility-influenza/neuraminidase-inhibitor.
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getAuthorRelatedSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Clades',
+                fields: [CLADE_HA_FIELD_NAME, CLADE_NA_FIELD_NAME],
+            },
+        });
     }
 
     constructor(organismsConfig: OrganismsConfig) {
@@ -112,7 +120,7 @@ export class H3n2CompareSideBySideView extends BaseView<
             {},
             {
                 lineages: {
-                    cladeHA: '3C.2a1b.2a.2a.3a.1',
+                    [CLADE_HA_FIELD_NAME]: '3C.2a1b.2a.2a.3a.1',
                 },
             },
         ]);

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -21,7 +21,7 @@ import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenspectrumLoculusFilters,
-    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
+    getGenSpectrumLoculusAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -80,8 +80,8 @@ class H3n2Constants implements OrganismConstants {
     // Antiviral susceptibility mutations have been compiled here: https://www.who.int/teams/global-influenza-programme/laboratory-network/quality-assurance/antiviral-susceptibility-influenza/neuraminidase-inhibitor.
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+    public get aggregatedVisualizations() {
+        return getGenSpectrumLoculusAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Clades',
                 fields: [CLADE_HA_FIELD_NAME, CLADE_NA_FIELD_NAME],

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -21,7 +21,7 @@ import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenspectrumLoculusFilters,
-    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
+    getGenSpectrumLoculusAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -119,8 +119,8 @@ class H5n1Constants implements OrganismConstants {
         },
     ];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+    public get aggregatedVisualizations() {
+        return getGenSpectrumLoculusAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Clades',
                 fields: [CLADE_FIELD_NAME],

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getAuthorRelatedSequencingEffortsFields,
     getGenspectrumLoculusFilters,
+    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -37,6 +37,8 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1905-01-01';
 
+const CLADE_FIELD_NAME = 'clade';
+
 class H5n1Constants implements OrganismConstants {
     public readonly organism = Organisms.h5n1;
     public readonly earliestDate = earliestDate;
@@ -44,7 +46,7 @@ class H5n1Constants implements OrganismConstants {
     public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'clade',
+            lapisField: CLADE_FIELD_NAME,
             placeholderText: 'Clade',
             filterType: 'text' as const,
         },
@@ -64,10 +66,10 @@ class H5n1Constants implements OrganismConstants {
     public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
-            lineages: { clade: '2.3.4.4b' },
+            lineages: { [CLADE_FIELD_NAME]: '2.3.4.4b' },
         },
         {
-            lineages: { clade: '2.3.2.1a' },
+            lineages: { [CLADE_FIELD_NAME]: '2.3.2.1a' },
         },
         {
             mutations: {
@@ -117,8 +119,13 @@ class H5n1Constants implements OrganismConstants {
         },
     ];
 
-    public get additionalSequencingEffortsFields() {
-        return getAuthorRelatedSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Clades',
+                fields: [CLADE_FIELD_NAME],
+            },
+        });
     }
 
     constructor(organismsConfig: OrganismsConfig) {
@@ -152,7 +159,7 @@ export class H5n1CompareSideBySideView extends BaseView<
             {},
             {
                 lineages: {
-                    clade: '2.3.4.4b',
+                    [CLADE_FIELD_NAME]: '2.3.4.4b',
                 },
             },
         ]);

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -13,7 +13,7 @@ import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenspectrumLoculusFilters,
-    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
+    getGenSpectrumLoculusAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -64,8 +64,8 @@ class InfluenzaAConstants implements OrganismConstants {
     public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+    public get aggregatedVisualizations() {
+        return getGenSpectrumLoculusAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Subtypes',
                 fields: [SUBTYPE_HA_FIELD_NAME, SUBTYPE_NA_FIELD_NAME],

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -1,4 +1,4 @@
-import { dateRangeOptionPresets, type MutationAnnotation } from '@genspectrum/dashboard-components/util';
+import { dateRangeOptionPresets, type MutationAnnotation, views } from '@genspectrum/dashboard-components/util';
 
 import {
     type CompareSideBySideData,
@@ -12,8 +12,8 @@ import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getAuthorRelatedSequencingEffortsFields,
     getGenspectrumLoculusFilters,
+    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -29,6 +29,9 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1905-01-01';
 
+const SUBTYPE_HA_FIELD_NAME = 'subtypeHA';
+const SUBTYPE_NA_FIELD_NAME = 'subtypeNA';
+
 class InfluenzaAConstants implements OrganismConstants {
     public readonly organism = Organisms.influenzaA;
     public readonly earliestDate = earliestDate;
@@ -36,12 +39,12 @@ class InfluenzaAConstants implements OrganismConstants {
     public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'subtypeHA',
+            lapisField: SUBTYPE_HA_FIELD_NAME,
             placeholderText: 'HA subtype',
             filterType: 'text' as const,
         },
         {
-            lapisField: 'subtypeNA',
+            lapisField: SUBTYPE_NA_FIELD_NAME,
             placeholderText: 'NA subtype',
             filterType: 'text' as const,
         },
@@ -61,8 +64,14 @@ class InfluenzaAConstants implements OrganismConstants {
     public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getAuthorRelatedSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Subtypes',
+                fields: [SUBTYPE_HA_FIELD_NAME, SUBTYPE_NA_FIELD_NAME],
+                views: [views.bar, views.table],
+            },
+        });
     }
 
     constructor(organismsConfig: OrganismsConfig) {
@@ -89,14 +98,14 @@ export class InfluenzaACompareSideBySideView extends BaseView<
         const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
             {
                 lineages: {
-                    subtypeHA: 'H5',
-                    subtypeNA: 'N1',
+                    [SUBTYPE_HA_FIELD_NAME]: 'H5',
+                    [SUBTYPE_NA_FIELD_NAME]: 'N1',
                 },
             },
             {
                 lineages: {
-                    subtypeHA: 'H3',
-                    subtypeNA: 'N2',
+                    [SUBTYPE_HA_FIELD_NAME]: 'H3',
+                    [SUBTYPE_NA_FIELD_NAME]: 'N2',
                 },
             },
         ]);

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -13,7 +13,7 @@ import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenspectrumLoculusFilters,
-    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
+    getGenSpectrumLoculusAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -58,8 +58,8 @@ class InfluenzaBConstants implements OrganismConstants {
     public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+    public get aggregatedVisualizations() {
+        return getGenSpectrumLoculusAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Lineages',
                 fields: [LINEAGE_HA_FIELD_NAME],

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -12,8 +12,8 @@ import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getAuthorRelatedSequencingEffortsFields,
     getGenspectrumLoculusFilters,
+    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -29,6 +29,8 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1905-01-01';
 
+const LINEAGE_HA_FIELD_NAME = 'lineageHA';
+
 class InfluenzaBConstants implements OrganismConstants {
     public readonly organism = Organisms.influenzaB;
     public readonly earliestDate = earliestDate;
@@ -36,8 +38,8 @@ class InfluenzaBConstants implements OrganismConstants {
     public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'lineageHA',
-            placeholderText: 'lineage',
+            lapisField: LINEAGE_HA_FIELD_NAME,
+            placeholderText: 'Lineage',
             filterType: 'text' as const,
         },
     ];
@@ -56,8 +58,13 @@ class InfluenzaBConstants implements OrganismConstants {
     public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getAuthorRelatedSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Lineages',
+                fields: [LINEAGE_HA_FIELD_NAME],
+            },
+        });
     }
 
     constructor(organismsConfig: OrganismsConfig) {
@@ -84,12 +91,12 @@ export class InfluenzaBCompareSideBySideView extends BaseView<
         const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
             {
                 lineages: {
-                    lineageHA: 'vic',
+                    [LINEAGE_HA_FIELD_NAME]: 'vic',
                 },
             },
             {
                 lineages: {
-                    lineageHA: 'yam',
+                    [LINEAGE_HA_FIELD_NAME]: 'yam',
                 },
             },
         ]);

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -97,7 +97,7 @@ class MpoxConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
+    public get aggregatedVisualizations() {
         return getPathoplexusSequencingEffortsAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Sub-Lineages',

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -19,7 +19,7 @@ import {
 } from './BaseView.ts';
 import {
     type OrganismConstants,
-    getPathoplexusAdditionalSequencingEffortsFields,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS,
     PATHOPLEXUS_LOCATION_FIELDS,
     LOCULUS_AUTHORS_FIELD,
@@ -37,6 +37,9 @@ import { defaultDateRangeOption } from '../util/defaultDateRangeOption.ts';
 
 const earliestDate = '1960-01-01';
 
+const LINEAGE_FIELD_NAME = 'lineage';
+const CLADE_FIELD_NAME = 'clade';
+
 class MpoxConstants implements OrganismConstants {
     public readonly organism = Organisms.mpox;
     public readonly mainDateField: string;
@@ -44,12 +47,12 @@ class MpoxConstants implements OrganismConstants {
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'lineage',
+            lapisField: LINEAGE_FIELD_NAME,
             placeholderText: 'Lineage',
             filterType: 'text' as const,
         },
         {
-            lapisField: 'clade',
+            lapisField: CLADE_FIELD_NAME,
             placeholderText: 'Clade',
             filterType: 'text' as const,
         },
@@ -83,19 +86,24 @@ class MpoxConstants implements OrganismConstants {
     public readonly accessionDownloadFields = PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
-            lineages: { lineage: 'F.1' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'F.1' },
         },
         {
-            lineages: { lineage: 'F.2' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'F.2' },
         },
         {
-            lineages: { clade: 'Ia' },
+            lineages: { [CLADE_FIELD_NAME]: 'Ia' },
         },
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getPathoplexusAdditionalSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getPathoplexusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Sub-Lineages',
+                fields: [LINEAGE_FIELD_NAME, CLADE_FIELD_NAME],
+            },
+        });
     }
 
     public readonly additionalFilters: Record<string, string> | undefined;
@@ -131,12 +139,12 @@ export class MpoxCompareSideBySideView extends BaseView<
         const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
             {
                 lineages: {
-                    lineage: 'F.1',
+                    [LINEAGE_FIELD_NAME]: 'F.1',
                 },
             },
             {
                 lineages: {
-                    lineage: 'F.2',
+                    [LINEAGE_FIELD_NAME]: 'F.2',
                 },
             },
         ]);

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -20,7 +20,7 @@ const mockConstants: OrganismConstants = {
             filterType: 'text',
         },
     ],
-    additionalSequencingEffortsFields: [],
+    sequencingEffortsAggregatedVisualizations: [],
     accessionDownloadFields: [],
     useAdvancedQuery: false,
     baselineFilterConfigs: [

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -20,7 +20,11 @@ const mockConstants: OrganismConstants = {
             filterType: 'text',
         },
     ],
-    sequencingEffortsAggregatedVisualizations: [],
+    aggregatedVisualizations: {
+        sequencingEfforts: [],
+        singleVariant: [],
+        compareSideBySide: [],
+    },
     accessionDownloadFields: [],
     useAdvancedQuery: false,
     baselineFilterConfigs: [

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -20,7 +20,7 @@ const mockConstants: OrganismConstants = {
             filterType: 'text',
         },
     ],
-    additionalSequencingEffortsFields: [],
+    sequencingEffortsAggregatedVisualizations: [],
     accessionDownloadFields: [],
     useAdvancedQuery: true,
     baselineFilterConfigs: [

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -20,7 +20,11 @@ const mockConstants: OrganismConstants = {
             filterType: 'text',
         },
     ],
-    sequencingEffortsAggregatedVisualizations: [],
+    aggregatedVisualizations: {
+        sequencingEfforts: [],
+        singleVariant: [],
+        compareSideBySide: [],
+    },
     accessionDownloadFields: [],
     useAdvancedQuery: true,
     baselineFilterConfigs: [

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -20,7 +20,7 @@ const mockConstants: OrganismConstants = {
             filterType: 'text',
         },
     ],
-    additionalSequencingEffortsFields: [],
+    sequencingEffortsAggregatedVisualizations: [],
     accessionDownloadFields: [],
     useAdvancedQuery: true,
     baselineFilterConfigs: [

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -20,7 +20,11 @@ const mockConstants: OrganismConstants = {
             filterType: 'text',
         },
     ],
-    sequencingEffortsAggregatedVisualizations: [],
+    aggregatedVisualizations: {
+        sequencingEfforts: [],
+        singleVariant: [],
+        compareSideBySide: [],
+    },
     accessionDownloadFields: [],
     useAdvancedQuery: true,
     baselineFilterConfigs: [

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -20,7 +20,7 @@ const mockConstants: OrganismConstants = {
             filterType: 'text',
         },
     ],
-    additionalSequencingEffortsFields: [],
+    sequencingEffortsAggregatedVisualizations: [],
     accessionDownloadFields: [],
     useAdvancedQuery: false,
     baselineFilterConfigs: [

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -20,7 +20,11 @@ const mockConstants: OrganismConstants = {
             filterType: 'text',
         },
     ],
-    sequencingEffortsAggregatedVisualizations: [],
+    aggregatedVisualizations: {
+        sequencingEfforts: [],
+        singleVariant: [],
+        compareSideBySide: [],
+    },
     accessionDownloadFields: [],
     useAdvancedQuery: false,
     baselineFilterConfigs: [

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getAuthorRelatedSequencingEffortsFields,
     getGenspectrumLoculusFilters,
+    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
@@ -36,6 +36,8 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1956-01-01';
 
+const LINEAGE_FIELD_NAME = 'lineage';
+
 class RsvAConstants implements OrganismConstants {
     public readonly organism = Organisms.rsvA;
     public readonly mainDateField: string;
@@ -43,7 +45,7 @@ class RsvAConstants implements OrganismConstants {
     public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'lineage',
+            lapisField: LINEAGE_FIELD_NAME,
             placeholderText: 'Lineage',
             filterType: 'text' as const,
         },
@@ -63,19 +65,24 @@ class RsvAConstants implements OrganismConstants {
     public readonly accessionDownloadFields = ['insdcAccessionFull'];
     public readonly predefinedVariants = [
         {
-            lineages: { lineage: 'A.D.3' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'A.D.3' },
         },
         {
-            lineages: { lineage: 'A.D.5.2' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'A.D.5.2' },
         },
         {
-            lineages: { lineage: 'A.D.1' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'A.D.1' },
         },
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getAuthorRelatedSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Lineages',
+                fields: [LINEAGE_FIELD_NAME],
+            },
+        });
     }
 
     constructor(organismsConfig: OrganismsConfig) {
@@ -109,7 +116,7 @@ export class RsvACompareSideBySideView extends BaseView<
             {},
             {
                 lineages: {
-                    lineage: 'A.D.5.2',
+                    [LINEAGE_FIELD_NAME]: 'A.D.5.2',
                 },
             },
         ]);

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -21,7 +21,7 @@ import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenspectrumLoculusFilters,
-    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
+    getGenSpectrumLoculusAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
@@ -76,8 +76,8 @@ class RsvAConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+    public get aggregatedVisualizations() {
+        return getGenSpectrumLoculusAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Lineages',
                 fields: [LINEAGE_FIELD_NAME],

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getAuthorRelatedSequencingEffortsFields,
     getGenspectrumLoculusFilters,
+    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
@@ -36,6 +36,8 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1956-01-01';
 
+const LINEAGE_FIELD_NAME = 'lineage';
+
 class RsvBConstants implements OrganismConstants {
     public readonly organism = Organisms.rsvB;
     public readonly mainDateField: string;
@@ -43,7 +45,7 @@ class RsvBConstants implements OrganismConstants {
     public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'lineage',
+            lapisField: LINEAGE_FIELD_NAME,
             placeholderText: 'Lineage',
             filterType: 'text' as const,
         },
@@ -63,19 +65,24 @@ class RsvBConstants implements OrganismConstants {
     public readonly accessionDownloadFields = ['insdcAccessionFull'];
     public readonly predefinedVariants = [
         {
-            lineages: { lineage: 'B.D.E.1' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'B.D.E.1' },
         },
         {
-            lineages: { lineage: 'B.D.E.1.1' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'B.D.E.1.1' },
         },
         {
-            lineages: { lineage: 'B.D.4.1.1' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'B.D.4.1.1' },
         },
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getAuthorRelatedSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Lineages',
+                fields: [LINEAGE_FIELD_NAME],
+            },
+        });
     }
 
     constructor(organismsConfig: OrganismsConfig) {
@@ -109,7 +116,7 @@ export class RsvBCompareSideBySideView extends BaseView<
             {},
             {
                 lineages: {
-                    lineage: 'B.D.E.1',
+                    [LINEAGE_FIELD_NAME]: 'B.D.E.1',
                 },
             },
         ]);

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -21,7 +21,7 @@ import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenspectrumLoculusFilters,
-    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
+    getGenSpectrumLoculusAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
@@ -76,8 +76,8 @@ class RsvBConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+    public get aggregatedVisualizations() {
+        return getGenSpectrumLoculusAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Lineages',
                 fields: [LINEAGE_FIELD_NAME],

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getAuthorRelatedSequencingEffortsFields,
     getGenspectrumLoculusFilters,
+    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -37,6 +37,9 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1905-01-01';
 
+const CLADE_HA_FIELD_NAME = 'cladeHA';
+const CLADE_NA_FIELD_NAME = 'cladeNA';
+
 class VictoriaConstants implements OrganismConstants {
     public readonly organism = Organisms.victoria;
     public readonly earliestDate = earliestDate;
@@ -44,12 +47,12 @@ class VictoriaConstants implements OrganismConstants {
     public readonly locationFields = GENSPECTRUM_LOCULUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'cladeHA',
+            lapisField: CLADE_HA_FIELD_NAME,
             placeholderText: 'Clade HA',
             filterType: 'text' as const,
         },
         {
-            lapisField: 'cladeNA',
+            lapisField: CLADE_NA_FIELD_NAME,
             placeholderText: 'Clade NA',
             filterType: 'text' as const,
         },
@@ -73,8 +76,13 @@ class VictoriaConstants implements OrganismConstants {
     // Antiviral susceptibility mutations have been compiled here: https://www.who.int/teams/global-influenza-programme/laboratory-network/quality-assurance/antiviral-susceptibility-influenza/neuraminidase-inhibitor.
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getAuthorRelatedSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Clades',
+                fields: [CLADE_HA_FIELD_NAME, CLADE_NA_FIELD_NAME],
+            },
+        });
     }
 
     constructor(organismsConfig: OrganismsConfig) {

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -21,7 +21,7 @@ import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenspectrumLoculusFilters,
-    getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations,
+    getGenSpectrumLoculusAggregatedVisualizations,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -76,8 +76,8 @@ class VictoriaConstants implements OrganismConstants {
     // Antiviral susceptibility mutations have been compiled here: https://www.who.int/teams/global-influenza-programme/laboratory-network/quality-assurance/antiviral-susceptibility-influenza/neuraminidase-inhibitor.
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
-        return getGenSpectrumLoculusSequencingEffortsAggregatedVisualizations(this, {
+    public get aggregatedVisualizations() {
+        return getGenSpectrumLoculusAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Clades',
                 fields: [CLADE_HA_FIELD_NAME, CLADE_NA_FIELD_NAME],

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -18,7 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    getPathoplexusAdditionalSequencingEffortsFields,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     getPathoplexusFilters,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -37,6 +37,8 @@ import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOpti
 
 const earliestDate = '1930-01-01';
 
+const LINEAGE_FIELD_NAME = 'lineage';
+
 class WestNileConstants implements OrganismConstants {
     public readonly organism = Organisms.westNile;
     public readonly mainDateField: string;
@@ -44,7 +46,7 @@ class WestNileConstants implements OrganismConstants {
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
-            lapisField: 'lineage',
+            lapisField: LINEAGE_FIELD_NAME,
             placeholderText: 'Lineage',
             filterType: 'text' as const,
         },
@@ -79,8 +81,13 @@ class WestNileConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get additionalSequencingEffortsFields() {
-        return getPathoplexusAdditionalSequencingEffortsFields(this);
+    public get sequencingEffortsAggregatedVisualizations() {
+        return getPathoplexusSequencingEffortsAggregatedVisualizations(this, {
+            sublineages: {
+                label: 'Lineages',
+                fields: [LINEAGE_FIELD_NAME],
+            },
+        });
     }
 
     public readonly additionalFilters: Record<string, string> | undefined;

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -81,7 +81,7 @@ class WestNileConstants implements OrganismConstants {
     ];
     public readonly mutationAnnotations: MutationAnnotation[] = [];
 
-    public get sequencingEffortsAggregatedVisualizations() {
+    public get aggregatedVisualizations() {
         return getPathoplexusSequencingEffortsAggregatedVisualizations(this, {
             sublineages: {
                 label: 'Lineages',


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #636

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

This is mostly a refactoring to make it configurable. The idea was to include all `gs-aggregated`s into the `additionalSequencingEffortsFields` (which are no longer "additional" then). Consequently, I introduced the same concept for the other views that use `gs-aggregated` in the same manner.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![image](https://github.com/user-attachments/assets/5fbf7a02-1c6c-4cfe-96cc-c1d705aa11d3)
