### PR TITLE
feat(components): use influenza a and b as breadcrumbs

### DIFF
--- a/website/src/components/views/overview/GenericOverview.astro
+++ b/website/src/components/views/overview/GenericOverview.astro
@@ -3,6 +3,7 @@ import { defaultBreadcrumbs } from '../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { getPathogenMegaMenuSections } from '../../../layouts/base/header/getPathogenMegaMenuSections';
 import { PageHeadline } from '../../../styles/containers/PageHeadline';
+import { paths } from '../../../types/Organism';
 import { iconMapping } from '../../iconCss';
 
 type Props = {
@@ -12,12 +13,11 @@ type Props = {
 const { organism } = Astro.props;
 
 const section = getPathogenMegaMenuSections()[organism];
+
+const breadcrumbs = [...defaultBreadcrumbs, ...paths[organism].breadcrumbs];
 ---
 
-<ContaineredPageLayout
-    title={section.headline}
-    breadcrumbs={[...defaultBreadcrumbs, { name: section.headline, href: section.href }]}
->
+<ContaineredPageLayout title={section.headline} breadcrumbs={breadcrumbs}>
     <PageHeadline>{section.headline}</PageHeadline>
     <slot name='pre-navigation' />
     <div class='group flex flex-wrap justify-center gap-2'>

--- a/website/src/layouts/base/header/getPathogenMegaMenuSections.ts
+++ b/website/src/layouts/base/header/getPathogenMegaMenuSections.ts
@@ -1,5 +1,5 @@
 import type { MenuIconType } from '../../../components/iconCss.ts';
-import { type Organism, organismConfig } from '../../../types/Organism.ts';
+import { type Organism, organismConfig, paths } from '../../../types/Organism.ts';
 import { wastewaterConfig, wastewaterPathFragment } from '../../../types/wastewaterConfig.ts';
 import { ServerSide } from '../../../views/serverSideRouting.ts';
 
@@ -57,7 +57,7 @@ export function getPathogenMegaMenuSections(): PathogenMegaMenuSections {
             headlineBackgroundColorFocus: config.backgroundColorFocus,
             borderEntryDecoration: config.borderEntryDecoration,
             navigationEntries: megaMenuSections,
-            href: `/${config.pathFragment}`,
+            href: paths[config.organism].basePath,
         };
         return acc;
     }, {} as PathogenMegaMenuSections);

--- a/website/src/pages/swiss-wastewater/flu.astro
+++ b/website/src/pages/swiss-wastewater/flu.astro
@@ -9,8 +9,8 @@ import { dataOrigins } from '../../types/dataOrigins';
 import {
     getMutationAnnotation,
     InfluenzaTypes,
+    wastewaterBreadcrumb,
     wastewaterConfig,
-    wastewaterPathFragment,
 } from '../../types/wastewaterConfig';
 
 const lapisUrl = `${wastewaterConfig.lapisBaseUrl}/influenza`;
@@ -20,7 +20,7 @@ const lapisUrl = `${wastewaterConfig.lapisBaseUrl}/influenza`;
     title='Swiss wastewater - Influenza'
     breadcrumbs={[
         ...defaultBreadcrumbs,
-        { name: 'Swiss Wastewater', href: `/${wastewaterPathFragment}` },
+        wastewaterBreadcrumb,
         {
             name: 'Influenza',
             href: wastewaterConfig.pages.influenza,

--- a/website/src/pages/swiss-wastewater/rsv.astro
+++ b/website/src/pages/swiss-wastewater/rsv.astro
@@ -6,7 +6,7 @@ import GsWastewaterMutationsOverTime from '../../components/genspectrum/GsWastew
 import { defaultBreadcrumbs } from '../../layouts/Breadcrumbs';
 import DataPageLayout from '../../layouts/OrganismPage/DataPageLayout.astro';
 import { dataOrigins } from '../../types/dataOrigins';
-import { wastewaterConfig, RSVTypes, wastewaterPathFragment } from '../../types/wastewaterConfig';
+import { wastewaterConfig, RSVTypes, wastewaterBreadcrumb } from '../../types/wastewaterConfig';
 
 const lapisUrl = `${wastewaterConfig.lapisBaseUrl}/rsv`;
 ---
@@ -15,7 +15,7 @@ const lapisUrl = `${wastewaterConfig.lapisBaseUrl}/rsv`;
     title='Swiss wastewater - RSV'
     breadcrumbs={[
         ...defaultBreadcrumbs,
-        { name: 'Swiss Wastewater', href: `/${wastewaterPathFragment}` },
+        wastewaterBreadcrumb,
         {
             name: 'RSV',
             href: wastewaterConfig.pages.rsv,

--- a/website/src/types/Organism.ts
+++ b/website/src/types/Organism.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { wastewaterBreadcrumb, wastewaterPathFragment } from './wastewaterConfig.ts';
+
 export const Organisms = {
     covid: 'covid' as const,
     influenzaA: 'influenzaA' as const,
@@ -38,8 +40,8 @@ export const organismConfig = {
     },
     [Organisms.h5n1]: {
         organism: Organisms.h5n1,
-        pathFragment: 'influenza-a/h5n1',
-        label: 'Influenza A/H5N1',
+        pathFragment: 'h5n1',
+        label: 'H5N1',
         backgroundColor: 'bg-cyanMuted',
         backgroundColorFocus: 'group-hover:bg-cyan',
         menuListEntryDecoration: 'decoration-cyan',
@@ -47,8 +49,8 @@ export const organismConfig = {
     },
     [Organisms.h1n1pdm]: {
         organism: Organisms.h1n1pdm,
-        pathFragment: 'influenza-a/h1n1pdm',
-        label: 'Influenza A/H1N1pdm',
+        pathFragment: 'h1n1pdm',
+        label: 'H1N1pdm',
         backgroundColor: 'bg-cyanMuted',
         backgroundColorFocus: 'group-hover:bg-cyan',
         menuListEntryDecoration: 'decoration-cyan',
@@ -56,8 +58,8 @@ export const organismConfig = {
     },
     [Organisms.h3n2]: {
         organism: Organisms.h3n2,
-        pathFragment: 'influenza-a/h3n2',
-        label: 'Influenza A/H3N2',
+        pathFragment: 'h3n2',
+        label: 'H3N2',
         backgroundColor: 'bg-cyanMuted',
         backgroundColorFocus: 'group-hover:bg-cyan',
         menuListEntryDecoration: 'decoration-cyan',
@@ -74,8 +76,8 @@ export const organismConfig = {
     },
     [Organisms.victoria]: {
         organism: Organisms.victoria,
-        pathFragment: 'influenza-b/victoria',
-        label: 'Influenza B/Victoria',
+        pathFragment: 'victoria',
+        label: 'Victoria',
         backgroundColor: 'bg-indigoMuted',
         backgroundColorFocus: 'group-hover:bg-indigo',
         menuListEntryDecoration: 'decoration-indigo',
@@ -145,8 +147,87 @@ export const organismConfig = {
         borderEntryDecoration: 'hover:border-olive',
     },
 };
-export const allOrganisms = Object.keys(organismConfig) as Organism[];
-export type Organism = keyof typeof organismConfig;
 
+export const paths = {
+    [Organisms.covid]: getDefaultPathConfig(Organisms.covid),
+    [Organisms.influenzaA]: {
+        basePath: `/${organismConfig[Organisms.influenzaA].pathFragment}`,
+        breadcrumbs: [getBreadcrumbItem(Organisms.influenzaA)],
+    },
+    [Organisms.h5n1]: {
+        basePath: `/${organismConfig[Organisms.influenzaA].pathFragment}/${organismConfig[Organisms.h5n1].pathFragment}`,
+        breadcrumbs: [
+            getBreadcrumbItem(Organisms.influenzaA),
+            {
+                name: organismConfig[Organisms.h5n1].label,
+                href: `/${organismConfig[Organisms.influenzaA].pathFragment}/${organismConfig[Organisms.h5n1].pathFragment}`,
+            },
+        ],
+    },
+    [Organisms.h1n1pdm]: {
+        basePath: `/${organismConfig[Organisms.influenzaA].pathFragment}/${organismConfig[Organisms.h1n1pdm].pathFragment}`,
+        breadcrumbs: [
+            getBreadcrumbItem(Organisms.influenzaA),
+            {
+                name: organismConfig[Organisms.h1n1pdm].label,
+                href: `/${organismConfig[Organisms.influenzaA].pathFragment}/${organismConfig[Organisms.h1n1pdm].pathFragment}`,
+            },
+        ],
+    },
+    [Organisms.h3n2]: {
+        basePath: `/${organismConfig[Organisms.influenzaA].pathFragment}/${organismConfig[Organisms.h3n2].pathFragment}`,
+        breadcrumbs: [
+            getBreadcrumbItem(Organisms.influenzaA),
+            {
+                name: organismConfig[Organisms.h3n2].label,
+                href: `/${organismConfig[Organisms.influenzaA].pathFragment}/${organismConfig[Organisms.h3n2].pathFragment}`,
+            },
+        ],
+    },
+    [Organisms.influenzaB]: {
+        basePath: `/${organismConfig[Organisms.influenzaB].pathFragment}`,
+        breadcrumbs: [getBreadcrumbItem(Organisms.influenzaB)],
+    },
+    [Organisms.victoria]: {
+        basePath: `/${organismConfig[Organisms.influenzaB].pathFragment}/${organismConfig[Organisms.victoria].pathFragment}`,
+        breadcrumbs: [
+            getBreadcrumbItem(Organisms.influenzaB),
+            {
+                name: organismConfig[Organisms.victoria].label,
+                href: `/${organismConfig[Organisms.influenzaB].pathFragment}/${organismConfig[Organisms.victoria].pathFragment}`,
+            },
+        ],
+    },
+    [Organisms.westNile]: getDefaultPathConfig(Organisms.westNile),
+    [Organisms.rsvA]: getDefaultPathConfig(Organisms.rsvA),
+    [Organisms.rsvB]: getDefaultPathConfig(Organisms.rsvB),
+    [Organisms.mpox]: getDefaultPathConfig(Organisms.mpox),
+    [Organisms.ebolaSudan]: getDefaultPathConfig(Organisms.ebolaSudan),
+    [Organisms.ebolaZaire]: getDefaultPathConfig(Organisms.ebolaZaire),
+    [Organisms.cchf]: getDefaultPathConfig(Organisms.cchf),
+    swissWastewater: {
+        basePath: `/${wastewaterPathFragment}`,
+        breadcrumbs: [wastewaterBreadcrumb],
+    },
+};
+
+export const allOrganisms = Object.keys(organismConfig) as Organism[];
+
+export type Organism = keyof typeof organismConfig;
 export const organismSchema = z.enum(Object.keys(organismConfig) as [keyof typeof organismConfig]);
+
 export const organismsSchema = z.array(organismSchema);
+
+function getDefaultPathConfig(organism: Organism) {
+    return {
+        basePath: `/${organismConfig[organism].pathFragment}`,
+        breadcrumbs: [getBreadcrumbItem(organism)],
+    };
+}
+
+function getBreadcrumbItem(organism: Organism) {
+    return {
+        name: organismConfig[organism].label,
+        href: `/${organismConfig[organism].pathFragment}`,
+    };
+}

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -15,6 +15,11 @@ export const wastewaterConfig = {
     },
 };
 
+export const wastewaterBreadcrumb = {
+    name: 'Swiss Wastewater',
+    href: `/${wastewaterPathFragment}`,
+};
+
 export const RSVTypes = ['RSV-A', 'RSV-B'] as const;
 
 export type RSVType = (typeof RSVTypes)[number];

--- a/website/src/views/BaseView.ts
+++ b/website/src/views/BaseView.ts
@@ -9,7 +9,7 @@ import {
 } from './ViewConstants.ts';
 import { type PageStateHandler } from './pageStateHandlers/PageStateHandler.ts';
 import { defaultBreadcrumbs } from '../layouts/Breadcrumbs.tsx';
-import { organismConfig } from '../types/Organism.ts';
+import { organismConfig, paths } from '../types/Organism.ts';
 import { CompareToBaselineStateHandler } from './pageStateHandlers/CompareToBaselinePageStateHandler.ts';
 import { CompareVariantsPageStateHandler } from './pageStateHandlers/CompareVariantsPageStateHandler.ts';
 import { SequencingEffortsStateHandler } from './pageStateHandlers/SequencingEffortsPageStateHandler.ts';
@@ -30,14 +30,11 @@ export abstract class BaseView<
         public readonly pageStateHandler: StateHandler,
         public readonly viewConstants: ViewConstants,
     ) {
-        this.pathname = `/${organismConfig[this.organismConstants.organism].pathFragment}/${this.viewConstants.pathFragment}`;
+        this.pathname = `${paths[this.organismConstants.organism].basePath}/${this.viewConstants.pathFragment}`;
         this.viewTitle = `${this.viewConstants.label} | ${organismConfig[this.organismConstants.organism].label} | GenSpectrum`;
         this.viewBreadcrumbEntries = [
             ...defaultBreadcrumbs,
-            {
-                name: organismConfig[this.organismConstants.organism].label,
-                href: `/${organismConfig[this.organismConstants.organism].pathFragment}`,
-            },
+            ...paths[this.organismConstants.organism].breadcrumbs,
             { name: this.viewConstants.label, href: this.pageStateHandler.getDefaultPageUrl() },
         ];
     }
@@ -49,15 +46,7 @@ export class GenericSingleVariantView<Constants extends OrganismConstants> exten
     SingleVariantPageStateHandler
 > {
     constructor(constants: Constants, defaultPageState: DatasetAndVariantData) {
-        super(
-            constants,
-            new SingleVariantPageStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
-            singleVariantViewConstants,
-        );
+        super(constants, new SingleVariantPageStateHandler(constants, defaultPageState), singleVariantViewConstants);
     }
 }
 
@@ -69,11 +58,7 @@ export class GenericSequencingEffortsView<Constants extends OrganismConstants> e
     constructor(constants: Constants, defaultPageState: DatasetAndVariantData) {
         super(
             constants,
-            new SequencingEffortsStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new SequencingEffortsStateHandler(constants, defaultPageState),
             sequencingEffortsViewConstants,
         );
     }
@@ -87,11 +72,7 @@ export class GenericCompareVariantsView<Constants extends OrganismConstants> ext
     constructor(constants: Constants, defaultPageState: CompareVariantsData) {
         super(
             constants,
-            new CompareVariantsPageStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareVariantsPageStateHandler(constants, defaultPageState),
             compareVariantsViewConstants,
         );
     }
@@ -105,11 +86,7 @@ export class GenericCompareToBaselineView<Constants extends OrganismConstants> e
     constructor(constants: Constants, defaultPageState: CompareToBaselineData) {
         super(
             constants,
-            new CompareToBaselineStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareToBaselineStateHandler(constants, defaultPageState),
             compareToBaselineViewConstants,
         );
     }

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -18,8 +18,8 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    getPathoplexusSequencingEffortsAggregatedVisualizations,
     getPathoplexusFilters,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
@@ -29,7 +29,7 @@ import {
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -116,11 +116,7 @@ export class CchfCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -32,7 +32,7 @@ import {
     setSearchFromTextFilters,
 } from './pageStateHandlers/PageStateHandler.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { SingleVariantPageStateHandler } from './pageStateHandlers/SingleVariantPageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -181,11 +181,7 @@ export class CovidAnalyzeSingleVariantView extends BaseView<
         const constants = new CovidConstants(organismsConfig);
         super(
             constants,
-            new CovidSingleVariantStateHandler(
-                constants,
-                makeDatasetAndVariantData(defaultDatasetFilter),
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CovidSingleVariantStateHandler(constants, makeDatasetAndVariantData(defaultDatasetFilter)),
             singleVariantViewConstants,
         );
     }
@@ -198,9 +194,8 @@ class CovidSingleVariantStateHandler
     constructor(
         protected readonly constants: CovidConstants,
         defaultPageState: CovidVariantData,
-        pathname: string,
     ) {
-        super(constants, defaultPageState, pathname);
+        super(constants, defaultPageState);
     }
 
     public override parsePageStateFromUrl(url: URL): CovidVariantData {
@@ -253,11 +248,7 @@ export class CovidCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -18,8 +18,8 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    getPathoplexusSequencingEffortsAggregatedVisualizations,
     getPathoplexusFilters,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
@@ -29,7 +29,7 @@ import {
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -111,11 +111,7 @@ export class EbolaSudanCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -18,8 +18,8 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    getPathoplexusSequencingEffortsAggregatedVisualizations,
     getPathoplexusFilters,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
@@ -29,7 +29,7 @@ import {
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -112,11 +112,7 @@ export class EbolaZaireCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getGenspectrumLoculusFilters,
     getGenSpectrumLoculusAggregatedVisualizations,
+    getGenspectrumLoculusFilters,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -30,7 +30,7 @@ import {
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOption.ts';
@@ -128,11 +128,7 @@ export class H1n1pdmCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getGenspectrumLoculusFilters,
     getGenSpectrumLoculusAggregatedVisualizations,
+    getGenspectrumLoculusFilters,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -30,7 +30,7 @@ import {
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOption.ts';
@@ -127,11 +127,7 @@ export class H3n2CompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getGenspectrumLoculusFilters,
     getGenSpectrumLoculusAggregatedVisualizations,
+    getGenspectrumLoculusFilters,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -30,7 +30,7 @@ import {
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOption.ts';
@@ -166,11 +166,7 @@ export class H5n1CompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -12,8 +12,8 @@ import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getGenspectrumLoculusFilters,
     getGenSpectrumLoculusAggregatedVisualizations,
+    getGenspectrumLoculusFilters,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -21,7 +21,7 @@ import {
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -112,11 +112,7 @@ export class InfluenzaACompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -12,8 +12,8 @@ import { BaseView, GenericSequencingEffortsView } from './BaseView.ts';
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getGenspectrumLoculusFilters,
     getGenSpectrumLoculusAggregatedVisualizations,
+    getGenspectrumLoculusFilters,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -21,7 +21,7 @@ import {
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -103,11 +103,7 @@ export class InfluenzaBCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -18,18 +18,18 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    type OrganismConstants,
-    getPathoplexusSequencingEffortsAggregatedVisualizations,
-    PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS,
-    PATHOPLEXUS_LOCATION_FIELDS,
-    LOCULUS_AUTHORS_FIELD,
-    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
-    PATHOPLEXUS_HOST_FIELD,
     getPathoplexusFilters,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
+    LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
+    LOCULUS_AUTHORS_FIELD,
+    type OrganismConstants,
+    PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS,
+    PATHOPLEXUS_HOST_FIELD,
+    PATHOPLEXUS_LOCATION_FIELDS,
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -151,11 +151,7 @@ export class MpoxCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -85,18 +85,18 @@ const mockDefaultPageState: CompareSideBySideData = {
 };
 
 describe('CompareSideBySideStateHandler', () => {
-    const handler = new CompareSideBySideStateHandler(mockConstants, mockDefaultPageState, 'testPath');
+    const handler = new CompareSideBySideStateHandler(mockConstants, mockDefaultPageState);
 
     it('should return the default page URL', () => {
         const url = handler.getDefaultPageUrl();
         expect(url).toBe(
-            '/testPath/compare-side-by-side?' + 'columns=2' + '&lineage%241=B.1.1.7' + '&date%241=Last+7+Days' + '&',
+            '/covid/compare-side-by-side?' + 'columns=2' + '&lineage%241=B.1.1.7' + '&date%241=Last+7+Days' + '&',
         );
     });
 
     it('should parse page state from URL, including variants', () => {
         const url = new URL(
-            'http://example.com/testPath/compare-side-by-side?' +
+            'http://example.com/covid/compare-side-by-side?' +
                 'columns=3' +
                 '&lineage%241=B.1.1.7&date%241=Last+7+Days' +
                 '&variantQuery%242=C234G' +
@@ -184,7 +184,7 @@ describe('CompareSideBySideStateHandler', () => {
 
         const url = handler.toUrl(pageState);
         expect(url).toBe(
-            '/testPath/compare-side-by-side?' +
+            '/covid/compare-side-by-side?' +
                 'columns=2' +
                 '&lineage%240=B.1.1.7&date%240=Last+7+Days' +
                 '&variantQuery%241=C234G&date%241=Last+7+Days' +
@@ -210,7 +210,7 @@ describe('CompareSideBySideStateHandler', () => {
         };
 
         const url = handler.toUrl(pageState);
-        expect(url).toBe('/testPath/compare-side-by-side?columns=1&');
+        expect(url).toBe('/covid/compare-side-by-side?columns=1&');
     });
 
     it('should convert variant filter to Lapis filter', () => {

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
@@ -1,5 +1,6 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
+import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareSideBySideData, type DatasetAndVariantData, getLineageFilterFields, type Id } from '../View.ts';
 import { compareSideBySideViewConstants } from '../ViewConstants.ts';
@@ -24,9 +25,8 @@ export class CompareSideBySideStateHandler implements PageStateHandler<CompareSi
     constructor(
         protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: CompareSideBySideData,
-        pathFragment: string,
     ) {
-        this.pathname = `/${pathFragment}/${compareSideBySideViewConstants.pathFragment}`;
+        this.pathname = `${paths[constants.organism].basePath}/${compareSideBySideViewConstants.pathFragment}`;
     }
 
     public getDefaultPageUrl() {

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -63,16 +63,16 @@ const mockDefaultPageState: CompareToBaselineData = {
 };
 
 describe('CompareToBaselinePageStateHandler', () => {
-    const handler = new CompareToBaselineStateHandler(mockConstants, mockDefaultPageState, 'testPath');
+    const handler = new CompareToBaselineStateHandler(mockConstants, mockDefaultPageState);
 
     it('should return the default page URL', () => {
         const url = handler.getDefaultPageUrl();
-        expect(url).toBe('/testPath/compare-to-baseline?date=Last+7+Days&');
+        expect(url).toBe('/covid/compare-to-baseline?date=Last+7+Days&');
     });
 
     it('should parse page state from URL, including variants', () => {
         const url = new URL(
-            'http://example.com/testPath/compare-to-baseline?' +
+            'http://example.com/covid/compare-to-baseline?' +
                 'columns=3' +
                 '&country=US&date=Last 7 Days' +
                 '&lineage=B.2.3.4&nucleotideMutations=C234G' +
@@ -150,7 +150,7 @@ describe('CompareToBaselinePageStateHandler', () => {
         };
         const url = handler.toUrl(pageState);
         expect(url).toBe(
-            '/testPath/compare-to-baseline?' +
+            '/covid/compare-to-baseline?' +
                 'columns=3' +
                 '&nucleotideMutations%240=D614G&lineage%240=B.1.1.7' +
                 '&aminoAcidMutations%241=S%3AA123T&lineage%241=A.1.2.3' +
@@ -174,7 +174,7 @@ describe('CompareToBaselinePageStateHandler', () => {
 
         const url = handler.toUrl(pageState);
 
-        expect(url).toBe('/testPath/compare-to-baseline');
+        expect(url).toBe('/covid/compare-to-baseline');
     });
 
     it('should convert page state with deleted id to URL', () => {
@@ -211,7 +211,7 @@ describe('CompareToBaselinePageStateHandler', () => {
         };
         const url = handler.toUrl(pageState);
         expect(url).toBe(
-            '/testPath/compare-to-baseline?' +
+            '/covid/compare-to-baseline?' +
                 'columns=2' +
                 '&nucleotideMutations%240=D614G&lineage%240=B.1.1.7' +
                 '&variantQuery%241=C234G' +

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
@@ -1,5 +1,6 @@
 import type { LapisFilter, NamedLapisFilter } from '@genspectrum/dashboard-components/util';
 
+import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareToBaselineData, type DatasetFilter, getLineageFilterFields, type VariantFilter } from '../View.ts';
 import { compareToBaselineViewConstants } from '../ViewConstants.ts';
@@ -26,9 +27,8 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
     constructor(
         protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: CompareToBaselineData,
-        pathFragment: string,
     ) {
-        this.pathname = `/${pathFragment}/${compareToBaselineViewConstants.pathFragment}`;
+        this.pathname = `${paths[constants.organism].basePath}/${compareToBaselineViewConstants.pathFragment}`;
     }
 
     public getDefaultPageUrl() {

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -59,16 +59,16 @@ const mockDefaultPageState: CompareVariantsData = {
 };
 
 describe('CompareVariantsPageStateHandler', () => {
-    const handler = new CompareVariantsPageStateHandler(mockConstants, mockDefaultPageState, 'testPath');
+    const handler = new CompareVariantsPageStateHandler(mockConstants, mockDefaultPageState);
 
     it('should return the default page URL', () => {
         const url = handler.getDefaultPageUrl();
-        expect(url).toBe('/testPath/compare-variants?date=Last+7+Days&');
+        expect(url).toBe('/covid/compare-variants?date=Last+7+Days&');
     });
 
     it('should parse page state from URL, including variants', () => {
         const url = new URL(
-            'http://example.com/testPath/compareVariants?' +
+            'http://example.com/covid/compareVariants?' +
                 'columns=3' +
                 '&country=US&date=Last 7 Days' +
                 '&lineage$0=B.1.1.7&nucleotideMutations$0=D614G' +
@@ -130,7 +130,7 @@ describe('CompareVariantsPageStateHandler', () => {
         };
         const url = handler.toUrl(pageState);
         expect(url).toBe(
-            '/testPath/compare-variants?' +
+            '/covid/compare-variants?' +
                 'columns=3' +
                 '&nucleotideMutations%240=D614G&lineage%240=B.1.1.7' +
                 '&aminoAcidMutations%241=S%3AA123T&lineage%241=A.1.2.3' +
@@ -167,7 +167,7 @@ describe('CompareVariantsPageStateHandler', () => {
         };
         const url = handler.toUrl(pageState);
         expect(url).toBe(
-            '/testPath/compare-variants?' +
+            '/covid/compare-variants?' +
                 'columns=2' +
                 '&nucleotideMutations%240=D614G&lineage%240=B.1.1.7' +
                 '&variantQuery%241=C234G' +
@@ -189,7 +189,7 @@ describe('CompareVariantsPageStateHandler', () => {
 
         const url = handler.toUrl(pageState);
 
-        expect(url).toBe('/testPath/compare-variants');
+        expect(url).toBe('/covid/compare-variants');
     });
 
     it('should convert dataset filter to Lapis filter', () => {

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
@@ -1,5 +1,6 @@
 import type { LapisFilter, NamedLapisFilter } from '@genspectrum/dashboard-components/util';
 
+import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareVariantsData, type DatasetFilter, getLineageFilterFields, type VariantFilter } from '../View.ts';
 import { compareVariantsViewConstants } from '../ViewConstants.ts';
@@ -26,9 +27,8 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
     constructor(
         protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: CompareVariantsData,
-        pathFragment: string,
     ) {
-        this.pathname = `/${pathFragment}/${compareVariantsViewConstants.pathFragment}`;
+        this.pathname = `${paths[constants.organism].basePath}/${compareVariantsViewConstants.pathFragment}`;
     }
 
     public getDefaultPageUrl() {

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -1,3 +1,4 @@
+import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { sequencingEffortsViewConstants } from '../ViewConstants.ts';
@@ -23,9 +24,8 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
     constructor(
         protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: PageState,
-        pathFragment: string,
     ) {
-        this.pathname = `/${pathFragment}/${sequencingEffortsViewConstants.pathFragment}`;
+        this.pathname = `${paths[constants.organism].basePath}/${sequencingEffortsViewConstants.pathFragment}`;
     }
 
     public parsePageStateFromUrl(url: URL): DatasetAndVariantData {

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -64,16 +64,16 @@ const mockDefaultPageState: DatasetAndVariantData = {
 };
 
 describe('SingleVariantPageStateHandler', () => {
-    const handler = new SingleVariantPageStateHandler(mockConstants, mockDefaultPageState, 'testPath');
+    const handler = new SingleVariantPageStateHandler(mockConstants, mockDefaultPageState);
 
     it('should return the default page URL', () => {
         const url = handler.getDefaultPageUrl();
-        expect(url).toBe('/testPath/single-variant?date=Last+7+Days&');
+        expect(url).toBe('/covid/single-variant?date=Last+7+Days&');
     });
 
     it('should parse page state from URL, including variants', () => {
         const url = new URL(
-            'http://example.com/testPath/single-variant?' +
+            'http://example.com/covid/single-variant?' +
                 'country=US&date=Last 7 Days' +
                 '&lineage=B.2.3.4&nucleotideMutations=C234G' +
                 '&',
@@ -109,7 +109,7 @@ describe('SingleVariantPageStateHandler', () => {
         };
         const url = handler.toUrl(pageState);
         expect(url).toBe(
-            '/testPath/single-variant?' +
+            '/covid/single-variant?' +
                 'country=US' +
                 '&date=Last+7+Days' +
                 '&nucleotideMutations=D614G&lineage=B.1.1.7' +
@@ -127,7 +127,7 @@ describe('SingleVariantPageStateHandler', () => {
             },
         };
         const url = handler.toUrl(pageState);
-        expect(url).toBe('/testPath/single-variant');
+        expect(url).toBe('/covid/single-variant');
     });
 
     it('should convert pageState to Lapis filter', () => {

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -1,5 +1,6 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
+import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { singleVariantViewConstants } from '../ViewConstants.ts';
@@ -25,9 +26,8 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
     constructor(
         protected readonly constants: OrganismConstants,
         protected readonly defaultPageState: PageState,
-        pathFragment: string,
     ) {
-        this.pathname = `/${pathFragment}/${singleVariantViewConstants.pathFragment}`;
+        this.pathname = `${paths[constants.organism].basePath}/${singleVariantViewConstants.pathFragment}`;
     }
 
     public parsePageStateFromUrl(url: URL): DatasetAndVariantData {

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -20,15 +20,15 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getGenspectrumLoculusFilters,
     getGenSpectrumLoculusAggregatedVisualizations,
+    getGenspectrumLoculusFilters,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -123,11 +123,7 @@ export class RsvACompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -20,15 +20,15 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getGenspectrumLoculusFilters,
     getGenSpectrumLoculusAggregatedVisualizations,
+    getGenspectrumLoculusFilters,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -123,11 +123,7 @@ export class RsvBCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -20,8 +20,8 @@ import {
 import {
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
-    getGenspectrumLoculusFilters,
     getGenSpectrumLoculusAggregatedVisualizations,
+    getGenspectrumLoculusFilters,
     INFLUENZA_ACCESSION_DOWNLOAD_FIELDS,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
@@ -30,7 +30,7 @@ import {
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import { fineGrainedDefaultDateRangeOptions } from '../util/defaultDateRangeOption.ts';
@@ -123,11 +123,7 @@ export class VictoriaCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -18,8 +18,8 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
-    getPathoplexusSequencingEffortsAggregatedVisualizations,
     getPathoplexusFilters,
+    getPathoplexusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
     LOCULUS_AUTHORS_FIELD,
     type OrganismConstants,
@@ -29,7 +29,7 @@ import {
 } from './OrganismConstants.ts';
 import { compareSideBySideViewConstants } from './ViewConstants.ts';
 import type { LineageFilterConfig } from '../components/pageStateSelectors/LineageFilterInput.tsx';
-import { organismConfig, Organisms } from '../types/Organism.ts';
+import { Organisms } from '../types/Organism.ts';
 import { type DataOrigin, dataOrigins } from '../types/dataOrigins.ts';
 import { CompareSideBySideStateHandler } from './pageStateHandlers/CompareSideBySidePageStateHandler.ts';
 import type { BaselineFilterConfig } from '../components/pageStateSelectors/BaselineSelector.tsx';
@@ -131,11 +131,7 @@ export class WestNileCompareSideBySideView extends BaseView<
 
         super(
             constants,
-            new CompareSideBySideStateHandler(
-                constants,
-                defaultPageState,
-                organismConfig[constants.organism].pathFragment,
-            ),
+            new CompareSideBySideStateHandler(constants, defaultPageState),
             compareSideBySideViewConstants,
         );
     }

--- a/website/tests/CompareVariantsPage.ts
+++ b/website/tests/CompareVariantsPage.ts
@@ -1,7 +1,7 @@
 import { expect, type Page } from '@playwright/test';
 
 import { ViewPage } from './ViewPage.ts';
-import { organismConfig } from '../src/types/Organism.ts';
+import { paths } from '../src/types/Organism.ts';
 import { type OrganismWithViewKey } from '../src/views/routing';
 import { compareVariantsViewKey } from '../src/views/viewKeys';
 
@@ -18,7 +18,7 @@ export class CompareVariantsPage extends ViewPage {
     }
 
     public async goto(organism: OrganismViewCompareVariant) {
-        await this.page.goto(`/${organismConfig[organism].pathFragment}/compare-variants`);
+        await this.page.goto(`${paths[organism].basePath}/compare-variants`);
     }
 
     public async addVariant(options: { lineage?: string; lineageFieldPlaceholder?: string; mutation?: string }) {

--- a/website/tests/SequencingEffortsPage.ts
+++ b/website/tests/SequencingEffortsPage.ts
@@ -1,11 +1,11 @@
 import { expect } from '@playwright/test';
 
 import { ViewPage } from './ViewPage.ts';
-import { type Organism, organismConfig } from '../src/types/Organism.ts';
+import { type Organism, paths } from '../src/types/Organism.ts';
 
 export class SequencingEffortsPage extends ViewPage {
     public async goto(organism: Organism) {
-        await this.page.goto(`/${organismConfig[organism].pathFragment}/sequencing-efforts`);
+        await this.page.goto(`${paths[organism].basePath}/sequencing-efforts`);
     }
 
     public async selectLocation(location: string) {


### PR DESCRIPTION
Resolves #653 
### Summary

- uses new paths object to define paths to the pages
- I put it not in `OrganismConstants`, since we need the breadcrumbs also on the index pages, where they are not known

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

![grafik](https://github.com/user-attachments/assets/75bb9529-d4fd-4b95-a6d3-f459e4457a92)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
