### PR TITLE
fix(components): components grid layout

### DIFF
--- a/website/src/components/ComponentWrapper.astro
+++ b/website/src/components/ComponentWrapper.astro
@@ -21,11 +21,11 @@ const { title, height, linkSuffix, collapsible } = Astro.props;
             </div>
         </details>
     ) : (
-        <>
+        <div>
             <ComponentHeadline title={title} linkSuffix={linkSuffix} collapsible={collapsible} />
             <div style={{ height }}>
                 <slot />
             </div>
-        </>
+        </div>
     )
 }


### PR DESCRIPTION

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
It seems that #654 accidentally broke the grid layout

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
Before:
![image](https://github.com/user-attachments/assets/4f712334-9b11-4dd4-9e5b-990f18b4837a)


After:
![image](https://github.com/user-attachments/assets/d60022a0-ef3f-4cae-8350-3a6b3a14033f)
