### PR TITLE
chore(website): use event name constants instead of string

### DIFF
--- a/website/src/components/genspectrum/GsDateRangeFilter.tsx
+++ b/website/src/components/genspectrum/GsDateRangeFilter.tsx
@@ -1,5 +1,9 @@
 import '@genspectrum/dashboard-components/components';
-import { type DateRangeOption, type DateRangeOptionChangedEvent } from '@genspectrum/dashboard-components/util';
+import {
+    type DateRangeOption,
+    type DateRangeOptionChangedEvent,
+    gsEventNames,
+} from '@genspectrum/dashboard-components/util';
 import { useEffect, useRef } from 'react';
 
 import { CustomDateRangeLabel } from '../../types/DateWindow.ts';
@@ -22,6 +26,11 @@ export function GsDateRangeFilter({
     const dateRangeSelectorRef = useRef<HTMLElement>();
 
     useEffect(() => {
+        const currentDateRangeSelectorRef = dateRangeSelectorRef.current;
+        if (!currentDateRangeSelectorRef) {
+            return;
+        }
+
         const handleDateRangeOptionChange = (event: DateRangeOptionChangedEvent) => {
             const dateRange = event.detail;
 
@@ -39,18 +48,13 @@ export function GsDateRangeFilter({
             }
         };
 
-        const currentDateRangeSelectorRef = dateRangeSelectorRef.current;
-        if (currentDateRangeSelectorRef) {
-            currentDateRangeSelectorRef.addEventListener('gs-date-range-option-changed', handleDateRangeOptionChange);
-        }
+        currentDateRangeSelectorRef.addEventListener(gsEventNames.dateRangeOptionChanged, handleDateRangeOptionChange);
 
         return () => {
-            if (currentDateRangeSelectorRef) {
-                currentDateRangeSelectorRef.removeEventListener(
-                    'gs-date-range-option-changed',
-                    handleDateRangeOptionChange,
-                );
-            }
+            currentDateRangeSelectorRef.removeEventListener(
+                gsEventNames.dateRangeOptionChanged,
+                handleDateRangeOptionChange,
+            );
         };
     }, [dateRangeOptions, lapisDateField, onDateRangeChange, dateRangeSelectorRef]);
 

--- a/website/src/components/genspectrum/GsLineageFilter.tsx
+++ b/website/src/components/genspectrum/GsLineageFilter.tsx
@@ -1,4 +1,4 @@
-import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+import { gsEventNames, type LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useEffect, useRef } from 'react';
 
 import '@genspectrum/dashboard-components/components';
@@ -21,19 +21,19 @@ export function GsLineageFilter<Lineage extends string>({
     const lineageFilterRef = useRef<HTMLElement>();
 
     useEffect(() => {
+        const currentLineageFilterRef = lineageFilterRef.current;
+        if (!currentLineageFilterRef) {
+            return;
+        }
+
         const handleLineageChange = (event: CustomEvent) => {
             onLineageChange(event.detail);
         };
 
-        const currentLineageFilterRef = lineageFilterRef.current;
-        if (currentLineageFilterRef) {
-            currentLineageFilterRef.addEventListener('gs-lineage-filter-changed', handleLineageChange);
-        }
+        currentLineageFilterRef.addEventListener(gsEventNames.lineageFilterChanged, handleLineageChange);
 
         return () => {
-            if (currentLineageFilterRef) {
-                currentLineageFilterRef.removeEventListener('gs-lineage-filter-changed', handleLineageChange);
-            }
+            currentLineageFilterRef.removeEventListener(gsEventNames.lineageFilterChanged, handleLineageChange);
         };
     }, [onLineageChange]);
 

--- a/website/src/components/genspectrum/GsLocationFilter.tsx
+++ b/website/src/components/genspectrum/GsLocationFilter.tsx
@@ -1,4 +1,4 @@
-import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+import { gsEventNames, type LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useEffect, useRef } from 'react';
 
 import '@genspectrum/dashboard-components/components';
@@ -22,19 +22,18 @@ export function GsLocationFilter<Field extends string>({
     const locationFilterRef = useRef<HTMLElement>();
 
     useEffect(() => {
+        const currentLocationFilterRef = locationFilterRef.current;
+        if (!currentLocationFilterRef) {
+            return;
+        }
         const handleLocationChange = (event: CustomEvent) => {
             onLocationChange(event.detail);
         };
 
-        const currentLocationFilterRef = locationFilterRef.current;
-        if (currentLocationFilterRef) {
-            currentLocationFilterRef.addEventListener('gs-location-changed', handleLocationChange);
-        }
+        currentLocationFilterRef.addEventListener(gsEventNames.locationChanged, handleLocationChange);
 
         return () => {
-            if (currentLocationFilterRef) {
-                currentLocationFilterRef.removeEventListener('gs-location-changed', handleLocationChange);
-            }
+            currentLocationFilterRef.removeEventListener(gsEventNames.locationChanged, handleLocationChange);
         };
     }, [onLocationChange]);
 

--- a/website/src/components/genspectrum/GsMutationFilter.tsx
+++ b/website/src/components/genspectrum/GsMutationFilter.tsx
@@ -1,4 +1,5 @@
 import '@genspectrum/dashboard-components/components';
+import { gsEventNames } from '@genspectrum/dashboard-components/util';
 import { useEffect, useRef } from 'react';
 
 export type MutationFilter = {
@@ -20,19 +21,21 @@ export function GsMutationFilter({
     const mutationFilterRef = useRef<HTMLElement>();
 
     useEffect(() => {
+        const currentMutationFilterRef = mutationFilterRef.current;
+        if (!currentMutationFilterRef) {
+            return;
+        }
+
         const handleMutationFilterChange = (event: CustomEvent) => {
             onMutationChange(event.detail);
         };
-
-        const currentMutationFilterRef = mutationFilterRef.current;
-        if (currentMutationFilterRef) {
-            currentMutationFilterRef.addEventListener('gs-mutation-filter-changed', handleMutationFilterChange);
-        }
+        currentMutationFilterRef.addEventListener(gsEventNames.mutationFilterChanged, handleMutationFilterChange);
 
         return () => {
-            if (currentMutationFilterRef) {
-                currentMutationFilterRef.removeEventListener('gs-mutation-filter-changed', handleMutationFilterChange);
-            }
+            currentMutationFilterRef.removeEventListener(
+                gsEventNames.mutationFilterChanged,
+                handleMutationFilterChange,
+            );
         };
     }, [onMutationChange]);
 

--- a/website/src/components/genspectrum/GsTextFilter.tsx
+++ b/website/src/components/genspectrum/GsTextFilter.tsx
@@ -1,4 +1,4 @@
-import type { LapisFilter } from '@genspectrum/dashboard-components/util';
+import { gsEventNames, type LapisFilter } from '@genspectrum/dashboard-components/util';
 import { useEffect, useRef } from 'react';
 
 import '@genspectrum/dashboard-components/components';
@@ -21,19 +21,18 @@ export function GsTextFilter<LapisField extends string>({
     const textInputRef = useRef<HTMLElement>();
 
     useEffect(() => {
+        const currentInputRef = textInputRef.current;
+        if (!currentInputRef) {
+            return;
+        }
+
         const handleTextInputChange = (event: CustomEvent) => {
             onInputChange(event.detail);
         };
-
-        const currentInputRef = textInputRef.current;
-        if (currentInputRef !== undefined) {
-            currentInputRef.addEventListener('gs-text-filter-changed', handleTextInputChange);
-        }
+        currentInputRef.addEventListener(gsEventNames.textFilterChanged, handleTextInputChange);
 
         return () => {
-            if (currentInputRef !== undefined) {
-                currentInputRef.removeEventListener('gs-text-filter-changed', handleTextInputChange);
-            }
+            currentInputRef.removeEventListener(gsEventNames.textFilterChanged, handleTextInputChange);
         };
     }, [onInputChange]);
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
Follow up to #686. We now use the constant of the filter names, instead of a string. Also changes, that there is an ealry return in the useEffect inside the filters

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
