### PR TITLE
feat(components): allow for multiple location filter

### DIFF
--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -1,6 +1,7 @@
 import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
 
 import type { DatasetFilter } from '../../views/View.ts';
+import { locationFieldsToFilterIdentifier } from '../../views/pageStateHandlers/PageStateHandler.ts';
 import { GsDateRangeFilter } from '../genspectrum/GsDateRangeFilter.tsx';
 import { GsLocationFilter } from '../genspectrum/GsLocationFilter.tsx';
 import { GsTextFilter } from '../genspectrum/GsTextFilter.tsx';
@@ -28,10 +29,10 @@ export type BaselineFilterConfig =
     | ({
           type: 'date';
       } & DateRangeFilterConfig)
-    | ({ type: 'text' } & TextInputConfig);
+    | ({ type: 'text' } & TextInputConfig)
+    | ({ type: 'location' } & LocationFilterConfig);
 
 export function BaselineSelector({
-    locationFilterConfig,
     baselineFilterConfigs,
     datasetFilter,
     setDatasetFilter,
@@ -40,87 +41,88 @@ export function BaselineSelector({
     datasetFilter: DatasetFilter;
     setDatasetFilter: (datasetFilter: DatasetFilter) => void;
     lapisFilter: LapisFilter;
-    locationFilterConfig?: LocationFilterConfig;
     baselineFilterConfigs?: BaselineFilterConfig[];
 }) {
     return (
         <div className={`flex flex-col gap-2`}>
-            {locationFilterConfig !== undefined && (
-                <label className='form-control'>
-                    <div className='label'>
-                        <span className='label-text'>
-                            {locationFilterConfig.label ?? locationFilterConfig.placeholderText}
-                        </span>
-                    </div>
-                    <GsLocationFilter
-                        fields={locationFilterConfig.locationFields}
-                        onLocationChange={(newLocation) => {
-                            setDatasetFilter({
-                                ...datasetFilter,
-                                location: newLocation,
-                            });
-                        }}
-                        value={datasetFilter.location}
-                        placeholderText={locationFilterConfig.placeholderText}
-                        lapisFilter={lapisFilter}
-                    ></GsLocationFilter>
-                </label>
-            )}
-
-            <>
-                {baselineFilterConfigs?.map((config: BaselineFilterConfig) => {
-                    switch (config.type) {
-                        case 'date': {
-                            return (
-                                <label className='form-control' key={`label${config.dateColumn}`}>
-                                    <div className='label'>
-                                        <span className='label-text'>{config.label ?? config.dateColumn}</span>
-                                    </div>
-                                    <GsDateRangeFilter
-                                        lapisDateField={config.dateColumn}
-                                        onDateRangeChange={(newDateRange) => {
-                                            setDatasetFilter({
-                                                ...datasetFilter,
-                                                dateFilters: {
-                                                    ...datasetFilter.dateFilters,
-                                                    [config.dateColumn]: newDateRange,
-                                                },
-                                            });
-                                        }}
-                                        earliestDate={config.earliestDate}
-                                        value={datasetFilter.dateFilters[config.dateColumn]}
-                                        dateRangeOptions={config.dateRangeOptions}
-                                    />
-                                </label>
-                            );
-                        }
-                        case 'text': {
-                            return (
-                                <label className='form-control' key={`$label${config.lapisField}`}>
-                                    <div className='label'>
-                                        <span className='label-text'>{config.label ?? config.lapisField}</span>
-                                    </div>
-                                    <GsTextFilter
-                                        value={datasetFilter.textFilters[config.lapisField]}
-                                        lapisField={config.lapisField}
-                                        placeholderText={config.placeholderText}
-                                        onInputChange={(input) => {
-                                            setDatasetFilter({
-                                                ...datasetFilter,
-                                                textFilters: {
-                                                    ...datasetFilter.textFilters,
-                                                    ...input,
-                                                },
-                                            });
-                                        }}
-                                        lapisFilter={lapisFilter}
-                                    />
-                                </label>
-                            );
-                        }
+            {baselineFilterConfigs?.map((config: BaselineFilterConfig) => {
+                switch (config.type) {
+                    case 'date': {
+                        return (
+                            <label className='form-control' key={`label${config.dateColumn}`}>
+                                <div className='label'>
+                                    <span className='label-text'>{config.label ?? config.dateColumn}</span>
+                                </div>
+                                <GsDateRangeFilter
+                                    lapisDateField={config.dateColumn}
+                                    onDateRangeChange={(newDateRange) => {
+                                        setDatasetFilter({
+                                            ...datasetFilter,
+                                            dateFilters: {
+                                                ...datasetFilter.dateFilters,
+                                                [config.dateColumn]: newDateRange,
+                                            },
+                                        });
+                                    }}
+                                    earliestDate={config.earliestDate}
+                                    value={datasetFilter.dateFilters[config.dateColumn]}
+                                    dateRangeOptions={config.dateRangeOptions}
+                                />
+                            </label>
+                        );
                     }
-                })}
-            </>
+                    case 'text': {
+                        return (
+                            <label className='form-control' key={`$label${config.lapisField}`}>
+                                <div className='label'>
+                                    <span className='label-text'>{config.label ?? config.lapisField}</span>
+                                </div>
+                                <GsTextFilter
+                                    value={datasetFilter.textFilters[config.lapisField]}
+                                    lapisField={config.lapisField}
+                                    placeholderText={config.placeholderText}
+                                    onInputChange={(input) => {
+                                        setDatasetFilter({
+                                            ...datasetFilter,
+                                            textFilters: {
+                                                ...datasetFilter.textFilters,
+                                                ...input,
+                                            },
+                                        });
+                                    }}
+                                    lapisFilter={lapisFilter}
+                                />
+                            </label>
+                        );
+                    }
+                    case 'location': {
+                        const filterIdentifier = locationFieldsToFilterIdentifier(config.locationFields);
+
+                        return (
+                            <label className='form-control' key={`label${filterIdentifier}`}>
+                                <div className='label'>
+                                    <span className='label-text'>{config.label ?? config.placeholderText}</span>
+                                </div>
+                                <GsLocationFilter
+                                    fields={config.locationFields}
+                                    onLocationChange={(newLocation) => {
+                                        setDatasetFilter({
+                                            ...datasetFilter,
+                                            locationFilters: {
+                                                ...datasetFilter.locationFilters,
+                                                [filterIdentifier]: newLocation,
+                                            },
+                                        });
+                                    }}
+                                    value={datasetFilter.locationFilters[filterIdentifier]}
+                                    placeholderText={config.placeholderText}
+                                    lapisFilter={lapisFilter}
+                                ></GsLocationFilter>
+                            </label>
+                        );
+                    }
+                }
+            })}
         </div>
     );
 }

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, type LocationFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
@@ -11,13 +11,11 @@ import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { compareSideBySideViewKey } from '../../views/viewKeys.ts';
 
 export function CompareSideBySidePageStateSelector({
-    locationFilterConfig,
     filterId,
     initialPageState,
     organismViewKey,
     organismsConfig,
 }: {
-    locationFilterConfig: LocationFilterConfig;
     filterId: number;
     initialPageState: CompareSideBySideData;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareSideBySideViewKey}`;
@@ -33,7 +31,7 @@ export function CompareSideBySidePageStateSelector({
     const { filterOfCurrentId, currentLapisFilter } = useMemo(() => {
         const filterOfCurrentId = pageState.filters.get(filterId) ?? {
             datasetFilter: {
-                location: {},
+                locationFilters: {},
                 dateFilters: {},
                 textFilters: {},
             },
@@ -55,7 +53,6 @@ export function CompareSideBySidePageStateSelector({
                     <SelectorHeadline>Filter dataset</SelectorHeadline>
                     <Inset className='p-2'>
                         <BaselineSelector
-                            locationFilterConfig={locationFilterConfig}
                             baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                             lapisFilter={currentLapisFilter}
                             datasetFilter={filterOfCurrentId.datasetFilter}

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, type LocationFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig } from './VariantSelector.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
@@ -12,12 +12,10 @@ import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { compareVariantsViewKey } from '../../views/viewKeys.ts';
 
 export function CompareVariantsPageStateSelector({
-    locationFilterConfig,
     organismViewKey,
     organismsConfig,
     initialPageState,
 }: {
-    locationFilterConfig: LocationFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareVariantsViewKey}`;
     organismsConfig: OrganismsConfig;
     initialPageState: CompareVariantsData;
@@ -43,7 +41,6 @@ export function CompareVariantsPageStateSelector({
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <Inset className='p-2'>
                     <BaselineSelector
-                        locationFilterConfig={locationFilterConfig}
                         baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
                         datasetFilter={pageState.datasetFilter}

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, type LocationFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
@@ -12,12 +12,10 @@ import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import { type compareToBaselineViewKey } from '../../views/viewKeys.ts';
 
 export function CompareVariantsToBaselineStateSelector({
-    locationFilterConfig,
     organismViewKey,
     organismsConfig,
     initialPageState,
 }: {
-    locationFilterConfig: LocationFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareToBaselineViewKey}`;
     organismsConfig: OrganismsConfig;
     initialPageState: CompareToBaselineData;
@@ -45,7 +43,6 @@ export function CompareVariantsToBaselineStateSelector({
                 <Inset>
                     <div className='px-2'>
                         <BaselineSelector
-                            locationFilterConfig={locationFilterConfig}
                             baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                             lapisFilter={currentLapisFilter}
                             datasetFilter={pageState.datasetFilter}

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, type LocationFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
@@ -11,12 +11,10 @@ import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { sequencingEffortsViewKey } from '../../views/viewKeys.ts';
 
 export function SequencingEffortsPageStateSelector({
-    locationFilterConfig,
     organismViewKey,
     organismsConfig,
     initialPageState,
 }: {
-    locationFilterConfig: LocationFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof sequencingEffortsViewKey}`;
     organismsConfig: OrganismsConfig;
     initialPageState: DatasetAndVariantData;
@@ -42,7 +40,6 @@ export function SequencingEffortsPageStateSelector({
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <Inset className='flex flex-col gap-6 p-2'>
                     <BaselineSelector
-                        locationFilterConfig={locationFilterConfig}
                         baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
                         datasetFilter={pageState.datasetFilter}

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.spec.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.spec.tsx
@@ -11,7 +11,7 @@ describe('SingleVariantPageStateSelector', () => {
 
         const initialPageState = {
             datasetFilter: {
-                location: {},
+                locationFilters: {},
                 dateFilters: {},
                 textFilters: {},
             },
@@ -22,10 +22,6 @@ describe('SingleVariantPageStateSelector', () => {
         const { getByRole } = render(
             <gs-app lapis={DUMMY_LAPIS_URL}>
                 <SingleVariantPageStateSelector
-                    locationFilterConfig={{
-                        locationFields: ['region', 'country', 'division'],
-                        placeholderText: 'Location',
-                    }}
                     organismViewKey='covid.singleVariantView'
                     organismsConfig={testOrganismsConfig}
                     initialPageState={initialPageState}

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, type LocationFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
@@ -11,12 +11,10 @@ import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { singleVariantViewKey } from '../../views/viewKeys.ts';
 
 export function SingleVariantPageStateSelector({
-    locationFilterConfig,
     organismViewKey,
     organismsConfig,
     initialPageState,
 }: {
-    locationFilterConfig: LocationFilterConfig;
     organismViewKey: OrganismViewKey & `${string}.${typeof singleVariantViewKey}`;
     organismsConfig: OrganismsConfig;
     initialPageState: DatasetAndVariantData;
@@ -40,7 +38,6 @@ export function SingleVariantPageStateSelector({
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <Inset className={'p-2'}>
                     <BaselineSelector
-                        locationFilterConfig={locationFilterConfig}
                         baselineFilterConfigs={baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
                         datasetFilter={pageState.datasetFilter}

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -9,7 +9,7 @@ import { Organisms } from '../../../types/Organism';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../../util/hasOnlyUndefinedValues';
 import { getLocationSubdivision } from '../../../views/locationHelpers';
-import { toDisplayName } from '../../../views/pageStateHandlers/PageStateHandler';
+import { locationFieldsToFilterIdentifier, toDisplayName } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { singleVariantViewKey } from '../../../views/viewKeys';
@@ -43,7 +43,7 @@ const timeGranularity = chooseGranularityBasedOnDateRange({
 
 const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
     view.organismConstants.locationFields,
-    pageState.datasetFilter.location,
+    pageState.datasetFilter.locationFilters[locationFieldsToFilterIdentifier(view.organismConstants.locationFields)],
 );
 
 const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
@@ -63,11 +63,6 @@ const downloadLinks = noVariantSelected
 <SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <SingleVariantPageStateSelector
         slot='filters'
-        locationFilterConfig={{
-            locationFields: view.organismConstants.locationFields,
-            placeholderText: 'Sampling location',
-            label: 'Sampling location',
-        }}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         initialPageState={pageState}

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -61,10 +61,6 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                     </a>
                                 )}
                                 <CompareSideBySidePageStateSelector
-                                    locationFilterConfig={{
-                                        locationFields: view.organismConstants.locationFields,
-                                        placeholderText: 'Sampling location',
-                                    }}
                                     filterId={id}
                                     initialPageState={pageState}
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}

--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
@@ -45,10 +45,6 @@ const downloadLinks = noVariantSelected
 <SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <CompareVariantsToBaselineStateSelector
         slot='filters'
-        locationFilterConfig={{
-            locationFields: view.organismConstants.locationFields,
-            placeholderText: 'Sampling location',
-        }}
         initialPageState={pageState}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}

--- a/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
+++ b/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
@@ -48,10 +48,6 @@ const componentHeight = '540px'; // prevalence over time table with 10 rows
 <SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <CompareVariantsPageStateSelector
         slot='filters'
-        locationFilterConfig={{
-            locationFields: view.organismConstants.locationFields,
-            placeholderText: 'Sampling location',
-        }}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         initialPageState={pageState}

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -4,6 +4,7 @@ import { getDashboardsConfig, getLapisUrl } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { getLocationDisplayConfig } from '../../../views/locationHelpers';
+import { locationFieldsToFilterIdentifier } from '../../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
 import { sequencingEffortsViewKey } from '../../../views/viewKeys';
@@ -30,9 +31,10 @@ const timeGranularity = chooseGranularityBasedOnDateRange({
     earliestDate: new Date(view.organismConstants.earliestDate),
     dateRange: pageState.datasetFilter.dateFilters[view.organismConstants.mainDateField],
 });
+
 const { locationField, mapName } = getLocationDisplayConfig(
     view.organismConstants.locationFields,
-    pageState.datasetFilter.location,
+    pageState.datasetFilter.locationFilters[locationFieldsToFilterIdentifier(view.organismConstants.locationFields)],
 );
 ---
 
@@ -48,11 +50,6 @@ const { locationField, mapName } = getLocationDisplayConfig(
 >
     <SequencingEffortsPageStateSelector
         slot='filters'
-        locationFilterConfig={{
-            locationFields: view.organismConstants.locationFields,
-            placeholderText: 'Sampling location',
-            label: 'Sampling location',
-        }}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         initialPageState={pageState}

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -58,10 +58,6 @@ const downloadLinks = [...pageState.filters.entries()].map(
                                     </a>
                                 )}
                                 <CompareSideBySidePageStateSelector
-                                    locationFilterConfig={{
-                                        locationFields: view.organismConstants.locationFields,
-                                        placeholderText: 'Sampling location',
-                                    }}
                                     filterId={id}
                                     initialPageState={pageState}
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -19,7 +19,7 @@ import SingleVariantOrganismPageLayout from '../../layouts/OrganismPage/SingleVa
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
 import { hasOnlyUndefinedValues } from '../../util/hasOnlyUndefinedValues';
 import { getLocationSubdivision } from '../../views/locationHelpers';
-import { toDisplayName } from '../../views/pageStateHandlers/PageStateHandler';
+import { locationFieldsToFilterIdentifier, toDisplayName } from '../../views/pageStateHandlers/PageStateHandler';
 import { type OrganismViewKey } from '../../views/routing';
 import { ServerSide } from '../../views/serverSideRouting';
 
@@ -36,7 +36,7 @@ const timeGranularity = chooseGranularityBasedOnDateRange({
 
 const { label: subdivisionLabel, field: subdivisionField } = getLocationSubdivision(
     view.organismConstants.locationFields,
-    pageState.datasetFilter.location,
+    pageState.datasetFilter.locationFilters[locationFieldsToFilterIdentifier(view.organismConstants.locationFields)],
 );
 
 const noVariantSelected = hasOnlyUndefinedValues(pageState.variantFilter);
@@ -57,10 +57,6 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
 <SingleVariantOrganismPageLayout view={view} downloadLinks={downloadLinks}>
     <div slot='filters'>
         <SingleVariantPageStateSelector
-            locationFilterConfig={{
-                locationFields: view.organismConstants.locationFields,
-                placeholderText: 'Sampling location',
-            }}
             organismViewKey={organismViewKey}
             organismsConfig={organismConfig}
             initialPageState={pageState}

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -211,6 +211,12 @@ export function getPathoplexusFilters({
 }): BaselineFilterConfig[] {
     return [
         {
+            type: 'location',
+            locationFields: PATHOPLEXUS_LOCATION_FIELDS,
+            label: 'Sampling location',
+            placeholderText: 'Sampling location',
+        },
+        {
             type: 'date',
             dateRangeOptions,
             earliestDate,
@@ -255,6 +261,12 @@ export function getGenspectrumLoculusFilters({
     earliestDate: string;
 }): BaselineFilterConfig[] {
     return [
+        {
+            type: 'location',
+            locationFields: GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
+            placeholderText: 'Sampling location',
+            label: 'Sampling location',
+        },
         {
             type: 'date',
             dateRangeOptions,

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -8,9 +8,13 @@ import type { LineageFilterConfig } from '../components/pageStateSelectors/Linea
 import { type BreadcrumbElement } from '../layouts/Breadcrumbs.tsx';
 
 export type DatasetFilter = {
-    location: LapisLocation;
+    locationFilters: LocationFilterState;
     textFilters: TextFilterState;
     dateFilters: DateFilterState;
+};
+
+export type LocationFilterState = {
+    [key: string]: LapisLocation | undefined;
 };
 
 export type DateFilterState = {

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -92,7 +92,7 @@ class CchfConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -1,11 +1,6 @@
 import { dateRangeOptionPresets, type MutationAnnotation, views } from '@genspectrum/dashboard-components/util';
 
-import {
-    getIntegerFromSearch,
-    getLapisVariantQuery,
-    setSearchFromLapisVariantQuery,
-    setSearchFromLocation,
-} from './helpers.ts';
+import { getIntegerFromSearch, getLapisVariantQuery, setSearchFromLapisVariantQuery } from './helpers.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -33,6 +28,7 @@ import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBy
 import {
     type PageStateHandler,
     setSearchFromDateFilters,
+    setSearchFromLocationFilters,
     setSearchFromTextFilters,
 } from './pageStateHandlers/PageStateHandler.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
@@ -47,6 +43,7 @@ const earliestDate = '2020-01-06';
 const hostField = 'host';
 
 const mainDateFilterColumn = 'date';
+const mainLocationFields = ['region', 'country', 'division'];
 
 const NEXTCLADE_PANGO_LINEAGE_FIELD_NAME = 'nextcladePangoLineage';
 const NEXTSTRAIN_CLADE_FIELD_NAME = 'nextstrainClade';
@@ -69,7 +66,7 @@ class CovidConstants implements OrganismConstants {
     public readonly organism = Organisms.covid;
     public readonly earliestDate = earliestDate;
     public readonly mainDateField: string;
-    public readonly locationFields = ['region', 'country', 'division'];
+    public readonly locationFields = mainLocationFields;
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: NEXTCLADE_PANGO_LINEAGE_FIELD_NAME,
@@ -79,6 +76,12 @@ class CovidConstants implements OrganismConstants {
     ];
     public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
+        {
+            type: 'location',
+            locationFields: mainLocationFields,
+            placeholderText: 'Sampling location',
+            label: 'Sampling location',
+        },
         {
             type: 'date',
             dateRangeOptions,
@@ -106,22 +109,10 @@ class CovidConstants implements OrganismConstants {
             label: 'Date submitted',
         },
         {
-            lapisField: 'regionExposure',
-            placeholderText: 'Region exposure',
-            type: 'text' as const,
-            label: 'Region exposure',
-        },
-        {
-            lapisField: 'countryExposure',
-            placeholderText: 'Country exposure',
-            type: 'text' as const,
-            label: 'Country exposure',
-        },
-        {
-            lapisField: 'divisionExposure',
-            placeholderText: 'Division exposure',
-            type: 'text' as const,
-            label: 'Division exposure',
+            type: 'location',
+            locationFields: ['regionExposure', 'countryExposure', 'divisionExposure'],
+            placeholderText: 'Exposure location',
+            label: 'Exposure location',
         },
     ];
     public readonly hostField: string = hostField;
@@ -172,7 +163,7 @@ class CovidConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [mainDateFilterColumn]: dateRangeOptionPresets.lastYear,
@@ -224,7 +215,7 @@ class CovidSingleVariantStateHandler
 
     public override toUrl(pageState: CovidVariantData): string {
         const search = new URLSearchParams();
-        setSearchFromLocation(search, pageState.datasetFilter.location);
+        setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
 

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -87,7 +87,7 @@ class EbolaSudanConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -88,7 +88,7 @@ class EbolaZaireConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -96,7 +96,7 @@ class H1n1pdmConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -96,7 +96,7 @@ class H3n2Constants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -135,7 +135,7 @@ class H5n1Constants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -81,7 +81,7 @@ class InfluenzaAConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -74,7 +74,7 @@ class InfluenzaBConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/locationHelpers.ts
+++ b/website/src/views/locationHelpers.ts
@@ -1,8 +1,8 @@
 import type { LapisLocation } from './helpers.ts';
 import { hasOnlyUndefinedValues } from '../util/hasOnlyUndefinedValues.ts';
 
-export function getLocationDisplayConfig(locationFields: string[], locationFilter: LapisLocation) {
-    if (hasOnlyUndefinedValues(locationFilter)) {
+export function getLocationDisplayConfig(locationFields: string[], locationFilter: LapisLocation | undefined) {
+    if (locationFilter === undefined || hasOnlyUndefinedValues(locationFilter)) {
         const locationField = locationFields.find((it) => isCountryField(it)) ?? locationFields[0];
         return { mapName: 'World', locationField };
     }
@@ -14,8 +14,8 @@ export function getLocationDisplayConfig(locationFields: string[], locationFilte
     };
 }
 
-export function getLocationSubdivision(locationFields: string[], locationFilter: LapisLocation) {
-    if (locationFields.length <= 1) {
+export function getLocationSubdivision(locationFields: string[], locationFilter: LapisLocation | undefined) {
+    if (locationFields.length <= 1 || locationFilter === undefined) {
         return { label: '', field: undefined };
     }
 

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -116,7 +116,7 @@ class MpoxConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -40,6 +40,12 @@ const mockConstants: OrganismConstants = {
             earliestDate: '1999-01-01',
             dateColumn: 'date',
         },
+        {
+            type: 'location',
+            placeholderText: 'Some location',
+            label: 'Some location',
+            locationFields: ['country', 'region'],
+        },
     ],
 };
 
@@ -49,7 +55,7 @@ const mockDefaultPageState: CompareSideBySideData = {
             1,
             {
                 datasetFilter: {
-                    location: {},
+                    locationFilters: {},
                     dateFilters: {},
                     textFilters: {},
                 },
@@ -63,7 +69,7 @@ const mockDefaultPageState: CompareSideBySideData = {
             2,
             {
                 datasetFilter: {
-                    location: {},
+                    locationFilters: {},
                     dateFilters: {
                         date: mockDateRangeOption,
                     },
@@ -103,7 +109,7 @@ describe('CompareSideBySideStateHandler', () => {
 
         expect(pageState.filters.get(0)).toEqual({
             datasetFilter: {
-                location: {},
+                locationFilters: {},
                 dateFilters: {},
                 textFilters: {},
             },
@@ -119,7 +125,7 @@ describe('CompareSideBySideStateHandler', () => {
                     date: mockDateRangeOption,
                 },
                 textFilters: {},
-                location: {},
+                locationFilters: {},
             },
             variantFilter: {
                 lineages: {
@@ -132,7 +138,7 @@ describe('CompareSideBySideStateHandler', () => {
         expect(pageState.filters.get(2)).toEqual({
             datasetFilter: {
                 dateFilters: {},
-                location: {},
+                locationFilters: {},
                 textFilters: {},
             },
             variantFilter: {
@@ -148,7 +154,7 @@ describe('CompareSideBySideStateHandler', () => {
                     1,
                     {
                         datasetFilter: {
-                            location: {},
+                            locationFilters: {},
                             dateFilters: { date: mockDateRangeOption },
                             textFilters: {},
                         },
@@ -162,7 +168,7 @@ describe('CompareSideBySideStateHandler', () => {
                     2,
                     {
                         datasetFilter: {
-                            location: {},
+                            locationFilters: {},
                             dateFilters: { date: mockDateRangeOption },
                             textFilters: {},
                         },
@@ -193,7 +199,7 @@ describe('CompareSideBySideStateHandler', () => {
                     1,
                     {
                         datasetFilter: {
-                            location: {},
+                            locationFilters: {},
                             dateFilters: { date: null },
                             textFilters: {},
                         },
@@ -211,7 +217,8 @@ describe('CompareSideBySideStateHandler', () => {
         const lapisFilter = handler.variantFilterToLapisFilter(
             {
                 dateFilters: { date: mockDateRangeOption },
-                location: { country: 'US' },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
                 textFilters: {
                     someTextField: 'SomeText',
                 },
@@ -235,7 +242,8 @@ describe('CompareSideBySideStateHandler', () => {
         const lapisFilter = handler.variantFilterToLapisFilter(
             {
                 dateFilters: { date: mockDateRangeOption },
-                location: { country: 'US' },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
                 textFilters: {
                     someTextField: 'SomeText',
                 },

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
@@ -3,19 +3,16 @@ import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareSideBySideData, type DatasetAndVariantData, getLineageFilterFields, type Id } from '../View.ts';
 import { compareSideBySideViewConstants } from '../ViewConstants.ts';
-import {
-    getLapisLocationFromSearch,
-    getLapisVariantQuery,
-    setSearchFromLapisVariantQuery,
-    setSearchFromLocation,
-} from '../helpers.ts';
+import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
 import {
     decodeFiltersFromSearch,
     type PageStateHandler,
     parseDateRangesFromUrl,
+    parseLocationFiltersFromUrl,
     parseTextFiltersFromUrl,
     searchParamsFromFilterMap,
     setSearchFromDateFilters,
+    setSearchFromLocationFilters,
     setSearchFromTextFilters,
     toLapisFilterWithoutVariant,
 } from './PageStateHandler.ts';
@@ -108,7 +105,7 @@ export class CompareSideBySideStateHandler implements PageStateHandler<CompareSi
             filter.variantFilter,
             getLineageFilterFields(this.constants.lineageFilters),
         );
-        setSearchFromLocation(searchOfFilter, filter.datasetFilter.location);
+        setSearchFromLocationFilters(searchOfFilter, filter, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(searchOfFilter, filter, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(searchOfFilter, filter, this.constants.baselineFilterConfigs);
     }
@@ -116,7 +113,7 @@ export class CompareSideBySideStateHandler implements PageStateHandler<CompareSi
     protected getEmptyColumnData(): DatasetAndVariantData {
         return {
             datasetFilter: {
-                location: {},
+                locationFilters: {},
                 textFilters: {},
                 dateFilters: {},
             },
@@ -130,7 +127,7 @@ export class CompareSideBySideStateHandler implements PageStateHandler<CompareSi
     protected getFilter(filterParams: Map<string, string>): DatasetAndVariantData {
         return {
             datasetFilter: {
-                location: getLapisLocationFromSearch(filterParams, this.constants.locationFields),
+                locationFilters: parseLocationFiltersFromUrl(filterParams, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(filterParams, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(filterParams, this.constants.baselineFilterConfigs),
             },

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -40,13 +40,19 @@ const mockConstants: OrganismConstants = {
             earliestDate: '1999-01-01',
             dateColumn: 'date',
         },
+        {
+            type: 'location',
+            placeholderText: 'Some location',
+            label: 'Some location',
+            locationFields: ['country', 'region'],
+        },
     ],
 };
 
 const mockDefaultPageState: CompareToBaselineData = {
     variants: new Map(),
     datasetFilter: {
-        location: {},
+        locationFilters: {},
         dateFilters: { date: mockDateRangeOption },
         textFilters: {},
     },
@@ -78,7 +84,8 @@ describe('CompareToBaselinePageStateHandler', () => {
 
         const pageState = handler.parsePageStateFromUrl(url);
 
-        expect(pageState.datasetFilter.location).toEqual({ country: 'US' });
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        expect(pageState.datasetFilter.locationFilters).toEqual({ 'country,region': { country: 'US' } });
         expect(pageState.datasetFilter.dateFilters).toEqual({ date: mockDateRangeOption });
 
         expect(pageState.baselineFilter).toEqual({
@@ -127,7 +134,8 @@ describe('CompareToBaselinePageStateHandler', () => {
                 ],
             ]),
             datasetFilter: {
-                location: { country: 'US' },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
             },
@@ -157,7 +165,7 @@ describe('CompareToBaselinePageStateHandler', () => {
         const pageState: CompareToBaselineData = {
             variants: new Map(),
             datasetFilter: {
-                location: {},
+                locationFilters: {},
                 dateFilters: { date: null },
                 textFilters: {},
             },
@@ -187,7 +195,8 @@ describe('CompareToBaselinePageStateHandler', () => {
                 ],
             ]),
             datasetFilter: {
-                location: { country: 'US' },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
             },
@@ -215,7 +224,8 @@ describe('CompareToBaselinePageStateHandler', () => {
     it('should convert dataset filter to Lapis filter', () => {
         const lapisFilter = handler.datasetFilterToLapisFilter({
             ...mockDefaultPageState.datasetFilter,
-            location: { country: 'US' },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            locationFilters: { 'country,region': { country: 'US' } },
         });
         expect(lapisFilter).toStrictEqual({
             dateFrom: '2024-11-22',

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
@@ -3,19 +3,16 @@ import type { LapisFilter, NamedLapisFilter } from '@genspectrum/dashboard-compo
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareToBaselineData, type DatasetFilter, getLineageFilterFields, type VariantFilter } from '../View.ts';
 import { compareToBaselineViewConstants } from '../ViewConstants.ts';
-import {
-    getLapisLocationFromSearch,
-    getLapisVariantQuery,
-    setSearchFromLapisVariantQuery,
-    setSearchFromLocation,
-} from '../helpers.ts';
+import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
 import {
     decodeFiltersFromSearch,
     type PageStateHandler,
     parseDateRangesFromUrl,
+    parseLocationFiltersFromUrl,
     parseTextFiltersFromUrl,
     searchParamsFromFilterMap,
     setSearchFromDateFilters,
+    setSearchFromLocationFilters,
     setSearchFromTextFilters,
     toDisplayName,
     toLapisFilterFromVariant,
@@ -49,7 +46,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
 
         return {
             datasetFilter: {
-                location: getLapisLocationFromSearch(search, this.constants.locationFields),
+                locationFilters: parseLocationFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
             },
@@ -63,7 +60,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
             setSearchFromLapisVariantQuery(search, variant, getLineageFilterFields(this.constants.lineageFilters)),
         );
 
-        setSearchFromLocation(search, pageState.datasetFilter.location);
+        setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
 

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -40,13 +40,19 @@ const mockConstants: OrganismConstants = {
             earliestDate: '1999-01-01',
             dateColumn: 'date',
         },
+        {
+            type: 'location',
+            placeholderText: 'Some location',
+            label: 'Some location',
+            locationFields: ['country', 'region'],
+        },
     ],
 };
 
 const mockDefaultPageState: CompareVariantsData = {
     variants: new Map(),
     datasetFilter: {
-        location: {},
+        locationFilters: {},
         dateFilters: { date: mockDateRangeOption },
         textFilters: {},
     },
@@ -73,7 +79,8 @@ describe('CompareVariantsPageStateHandler', () => {
 
         const pageState = handler.parsePageStateFromUrl(url);
 
-        expect(pageState.datasetFilter.location).toEqual({ country: 'US' });
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        expect(pageState.datasetFilter.locationFilters).toEqual({ 'country,region': { country: 'US' } });
         expect(pageState.datasetFilter.dateFilters).toEqual({ date: mockDateRangeOption });
 
         expect(pageState.variants.size).toBe(3);
@@ -115,7 +122,8 @@ describe('CompareVariantsPageStateHandler', () => {
                 ],
             ]),
             datasetFilter: {
-                location: { country: 'US' },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
             },
@@ -151,7 +159,8 @@ describe('CompareVariantsPageStateHandler', () => {
                 ],
             ]),
             datasetFilter: {
-                location: { country: 'US' },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
             },
@@ -172,7 +181,7 @@ describe('CompareVariantsPageStateHandler', () => {
         const pageState: CompareVariantsData = {
             variants: new Map(),
             datasetFilter: {
-                location: {},
+                locationFilters: {},
                 dateFilters: { date: null },
                 textFilters: {},
             },
@@ -186,7 +195,8 @@ describe('CompareVariantsPageStateHandler', () => {
     it('should convert dataset filter to Lapis filter', () => {
         const lapisFilter = handler.datasetFilterToLapisFilter({
             ...mockDefaultPageState.datasetFilter,
-            location: { country: 'US' },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            locationFilters: { 'country,region': { country: 'US' } },
         });
         expect(lapisFilter).toStrictEqual({
             dateFrom: '2024-11-22',

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
@@ -3,19 +3,16 @@ import type { LapisFilter, NamedLapisFilter } from '@genspectrum/dashboard-compo
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareVariantsData, type DatasetFilter, getLineageFilterFields, type VariantFilter } from '../View.ts';
 import { compareVariantsViewConstants } from '../ViewConstants.ts';
-import {
-    getLapisLocationFromSearch,
-    getLapisVariantQuery,
-    setSearchFromLapisVariantQuery,
-    setSearchFromLocation,
-} from '../helpers.ts';
+import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
 import {
     decodeFiltersFromSearch,
     type PageStateHandler,
     parseDateRangesFromUrl,
+    parseLocationFiltersFromUrl,
     parseTextFiltersFromUrl,
     searchParamsFromFilterMap,
     setSearchFromDateFilters,
+    setSearchFromLocationFilters,
     setSearchFromTextFilters,
     toDisplayName,
     toLapisFilterFromVariant,
@@ -50,7 +47,7 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
 
         return {
             datasetFilter: {
-                location: getLapisLocationFromSearch(search, this.constants.locationFields),
+                locationFilters: parseLocationFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
             },
@@ -63,7 +60,7 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
             setSearchFromLapisVariantQuery(search, variant, getLineageFilterFields(this.constants.lineageFilters)),
         );
 
-        setSearchFromLocation(search, pageState.datasetFilter.location);
+        setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
 

--- a/website/src/views/pageStateHandlers/PageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './PageStateHandler.ts';
+import type { BaselineFilterConfig } from '../../components/pageStateSelectors/BaselineSelector.tsx';
+import type { Dataset } from '../View.ts';
+
+describe('parseLocationFilterFromUrl', () => {
+    it('should parse location to filter', () => {
+        const configs = [
+            {
+                type: 'location',
+                placeholderText: 'Some location',
+                label: 'Some location',
+                locationFields: ['country', 'region'],
+            },
+        ] satisfies BaselineFilterConfig[];
+
+        const search = new Map<string, string>([
+            ['country', 'someCountry'],
+            ['notALocationFilter', 'notALocationFilter'],
+        ]);
+
+        const result = parseLocationFiltersFromUrl(search, configs);
+
+        expect(result['country,region']).toEqual({ country: 'someCountry' });
+    });
+
+    it('should parse one location to multiple filters', () => {
+        const configs = [
+            {
+                type: 'location',
+                placeholderText: 'Some location',
+                label: 'Some location',
+                locationFields: ['country', 'region'],
+            },
+            {
+                type: 'location',
+                placeholderText: 'Some other location',
+                label: 'Some other location',
+                locationFields: ['country', 'someOtherRegion'],
+            },
+        ] satisfies BaselineFilterConfig[];
+
+        const search = new Map<string, string>([
+            ['country', 'someCountry'],
+            ['notALocationFilter', 'notALocationFilter'],
+        ]);
+
+        const result = parseLocationFiltersFromUrl(search, configs);
+
+        expect(result['country,region']).toEqual({ country: 'someCountry' });
+        expect(result['country,someOtherRegion']).toEqual({ country: 'someCountry' });
+    });
+});
+
+describe('setSearchFromLocationFilters', () => {
+    it('should set search from one filter', () => {
+        const search = new URLSearchParams();
+
+        const pageState = {
+            datasetFilter: {
+                locationFilters: {
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    'country,region': { country: 'someCountry' },
+                },
+                textFilters: {},
+                dateFilters: {},
+            },
+        } satisfies Dataset;
+
+        const configs = [
+            {
+                type: 'location',
+                placeholderText: 'Some location',
+                label: 'Some location',
+                locationFields: ['country', 'region'],
+            },
+        ] satisfies BaselineFilterConfig[];
+
+        setSearchFromLocationFilters(search, pageState, configs);
+
+        expect(search.get('country')).toEqual('someCountry');
+        expect(search.keys().toArray().length).toEqual(1);
+    });
+
+    it('should set search from multiple filters', () => {
+        const search = new URLSearchParams();
+
+        const pageState = {
+            datasetFilter: {
+                locationFilters: {
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    'country,region': { country: 'someCountry' },
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    'someOtherCountry,someOtherRegion': { someOtherCountry: 'someOtherCountry' },
+                },
+                textFilters: {},
+                dateFilters: {},
+            },
+        } satisfies Dataset;
+
+        const configs = [
+            {
+                type: 'location',
+                placeholderText: 'Some location',
+                label: 'Some location',
+                locationFields: ['country', 'region'],
+            },
+            {
+                type: 'location',
+                placeholderText: 'Some other location',
+                label: 'Some other location',
+                locationFields: ['someOtherCountry', 'someOtherRegion'],
+            },
+        ] satisfies BaselineFilterConfig[];
+
+        setSearchFromLocationFilters(search, pageState, configs);
+
+        expect(search.get('country')).toEqual('someCountry');
+        expect(search.get('someOtherCountry')).toEqual('someOtherCountry');
+        expect(search.keys().toArray().length).toEqual(2);
+    });
+
+    it('should set search with two filters with the same field and use the first', () => {
+        const search = new URLSearchParams();
+
+        const pageState = {
+            datasetFilter: {
+                locationFilters: {
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    'country,region': { country: 'someCountry' },
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    'country,someOtherRegion': { country: 'someOtherRegion' },
+                },
+                textFilters: {},
+                dateFilters: {},
+            },
+        } satisfies Dataset;
+
+        const configs = [
+            {
+                type: 'location',
+                placeholderText: 'Some location',
+                label: 'Some location',
+                locationFields: ['country', 'region'],
+            },
+            {
+                type: 'location',
+                placeholderText: 'Some other location',
+                label: 'Some other location',
+                locationFields: ['someOtherCountry', 'someOtherRegion'],
+            },
+        ] satisfies BaselineFilterConfig[];
+
+        setSearchFromLocationFilters(search, pageState, configs);
+
+        expect(search.get('country')).toEqual('someCountry');
+        expect(search.keys().toArray().length).toEqual(1);
+    });
+});

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -1,17 +1,14 @@
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { sequencingEffortsViewConstants } from '../ViewConstants.ts';
-import {
-    getLapisLocationFromSearch,
-    getLapisVariantQuery,
-    setSearchFromLapisVariantQuery,
-    setSearchFromLocation,
-} from '../helpers.ts';
+import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
 import {
     type PageStateHandler,
     parseDateRangesFromUrl,
+    parseLocationFiltersFromUrl,
     parseTextFiltersFromUrl,
     setSearchFromDateFilters,
+    setSearchFromLocationFilters,
     setSearchFromTextFilters,
     toLapisFilterFromVariant,
     toLapisFilterWithoutVariant,
@@ -36,7 +33,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
 
         return {
             datasetFilter: {
-                location: getLapisLocationFromSearch(search, this.constants.locationFields),
+                locationFilters: parseLocationFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
             },
@@ -46,7 +43,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
 
     public toUrl(pageState: DatasetAndVariantData): string {
         const search = new URLSearchParams();
-        setSearchFromLocation(search, pageState.datasetFilter.location);
+        setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
 

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -40,12 +40,18 @@ const mockConstants: OrganismConstants = {
             earliestDate: '1999-01-01',
             dateColumn: 'date',
         },
+        {
+            type: 'location',
+            placeholderText: 'Some location',
+            label: 'Some location',
+            locationFields: ['country', 'region'],
+        },
     ],
 };
 
 const mockDefaultPageState: DatasetAndVariantData = {
     datasetFilter: {
-        location: {},
+        locationFilters: {},
         dateFilters: {
             date: mockDateRangeOption,
         },
@@ -75,7 +81,8 @@ describe('SingleVariantPageStateHandler', () => {
 
         const pageState = handler.parsePageStateFromUrl(url);
 
-        expect(pageState.datasetFilter.location).toEqual({ country: 'US' });
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        expect(pageState.datasetFilter.locationFilters).toEqual({ 'country,region': { country: 'US' } });
         expect(pageState.datasetFilter.dateFilters).toEqual({ date: mockDateRangeOption });
 
         expect(pageState.variantFilter).toEqual({
@@ -94,7 +101,8 @@ describe('SingleVariantPageStateHandler', () => {
                 mutations: { nucleotideMutations: ['D614G'] },
             },
             datasetFilter: {
-                location: { country: 'US' },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
             },
@@ -113,7 +121,7 @@ describe('SingleVariantPageStateHandler', () => {
         const pageState: DatasetAndVariantData = {
             variantFilter: {},
             datasetFilter: {
-                location: {},
+                locationFilters: {},
                 dateFilters: { date: null },
                 textFilters: {},
             },

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -3,18 +3,14 @@ import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { singleVariantViewConstants } from '../ViewConstants.ts';
-import {
-    getLapisLocationFromSearch,
-    getLapisVariantQuery,
-    type LapisLocation,
-    setSearchFromLapisVariantQuery,
-    setSearchFromLocation,
-} from '../helpers.ts';
+import { getLapisVariantQuery, type LapisLocation, setSearchFromLapisVariantQuery } from '../helpers.ts';
 import {
     type PageStateHandler,
     parseDateRangesFromUrl,
+    parseLocationFiltersFromUrl,
     parseTextFiltersFromUrl,
     setSearchFromDateFilters,
+    setSearchFromLocationFilters,
     setSearchFromTextFilters,
     toLapisFilterFromVariant,
     toLapisFilterWithoutVariant,
@@ -39,7 +35,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
 
         return {
             datasetFilter: {
-                location: getLapisLocationFromSearch(search, this.constants.locationFields),
+                locationFilters: parseLocationFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
             },
@@ -49,7 +45,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
 
     public toUrl(pageState: DatasetAndVariantData): string {
         const search = new URLSearchParams();
-        setSearchFromLocation(search, pageState.datasetFilter.location);
+        setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
 

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -92,7 +92,7 @@ class RsvAConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -92,7 +92,7 @@ class RsvBConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -92,7 +92,7 @@ class VictoriaConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -100,7 +100,7 @@ class WestNileConstants implements OrganismConstants {
 }
 
 const defaultDatasetFilter: DatasetFilter = {
-    location: {},
+    locationFilters: {},
     textFilters: {},
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,


### PR DESCRIPTION
Resolves: #618

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Moves the location config to the other configs (text and date). This allows us to set more than one location filter. 

### Screenshot

![grafik](https://github.com/user-attachments/assets/9b5b5e0c-f7bf-4d6c-94f0-d8f08ac53bcd)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
