### PR TITLE
feat(website): add completeness filter

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@astrojs/node": "^9.2.1",
                 "@auth/core": "^0.37.4",
-                "@genspectrum/dashboard-components": "^0.19.3",
+                "@genspectrum/dashboard-components": "^0.19.5",
                 "@tanstack/react-query": "^5.74.4",
                 "astro": "^5.7.5",
                 "auth-astro": "^4.2.0",
@@ -1494,21 +1494,21 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.6.9",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-            "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
+            "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/utils": "^0.2.9"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.6.13",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-            "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz",
+            "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/core": "^1.6.0",
+                "@floating-ui/core": "^1.7.0",
                 "@floating-ui/utils": "^0.2.9"
             }
         },
@@ -1519,9 +1519,9 @@
             "license": "MIT"
         },
         "node_modules/@genspectrum/dashboard-components": {
-            "version": "0.19.3",
-            "resolved": "https://registry.npmjs.org/@genspectrum/dashboard-components/-/dashboard-components-0.19.3.tgz",
-            "integrity": "sha512-IqiNsX+umI6viHPducOXvOfPgZVFGmvh+5n+/D2zVMplNmk2MH8dBKgGoOb1pggCGyqEA/g8Ii52pCdpIdw2Tw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@genspectrum/dashboard-components/-/dashboard-components-0.19.5.tgz",
+            "integrity": "sha512-9n2gcLhbNauZ9ml3NACb6MEiafWfe3pIUkTf2JU6Xvuu9VS0SLEYeR8UQnq3qS3dD89KiC0TBtP0YF6BFdsThg==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.5",
@@ -3108,9 +3108,9 @@
             }
         },
         "node_modules/@tanstack/table-core": {
-            "version": "8.21.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.2.tgz",
-            "integrity": "sha512-uvXk/U4cBiFMxt+p9/G7yUWI/UbHYbyghLCjlpWZ3mLeIZiUBSKcUnw9UnKkdRz7Z/N4UBuFLWQdJCjUe7HjvA==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+            "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -4896,9 +4896,9 @@
             }
         },
         "node_modules/chart.js": {
-            "version": "4.4.8",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
-            "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+            "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
             "license": "MIT",
             "dependencies": {
                 "@kurkle/color": "^0.3.0"

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@astrojs/node": "^9.2.1",
         "@auth/core": "^0.37.4",
-        "@genspectrum/dashboard-components": "^0.19.3",
+        "@genspectrum/dashboard-components": "^0.19.5",
         "@tanstack/react-query": "^5.74.4",
         "astro": "^5.7.5",
         "auth-astro": "^4.2.0",

--- a/website/src/components/genspectrum/GsNumerRangeFilter.tsx
+++ b/website/src/components/genspectrum/GsNumerRangeFilter.tsx
@@ -1,0 +1,52 @@
+import type { NumberRange } from '@genspectrum/dashboard-components/util';
+import { useEffect, useRef } from 'react';
+import '@genspectrum/dashboard-components/components';
+
+export function GsNumerRangeFilter({
+    lapisField,
+    width,
+    onNumberRangeChanged = () => {},
+    value,
+    sliderMin,
+    sliderMax,
+    sliderStep,
+}: {
+    lapisField: string;
+    width?: string;
+    onNumberRangeChanged?: (numberRange: NumberRange) => void;
+    value?: NumberRange;
+    sliderMin?: number;
+    sliderMax?: number;
+    sliderStep?: number;
+}) {
+    const numberRangeFilterRef = useRef<HTMLElement>();
+
+    useEffect(() => {
+        const handleNumberRangeFilterChange = (event: CustomEvent) => {
+            onNumberRangeChanged(event.detail);
+        };
+
+        const currentInputRef = numberRangeFilterRef.current;
+        if (currentInputRef !== undefined) {
+            currentInputRef.addEventListener('gs-number-range-value-changed', handleNumberRangeFilterChange);
+        }
+
+        return () => {
+            if (currentInputRef !== undefined) {
+                currentInputRef.removeEventListener('gs-number-range-value-changed', handleNumberRangeFilterChange);
+            }
+        };
+    }, [onNumberRangeChanged]);
+
+    return (
+        <gs-number-range-filter
+            ref={numberRangeFilterRef}
+            lapisField={lapisField}
+            width={width}
+            value={JSON.stringify(value ?? {})}
+            sliderMin={sliderMin}
+            sliderMax={sliderMax}
+            sliderStep={sliderStep}
+        ></gs-number-range-filter>
+    );
+}

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -4,6 +4,7 @@ import type { DatasetFilter } from '../../views/View.ts';
 import { locationFieldsToFilterIdentifier } from '../../views/pageStateHandlers/PageStateHandler.ts';
 import { GsDateRangeFilter } from '../genspectrum/GsDateRangeFilter.tsx';
 import { GsLocationFilter } from '../genspectrum/GsLocationFilter.tsx';
+import { GsNumerRangeFilter } from '../genspectrum/GsNumerRangeFilter.tsx';
 import { GsTextFilter } from '../genspectrum/GsTextFilter.tsx';
 
 export type LocationFilterConfig = {
@@ -25,12 +26,21 @@ export type TextInputConfig = {
     label?: string;
 };
 
+export type NumberRangeFilterConfig = {
+    lapisField: string;
+    label?: string;
+    sliderMin?: number;
+    sliderMax?: number;
+    sliderStep?: number;
+};
+
 export type BaselineFilterConfig =
     | ({
           type: 'date';
       } & DateRangeFilterConfig)
     | ({ type: 'text' } & TextInputConfig)
-    | ({ type: 'location' } & LocationFilterConfig);
+    | ({ type: 'location' } & LocationFilterConfig)
+    | ({ type: 'number' } & NumberRangeFilterConfig);
 
 export function BaselineSelector({
     baselineFilterConfigs,
@@ -118,6 +128,31 @@ export function BaselineSelector({
                                     placeholderText={config.placeholderText}
                                     lapisFilter={lapisFilter}
                                 ></GsLocationFilter>
+                            </label>
+                        );
+                    }
+                    case 'number': {
+                        return (
+                            <label className='form-control' key={`$label${config.lapisField}`}>
+                                <div className='label'>
+                                    <span className='label-text'>{config.label ?? config.lapisField}</span>
+                                </div>
+                                <GsNumerRangeFilter
+                                    lapisField={config.lapisField}
+                                    sliderMin={config.sliderMin}
+                                    sliderMax={config.sliderMax}
+                                    sliderStep={config.sliderStep}
+                                    value={datasetFilter.numberFilters[config.lapisField]}
+                                    onNumberRangeChanged={(newRange) => {
+                                        setDatasetFilter({
+                                            ...datasetFilter,
+                                            numberFilters: {
+                                                ...datasetFilter.numberFilters,
+                                                [config.lapisField]: newRange,
+                                            },
+                                        });
+                                    }}
+                                />
                             </label>
                         );
                     }

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -34,6 +34,7 @@ export function CompareSideBySidePageStateSelector({
                 locationFilters: {},
                 dateFilters: {},
                 textFilters: {},
+                numberFilters: {},
             },
             variantFilter: {},
         };

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.spec.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.spec.tsx
@@ -14,6 +14,7 @@ describe('SingleVariantPageStateSelector', () => {
                 locationFilters: {},
                 dateFilters: {},
                 textFilters: {},
+                numberFilters: {},
             },
             variantFilter: {},
             collectionId: 5,

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -251,6 +251,15 @@ export function getPathoplexusFilters({
     ];
 }
 
+export const COMPLETENESS_FILTER = {
+    lapisField: 'completeness',
+    type: 'number' as const,
+    label: 'Completeness',
+    sliderMin: 0,
+    sliderMax: 1,
+    sliderStep: 0.01,
+};
+
 export const GENPSECTRUM_LOCULUS_HOST_FIELD = 'hostNameScientific';
 
 export function getGenspectrumLoculusFilters({

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -1,4 +1,4 @@
-import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
+import type { DateRangeOption, NumberRange } from '@genspectrum/dashboard-components/util';
 
 import type { OrganismConstants } from './OrganismConstants.ts';
 import { type ViewConstants } from './ViewConstants';
@@ -11,6 +11,7 @@ export type DatasetFilter = {
     locationFilters: LocationFilterState;
     textFilters: TextFilterState;
     dateFilters: DateFilterState;
+    numberFilters: NumberFilterState;
 };
 
 export type LocationFilterState = {
@@ -23,6 +24,10 @@ export type DateFilterState = {
 
 export type TextFilterState = {
     [key: string]: string | undefined;
+};
+
+export type NumberFilterState = {
+    [key: string]: NumberRange | undefined;
 };
 
 export type Dataset = {

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -97,6 +97,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,
     },
+    numberFilters: {},
 };
 
 export class CchfAnalyzeSingleVariantView extends GenericSingleVariantView<CchfConstants> {

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -168,6 +168,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [mainDateFilterColumn]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export type CovidVariantData = DatasetAndVariantData & { collectionId?: number };

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -18,6 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
+    COMPLETENESS_FILTER,
     getPathoplexusFilters,
     getPathoplexusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
@@ -45,6 +46,7 @@ class EbolaSudanConstants implements OrganismConstants {
             dateRangeOptions: defaultDateRangeOptions,
             earliestDate,
         }),
+        COMPLETENESS_FILTER,
     ];
     public readonly mainDateField: string;
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
@@ -92,6 +94,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,
     },
+    numberFilters: {},
 };
 
 export class EbolaSudanAnalyzeSingleVariantView extends GenericSingleVariantView<EbolaSudanConstants> {

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -18,6 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
+    COMPLETENESS_FILTER,
     getPathoplexusFilters,
     getPathoplexusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
@@ -45,6 +46,7 @@ class EbolaZaireConstants implements OrganismConstants {
             dateRangeOptions: defaultDateRangeOptions,
             earliestDate,
         }),
+        COMPLETENESS_FILTER,
     ];
 
     public readonly mainDateField: string;
@@ -93,6 +95,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.allTimes,
     },
+    numberFilters: {},
 };
 
 export class EbolaZaireAnalyzeSingleVariantView extends GenericSingleVariantView<EbolaZaireConstants> {

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -101,6 +101,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class H1n1pdmAnalyzeSingleVariantView extends GenericSingleVariantView<H1n1pdmConstants> {

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -101,6 +101,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class H3n2AnalyzeSingleVariantView extends GenericSingleVariantView<H3n2Constants> {

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -140,6 +140,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class H5n1AnalyzeSingleVariantView extends GenericSingleVariantView<H5n1Constants> {

--- a/website/src/views/helpers.spec.ts
+++ b/website/src/views/helpers.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { getNumberRangeFromSearch, setSearchFromNumberRange } from './helpers.ts';
+
+describe('getNumberRangeFromSearch', () => {
+    it('should return undefined, when field is not in search param', () => {
+        const search = new Map<string, string>([
+            ['someLapisFieldFrom', '2'],
+            ['someLapisFieldTo', '3'],
+        ]);
+
+        const result = getNumberRangeFromSearch(search, 'someOtherLapisField');
+
+        expect(result).to.be.equal(undefined);
+    });
+
+    it('should extract number range from url', () => {
+        const search = new Map<string, string>([
+            ['someLapisFieldFrom', '2.1'],
+            ['someLapisFieldTo', '3'],
+        ]);
+
+        const result = getNumberRangeFromSearch(search, 'someLapisField');
+
+        expect(result).to.deep.equal({ min: 2.1, max: 3 });
+    });
+
+    it('should extract min from url, when only min is provided', () => {
+        const search = new Map<string, string>([['someLapisFieldFrom', '2']]);
+
+        const result = getNumberRangeFromSearch(search, 'someLapisField');
+
+        expect(result).to.deep.equal({ min: 2, max: undefined });
+    });
+
+    it('should extract max from url, when only min is provided', () => {
+        const search = new Map<string, string>([['someLapisFieldTo', '3']]);
+
+        const result = getNumberRangeFromSearch(search, 'someLapisField');
+
+        expect(result).to.deep.equal({ min: undefined, max: 3 });
+    });
+
+    it('should not parse values, that are not numbers', () => {
+        const search = new Map<string, string>([['someLapisFieldFrom', 'notANumber']]);
+
+        const result = getNumberRangeFromSearch(search, 'someLapisField');
+
+        expect(result).to.deep.equal(undefined);
+    });
+});
+
+describe('setSearchFromNumberRange', () => {
+    it('should set search from number range', () => {
+        const numberRange = { min: 2.1, max: 3 };
+
+        const search = new URLSearchParams();
+
+        setSearchFromNumberRange(search, 'someLapisField', numberRange);
+
+        expect(search.get('someLapisFieldFrom')).toEqual('2.1');
+        expect(search.get('someLapisFieldTo')).toEqual('3');
+    });
+
+    it('should set search with min, when min is defined but max is not', () => {
+        const numberRange = { min: 2.1 };
+
+        const search = new URLSearchParams();
+
+        setSearchFromNumberRange(search, 'someLapisField', numberRange);
+
+        expect(search.get('someLapisFieldFrom')).toEqual('2.1');
+        expect(search.get('someLapisFieldTo')).toEqual(null);
+    });
+
+    it('should set search with max, when max is defined but min is not', () => {
+        const numberRange = { max: 3 };
+
+        const search = new URLSearchParams();
+
+        setSearchFromNumberRange(search, 'someLapisField', numberRange);
+
+        expect(search.get('someLapisFieldFrom')).toEqual(null);
+        expect(search.get('someLapisFieldTo')).toEqual('3');
+    });
+});

--- a/website/src/views/helpers.ts
+++ b/website/src/views/helpers.ts
@@ -1,4 +1,4 @@
-import type { DateRangeOption } from '@genspectrum/dashboard-components/util';
+import type { DateRangeOption, NumberRange } from '@genspectrum/dashboard-components/util';
 
 import type { VariantFilter } from './View.ts';
 import type { MutationFilter } from '../components/genspectrum/GsMutationFilter.tsx';
@@ -41,6 +41,17 @@ export const setSearchFromDateRange = (
         search.set(name, serializedValue);
     }
 };
+
+export function setSearchFromNumberRange(search: URLSearchParams, name: string, numberRange: NumberRange | undefined) {
+    if (numberRange !== undefined) {
+        if (numberRange.min) {
+            search.set(`${name}From`, String(numberRange.min));
+        }
+        if (numberRange.max) {
+            search.set(`${name}To`, String(numberRange.max));
+        }
+    }
+}
 
 export const getStringFromSearch = (
     search: URLSearchParams | Map<string, string>,
@@ -85,6 +96,23 @@ export const getDateRangeFromSearch = (
     }
     return undefined;
 };
+
+export function getNumberRangeFromSearch(
+    search: URLSearchParams | Map<string, string>,
+    name: string,
+): NumberRange | undefined {
+    const minString = search.get(`${name}From`);
+    const maxString = search.get(`${name}To`);
+
+    const min = minString ? Number(minString) : undefined;
+    const max = maxString ? Number(maxString) : undefined;
+
+    if (min || max) {
+        return { min, max };
+    }
+
+    return undefined;
+}
 
 export type LapisLocation = Record<string, string | undefined>;
 

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -86,6 +86,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class InfluenzaACompareSideBySideView extends BaseView<

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -79,6 +79,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class InfluenzaBCompareSideBySideView extends BaseView<

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -18,6 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
+    COMPLETENESS_FILTER,
     getPathoplexusFilters,
     getPathoplexusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
@@ -79,6 +80,7 @@ class MpoxConstants implements OrganismConstants {
             ],
             earliestDate: '1960-01-01',
         }),
+        COMPLETENESS_FILTER,
     ];
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
@@ -121,6 +123,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class MpoxAnalyzeSingleVariantView extends GenericSingleVariantView<MpoxConstants> {

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -58,6 +58,7 @@ const mockDefaultPageState: CompareSideBySideData = {
                     locationFilters: {},
                     dateFilters: {},
                     textFilters: {},
+                    numberFilters: {},
                 },
                 variantFilter: {
                     lineages: {},
@@ -74,6 +75,7 @@ const mockDefaultPageState: CompareSideBySideData = {
                         date: mockDateRangeOption,
                     },
                     textFilters: {},
+                    numberFilters: {},
                 },
                 variantFilter: {
                     lineages: { lineage: 'B.1.1.7' },
@@ -112,6 +114,7 @@ describe('CompareSideBySideStateHandler', () => {
                 locationFilters: {},
                 dateFilters: {},
                 textFilters: {},
+                numberFilters: {},
             },
             variantFilter: {
                 lineages: {},
@@ -126,6 +129,7 @@ describe('CompareSideBySideStateHandler', () => {
                 },
                 textFilters: {},
                 locationFilters: {},
+                numberFilters: {},
             },
             variantFilter: {
                 lineages: {
@@ -140,6 +144,7 @@ describe('CompareSideBySideStateHandler', () => {
                 dateFilters: {},
                 locationFilters: {},
                 textFilters: {},
+                numberFilters: {},
             },
             variantFilter: {
                 variantQuery: 'C234G',
@@ -157,6 +162,7 @@ describe('CompareSideBySideStateHandler', () => {
                             locationFilters: {},
                             dateFilters: { date: mockDateRangeOption },
                             textFilters: {},
+                            numberFilters: {},
                         },
                         variantFilter: {
                             lineages: { lineage: 'B.1.1.7' },
@@ -171,6 +177,7 @@ describe('CompareSideBySideStateHandler', () => {
                             locationFilters: {},
                             dateFilters: { date: mockDateRangeOption },
                             textFilters: {},
+                            numberFilters: {},
                         },
                         variantFilter: {
                             lineages: { lineage: 'B.1.1.7' },
@@ -202,6 +209,7 @@ describe('CompareSideBySideStateHandler', () => {
                             locationFilters: {},
                             dateFilters: { date: null },
                             textFilters: {},
+                            numberFilters: {},
                         },
                         variantFilter: {},
                     },
@@ -222,6 +230,7 @@ describe('CompareSideBySideStateHandler', () => {
                 textFilters: {
                     someTextField: 'SomeText',
                 },
+                numberFilters: {},
             },
             {
                 lineages: { lineage: 'B.1.1.7' },
@@ -247,6 +256,7 @@ describe('CompareSideBySideStateHandler', () => {
                 textFilters: {
                     someTextField: 'SomeText',
                 },
+                numberFilters: {},
             },
             {
                 lineages: { lineage: 'B.1.1.7' },

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.ts
@@ -10,10 +10,12 @@ import {
     type PageStateHandler,
     parseDateRangesFromUrl,
     parseLocationFiltersFromUrl,
+    parseNumberRangeFilterFromUrl,
     parseTextFiltersFromUrl,
     searchParamsFromFilterMap,
     setSearchFromDateFilters,
     setSearchFromLocationFilters,
+    setSearchFromNumberRangeFilters,
     setSearchFromTextFilters,
     toLapisFilterWithoutVariant,
 } from './PageStateHandler.ts';
@@ -108,6 +110,7 @@ export class CompareSideBySideStateHandler implements PageStateHandler<CompareSi
         setSearchFromLocationFilters(searchOfFilter, filter, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(searchOfFilter, filter, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(searchOfFilter, filter, this.constants.baselineFilterConfigs);
+        setSearchFromNumberRangeFilters(searchOfFilter, filter, this.constants.baselineFilterConfigs);
     }
 
     protected getEmptyColumnData(): DatasetAndVariantData {
@@ -116,6 +119,7 @@ export class CompareSideBySideStateHandler implements PageStateHandler<CompareSi
                 locationFilters: {},
                 textFilters: {},
                 dateFilters: {},
+                numberFilters: {},
             },
             variantFilter: {
                 lineages: {},
@@ -130,6 +134,7 @@ export class CompareSideBySideStateHandler implements PageStateHandler<CompareSi
                 locationFilters: parseLocationFiltersFromUrl(filterParams, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(filterParams, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(filterParams, this.constants.baselineFilterConfigs),
+                numberFilters: parseNumberRangeFilterFromUrl(filterParams, this.constants.baselineFilterConfigs),
             },
             variantFilter: getLapisVariantQuery(filterParams, getLineageFilterFields(this.constants.lineageFilters)),
         };

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -55,6 +55,7 @@ const mockDefaultPageState: CompareToBaselineData = {
         locationFilters: {},
         dateFilters: { date: mockDateRangeOption },
         textFilters: {},
+        numberFilters: {},
     },
     baselineFilter: {
         lineages: {},
@@ -138,6 +139,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                 locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
+                numberFilters: {},
             },
             baselineFilter: {
                 lineages: {
@@ -168,6 +170,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                 locationFilters: {},
                 dateFilters: { date: null },
                 textFilters: {},
+                numberFilters: {},
             },
             baselineFilter: {},
         };
@@ -199,6 +202,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                 locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
+                numberFilters: {},
             },
             baselineFilter: {
                 lineages: {

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
@@ -10,10 +10,12 @@ import {
     type PageStateHandler,
     parseDateRangesFromUrl,
     parseLocationFiltersFromUrl,
+    parseNumberRangeFilterFromUrl,
     parseTextFiltersFromUrl,
     searchParamsFromFilterMap,
     setSearchFromDateFilters,
     setSearchFromLocationFilters,
+    setSearchFromNumberRangeFilters,
     setSearchFromTextFilters,
     toDisplayName,
     toLapisFilterFromVariant,
@@ -49,6 +51,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
                 locationFilters: parseLocationFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
+                numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
             },
             variants,
             baselineFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
@@ -63,6 +66,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
         setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
 
         setSearchFromLapisVariantQuery(
             search,

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -55,6 +55,7 @@ const mockDefaultPageState: CompareVariantsData = {
         locationFilters: {},
         dateFilters: { date: mockDateRangeOption },
         textFilters: {},
+        numberFilters: {},
     },
 };
 
@@ -126,6 +127,7 @@ describe('CompareVariantsPageStateHandler', () => {
                 locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
+                numberFilters: {},
             },
         };
         const url = handler.toUrl(pageState);
@@ -163,6 +165,7 @@ describe('CompareVariantsPageStateHandler', () => {
                 locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
+                numberFilters: {},
             },
         };
         const url = handler.toUrl(pageState);
@@ -184,6 +187,7 @@ describe('CompareVariantsPageStateHandler', () => {
                 locationFilters: {},
                 dateFilters: { date: null },
                 textFilters: {},
+                numberFilters: {},
             },
         };
 

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
@@ -10,10 +10,12 @@ import {
     type PageStateHandler,
     parseDateRangesFromUrl,
     parseLocationFiltersFromUrl,
+    parseNumberRangeFilterFromUrl,
     parseTextFiltersFromUrl,
     searchParamsFromFilterMap,
     setSearchFromDateFilters,
     setSearchFromLocationFilters,
+    setSearchFromNumberRangeFilters,
     setSearchFromTextFilters,
     toDisplayName,
     toLapisFilterFromVariant,
@@ -50,6 +52,7 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
                 locationFilters: parseLocationFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
+                numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
             },
             variants,
         };
@@ -63,6 +66,7 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
         setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
 
         return formatUrl(this.pathname, search);
     }

--- a/website/src/views/pageStateHandlers/PageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.spec.ts
@@ -65,6 +65,7 @@ describe('setSearchFromLocationFilters', () => {
                 },
                 textFilters: {},
                 dateFilters: {},
+                numberFilters: {},
             },
         } satisfies Dataset;
 
@@ -96,6 +97,7 @@ describe('setSearchFromLocationFilters', () => {
                 },
                 textFilters: {},
                 dateFilters: {},
+                numberFilters: {},
             },
         } satisfies Dataset;
 
@@ -134,6 +136,7 @@ describe('setSearchFromLocationFilters', () => {
                 },
                 textFilters: {},
                 dateFilters: {},
+                numberFilters: {},
             },
         } satisfies Dataset;
 

--- a/website/src/views/pageStateHandlers/PageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.ts
@@ -1,13 +1,15 @@
-import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
+import type { DateRangeOption, LapisFilter, NumberRange } from '@genspectrum/dashboard-components/util';
 
 import type { BaselineFilterConfig } from '../../components/pageStateSelectors/BaselineSelector.tsx';
 import { type Dataset, type Id, type VariantFilter } from '../View.ts';
 import {
     getDateRangeFromSearch,
     getLapisLocationFromSearch,
+    getNumberRangeFromSearch,
     getStringFromSearch,
     type LapisLocation,
     setSearchFromDateRange,
+    setSearchFromNumberRange,
     setSearchFromString,
 } from '../helpers.ts';
 
@@ -66,10 +68,37 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: string | undefined },
     );
 
+    const numberRangeFilters = Object.entries(pageState.datasetFilter.numberFilters).reduce(
+        (acc, [lapisField, numberRange]) => {
+            if (numberRange === undefined) {
+                return acc;
+            }
+
+            const fromValue = numberRange.min
+                ? {
+                      [`${lapisField}From`]: String(numberRange.min),
+                  }
+                : {};
+            const toValue = numberRange.max
+                ? {
+                      [`${lapisField}To`]: String(numberRange.max),
+                  }
+                : {};
+
+            return {
+                ...acc,
+                ...fromValue,
+                ...toValue,
+            };
+        },
+        {} as { [key: string]: string | undefined },
+    );
+
     return {
         ...locationFilters,
         ...dateFilters,
         ...textFilters,
+        ...numberRangeFilters,
         ...additionalFilters,
     };
 }
@@ -123,6 +152,28 @@ export function parseTextFiltersFromUrl(
             },
             {} as {
                 [key: string]: string | undefined;
+            },
+        ) ?? {}
+    );
+}
+
+export function parseNumberRangeFilterFromUrl(
+    search: URLSearchParams | Map<string, string>,
+    baselineFilterConfigs: BaselineFilterConfig[] | undefined,
+) {
+    const numberRangeFilterConfigs = baselineFilterConfigs?.filter((config) => config.type === 'number');
+
+    return (
+        numberRangeFilterConfigs?.reduce(
+            (acc, config) => {
+                const numberRange = getNumberRangeFromSearch(search, config.lapisField);
+                return {
+                    ...acc,
+                    [config.lapisField]: numberRange,
+                };
+            },
+            {} as {
+                [key: string]: NumberRange | undefined;
             },
         ) ?? {}
     );
@@ -201,6 +252,19 @@ export function setSearchFromLocationFilters(
 
             setSearchFromString(search, locationField, value);
         });
+    });
+}
+
+export function setSearchFromNumberRangeFilters(
+    search: URLSearchParams,
+    pageState: Dataset,
+    baselineFilterConfigs: BaselineFilterConfig[] | undefined,
+) {
+    const numberRangeFilterConfigs = baselineFilterConfigs?.filter((config) => config.type === 'number');
+
+    numberRangeFilterConfigs?.forEach((config) => {
+        const value = pageState.datasetFilter.numberFilters[config.lapisField];
+        setSearchFromNumberRange(search, config.lapisField, value);
     });
 }
 

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -7,9 +7,11 @@ import {
     type PageStateHandler,
     parseDateRangesFromUrl,
     parseLocationFiltersFromUrl,
+    parseNumberRangeFilterFromUrl,
     parseTextFiltersFromUrl,
     setSearchFromDateFilters,
     setSearchFromLocationFilters,
+    setSearchFromNumberRangeFilters,
     setSearchFromTextFilters,
     toLapisFilterFromVariant,
     toLapisFilterWithoutVariant,
@@ -36,6 +38,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
                 locationFilters: parseLocationFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
+                numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
             },
             variantFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
         };
@@ -46,6 +49,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
         setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
 
         setSearchFromLapisVariantQuery(
             search,

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -56,6 +56,7 @@ const mockDefaultPageState: DatasetAndVariantData = {
             date: mockDateRangeOption,
         },
         textFilters: {},
+        numberFilters: {},
     },
     variantFilter: {
         lineages: {},
@@ -105,6 +106,7 @@ describe('SingleVariantPageStateHandler', () => {
                 locationFilters: { 'country,region': { country: 'US' } },
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
+                numberFilters: {},
             },
         };
         const url = handler.toUrl(pageState);
@@ -124,6 +126,7 @@ describe('SingleVariantPageStateHandler', () => {
                 locationFilters: {},
                 dateFilters: { date: null },
                 textFilters: {},
+                numberFilters: {},
             },
         };
         const url = handler.toUrl(pageState);

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -9,9 +9,11 @@ import {
     type PageStateHandler,
     parseDateRangesFromUrl,
     parseLocationFiltersFromUrl,
+    parseNumberRangeFilterFromUrl,
     parseTextFiltersFromUrl,
     setSearchFromDateFilters,
     setSearchFromLocationFilters,
+    setSearchFromNumberRangeFilters,
     setSearchFromTextFilters,
     toLapisFilterFromVariant,
     toLapisFilterWithoutVariant,
@@ -38,6 +40,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
                 locationFilters: parseLocationFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
+                numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
             },
             variantFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
         };
@@ -48,6 +51,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
         setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
 
         setSearchFromLapisVariantQuery(
             search,

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -18,6 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
+    COMPLETENESS_FILTER,
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenSpectrumLoculusAggregatedVisualizations,
@@ -56,6 +57,7 @@ class RsvAConstants implements OrganismConstants {
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,
             earliestDate,
         }),
+        COMPLETENESS_FILTER,
     ];
     public readonly hostField: string = GENPSECTRUM_LOCULUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
@@ -97,6 +99,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class RsvAAnalyzeSingleVariantView extends GenericSingleVariantView<RsvAConstants> {

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -18,6 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
+    COMPLETENESS_FILTER,
     GENPSECTRUM_LOCULUS_HOST_FIELD,
     GENSPECTRUM_LOCULUS_LOCATION_FIELDS,
     getGenSpectrumLoculusAggregatedVisualizations,
@@ -56,6 +57,7 @@ class RsvBConstants implements OrganismConstants {
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,
             earliestDate,
         }),
+        COMPLETENESS_FILTER,
     ];
     public readonly hostField: string = GENPSECTRUM_LOCULUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
@@ -97,6 +99,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class RsvBAnalyzeSingleVariantView extends GenericSingleVariantView<RsvBConstants> {

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -97,6 +97,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class VictoriaAnalyzeSingleVariantView extends GenericSingleVariantView<VictoriaConstants> {

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -18,6 +18,7 @@ import {
     GenericSingleVariantView,
 } from './BaseView.ts';
 import {
+    COMPLETENESS_FILTER,
     getPathoplexusFilters,
     getPathoplexusSequencingEffortsAggregatedVisualizations,
     LOCULUS_AUTHORS_AFFILIATIONS_FIELD,
@@ -62,6 +63,7 @@ class WestNileConstants implements OrganismConstants {
             type: 'text' as const,
             label: 'Collection device',
         },
+        COMPLETENESS_FILTER,
     ];
     public readonly useAdvancedQuery = false;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
@@ -105,6 +107,7 @@ const defaultDatasetFilter: DatasetFilter = {
     dateFilters: {
         [PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN]: dateRangeOptionPresets.lastYear,
     },
+    numberFilters: {},
 };
 
 export class WestNileAnalyzeSingleVariantView extends GenericSingleVariantView<WestNileConstants> {


### PR DESCRIPTION
Resolves #637

### Summary

- uses the gs-number-range-filter
- adds new filter type "number"
- adds the new filter to multiple organisms (west-nile, rsvA, rsvB, mpox, ebola sudan, ebola zaire), which have one field named "completeness". Most other organisms have more than one field, eg "completeness_seg1", etc. 


<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
![grafik](https://github.com/user-attachments/assets/a1e254c3-ac0a-4aa4-b9e6-919a8a4103c3)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
