### PR TITLE
feat(website): add advanced query text field

### DIFF
--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -1,11 +1,14 @@
-import type { ChangeEventHandler } from 'react';
+import type { ChangeEvent } from 'react';
+
+export const advancedQueryUrlParamForVariant = 'advancedQueryVariant';
+export const advancedQueryUrlParam = 'advancedQuery';
 
 export function AdvancedQueryFilter({
     value,
     onInput,
 }: {
     value?: string;
-    onInput?: ChangeEventHandler<HTMLInputElement>;
+    onInput?: (newValue: string | undefined) => void;
 }) {
     return (
         <label className='form-control'>
@@ -16,7 +19,10 @@ export function AdvancedQueryFilter({
                 className='input input-bordered w-full'
                 placeholder={'Advanced query: A123T & ins_123:TA'}
                 value={value}
-                onInput={onInput}
+                onInput={(event: ChangeEvent<HTMLInputElement>) => {
+                    const newValue = event.target.value;
+                    onInput?.(newValue === '' ? undefined : newValue);
+                }}
             ></input>
         </label>
     );

--- a/website/src/components/genspectrum/VariantQueryFilter.tsx
+++ b/website/src/components/genspectrum/VariantQueryFilter.tsx
@@ -1,0 +1,23 @@
+import type { ChangeEventHandler } from 'react';
+
+export function VariantQueryFilter({
+    value,
+    onInput,
+}: {
+    value?: string;
+    onInput?: ChangeEventHandler<HTMLInputElement>;
+}) {
+    return (
+        <label className='form-control'>
+            <div className='label'>
+                <span className='label-text'>Variant query</span>
+            </div>
+            <input
+                className='input input-bordered w-full'
+                placeholder={'Variant query: A123T & ins_123:TA'}
+                value={value}
+                onInput={onInput}
+            ></input>
+        </label>
+    );
+}

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -1,6 +1,5 @@
 import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { OrganismConstants } from '../../views/OrganismConstants.ts';
 import type { DatasetFilter } from '../../views/View.ts';
 import { locationFieldsToFilterIdentifier } from '../../views/pageStateHandlers/locationFilterFromToUrl.ts';
 import { AdvancedQueryFilter } from '../genspectrum/AdvancedQueryFilter.tsx';
@@ -44,12 +43,6 @@ export type BaselineFilterConfig =
     | ({ type: 'location' } & LocationFilterConfig)
     | ({ type: 'number' } & NumberRangeFilterConfig)
     | { type: 'advancedQuery' };
-
-export function makeBaselineFilterConfig(organismConstants: OrganismConstants): BaselineFilterConfig[] {
-    return organismConstants.useAdvancedQuery
-        ? [...organismConstants.baselineFilterConfigs, { type: 'advancedQuery' }]
-        : [...organismConstants.baselineFilterConfigs];
-}
 
 export function BaselineSelector({
     baselineFilterConfigs,

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -1,7 +1,9 @@
 import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-components/util';
 
+import type { OrganismConstants } from '../../views/OrganismConstants.ts';
 import type { DatasetFilter } from '../../views/View.ts';
 import { locationFieldsToFilterIdentifier } from '../../views/pageStateHandlers/locationFilterFromToUrl.ts';
+import { AdvancedQueryFilter } from '../genspectrum/AdvancedQueryFilter.tsx';
 import { GsDateRangeFilter } from '../genspectrum/GsDateRangeFilter.tsx';
 import { GsLocationFilter } from '../genspectrum/GsLocationFilter.tsx';
 import { GsNumerRangeFilter } from '../genspectrum/GsNumerRangeFilter.tsx';
@@ -40,7 +42,14 @@ export type BaselineFilterConfig =
       } & DateRangeFilterConfig)
     | ({ type: 'text' } & TextInputConfig)
     | ({ type: 'location' } & LocationFilterConfig)
-    | ({ type: 'number' } & NumberRangeFilterConfig);
+    | ({ type: 'number' } & NumberRangeFilterConfig)
+    | { type: 'advancedQuery' };
+
+export function makeBaselineFilterConfig(organismConstants: OrganismConstants): BaselineFilterConfig[] {
+    return organismConstants.useAdvancedQuery
+        ? [...organismConstants.baselineFilterConfigs, { type: 'advancedQuery' }]
+        : [...organismConstants.baselineFilterConfigs];
+}
 
 export function BaselineSelector({
     baselineFilterConfigs,
@@ -154,6 +163,19 @@ export function BaselineSelector({
                                     }}
                                 />
                             </label>
+                        );
+                    }
+                    case 'advancedQuery': {
+                        return (
+                            <AdvancedQueryFilter
+                                onInput={(newValue) => {
+                                    setDatasetFilter({
+                                        ...datasetFilter,
+                                        advancedQuery: newValue,
+                                    });
+                                }}
+                                value={datasetFilter.advancedQuery ?? ''}
+                            />
                         );
                     }
                 }

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector } from './BaselineSelector.tsx';
+import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
@@ -47,6 +47,8 @@ export function CompareSideBySidePageStateSelector({
         };
     }, [pageState, filterId, view.pageStateHandler]);
 
+    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
+
     return (
         <div className='flex flex-col gap-4 p-2 shadow-lg'>
             <div className='flex gap-4'>
@@ -54,7 +56,7 @@ export function CompareSideBySidePageStateSelector({
                     <SelectorHeadline>Filter dataset</SelectorHeadline>
                     <Inset className='p-2'>
                         <BaselineSelector
-                            baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
+                            baselineFilterConfigs={baselineFilterConfigs}
                             lapisFilter={currentLapisFilter}
                             datasetFilter={filterOfCurrentId.datasetFilter}
                             setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
@@ -47,8 +47,6 @@ export function CompareSideBySidePageStateSelector({
         };
     }, [pageState, filterId, view.pageStateHandler]);
 
-    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
-
     return (
         <div className='flex flex-col gap-4 p-2 shadow-lg'>
             <div className='flex gap-4'>
@@ -56,7 +54,7 @@ export function CompareSideBySidePageStateSelector({
                     <SelectorHeadline>Filter dataset</SelectorHeadline>
                     <Inset className='p-2'>
                         <BaselineSelector
-                            baselineFilterConfigs={baselineFilterConfigs}
+                            baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                             lapisFilter={currentLapisFilter}
                             datasetFilter={filterOfCurrentId.datasetFilter}
                             setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector } from './BaselineSelector.tsx';
+import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig } from './VariantSelector.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
@@ -35,13 +35,15 @@ export function CompareVariantsPageStateSelector({
         return view.pageStateHandler.datasetFilterToLapisFilter(pageState.datasetFilter);
     }, [pageState, view.pageStateHandler]);
 
+    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
+
     return (
         <div className='flex flex-col gap-4'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <Inset className='p-2'>
                     <BaselineSelector
-                        baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
+                        baselineFilterConfigs={baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
                         datasetFilter={pageState.datasetFilter}
                         setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig } from './VariantSelector.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
@@ -35,15 +35,13 @@ export function CompareVariantsPageStateSelector({
         return view.pageStateHandler.datasetFilterToLapisFilter(pageState.datasetFilter);
     }, [pageState, view.pageStateHandler]);
 
-    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
-
     return (
         <div className='flex flex-col gap-4'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <Inset className='p-2'>
                     <BaselineSelector
-                        baselineFilterConfigs={baselineFilterConfigs}
+                        baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
                         datasetFilter={pageState.datasetFilter}
                         setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector } from './BaselineSelector.tsx';
+import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
@@ -32,6 +32,8 @@ export function CompareVariantsToBaselineStateSelector({
         return new Map(pageState.variants.entries().map(([id]) => [id, { ...variantFilterConfig }]));
     }, [pageState.variants, variantFilterConfig]);
 
+    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
+
     const currentLapisFilter = useMemo(() => {
         return view.pageStateHandler.baselineFilterToLapisFilter(pageState);
     }, [pageState, view.pageStateHandler]);
@@ -43,7 +45,7 @@ export function CompareVariantsToBaselineStateSelector({
                 <Inset>
                     <div className='px-2'>
                         <BaselineSelector
-                            baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
+                            baselineFilterConfigs={baselineFilterConfigs}
                             lapisFilter={currentLapisFilter}
                             datasetFilter={pageState.datasetFilter}
                             setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import { VariantsSelector } from './VariantsSelector.tsx';
@@ -32,8 +32,6 @@ export function CompareVariantsToBaselineStateSelector({
         return new Map(pageState.variants.entries().map(([id]) => [id, { ...variantFilterConfig }]));
     }, [pageState.variants, variantFilterConfig]);
 
-    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
-
     const currentLapisFilter = useMemo(() => {
         return view.pageStateHandler.baselineFilterToLapisFilter(pageState);
     }, [pageState, view.pageStateHandler]);
@@ -45,7 +43,7 @@ export function CompareVariantsToBaselineStateSelector({
                 <Inset>
                     <div className='px-2'>
                         <BaselineSelector
-                            baselineFilterConfigs={baselineFilterConfigs}
+                            baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                             lapisFilter={currentLapisFilter}
                             datasetFilter={pageState.datasetFilter}
                             setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import type { OrganismsConfig } from '../../config.ts';
 import { Inset } from '../../styles/Inset.tsx';
@@ -28,15 +28,13 @@ export function SequencingEffortsPageStateSelector({
         return view.pageStateHandler.toLapisFilter(pageState);
     }, [pageState, view.pageStateHandler]);
 
-    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
-
     return (
         <div className='flex flex-col gap-4'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <Inset className='flex flex-col gap-2 p-2'>
                     <BaselineSelector
-                        baselineFilterConfigs={baselineFilterConfigs}
+                        baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
                         datasetFilter={pageState.datasetFilter}
                         setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector } from './BaselineSelector.tsx';
+import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
@@ -26,7 +26,7 @@ export function SingleVariantPageStateSelector({
     );
     const [pageState, setPageState] = useState(initialPageState);
 
-    const baselineFilterConfigs = view.organismConstants.baselineFilterConfigs;
+    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
 
     const currentLapisFilter = useMemo(() => {
         return view.pageStateHandler.toLapisFilter(pageState);

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -30,13 +30,15 @@ export function SingleVariantPageStateSelector({
         return view.pageStateHandler.toLapisFilter(pageState);
     }, [pageState, view.pageStateHandler]);
 
+    const baselineFilterConfigs = view.organismConstants.baselineFilterConfigs;
+
     return (
         <div className='flex flex-col gap-4'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <Inset className={'p-2'}>
                     <BaselineSelector
-                        baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
+                        baselineFilterConfigs={baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
                         datasetFilter={pageState.datasetFilter}
                         setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
-import { BaselineSelector, makeBaselineFilterConfig } from './BaselineSelector.tsx';
+import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import { type OrganismsConfig } from '../../config.ts';
@@ -26,8 +26,6 @@ export function SingleVariantPageStateSelector({
     );
     const [pageState, setPageState] = useState(initialPageState);
 
-    const baselineFilterConfigs = makeBaselineFilterConfig(view.organismConstants);
-
     const currentLapisFilter = useMemo(() => {
         return view.pageStateHandler.toLapisFilter(pageState);
     }, [pageState, view.pageStateHandler]);
@@ -38,7 +36,7 @@ export function SingleVariantPageStateSelector({
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
                 <Inset className={'p-2'}>
                     <BaselineSelector
-                        baselineFilterConfigs={baselineFilterConfigs}
+                        baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
                         datasetFilter={pageState.datasetFilter}
                         setDatasetFilter={(newDatasetFilter) => {

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -38,7 +38,7 @@ export function makeVariantFilterConfig(
             enabled: enableVariantQuery ?? organismConstants.useVariantQuery,
         },
         advancedFilterConfig: {
-            enabled: organismConstants.useAdvancedQuery,
+            enabled: true,
         },
     };
 }

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -7,6 +7,7 @@ import type { VariantFilter } from '../../views/View.ts';
 import { getMutationFilter } from '../../views/helpers.ts';
 import { AdvancedQueryFilter } from '../genspectrum/AdvancedQueryFilter.tsx';
 import { GsMutationFilter } from '../genspectrum/GsMutationFilter.tsx';
+import { VariantQueryFilter } from '../genspectrum/VariantQueryFilter.tsx';
 
 export type VariantFilterConfig = {
     lineageFilterConfigs?: LineageFilterConfig[];
@@ -14,6 +15,9 @@ export type VariantFilterConfig = {
         enabled: boolean;
     };
     variantQueryConfig: {
+        enabled: boolean;
+    };
+    advancedFilterConfig: {
         enabled: boolean;
     };
 };
@@ -31,7 +35,10 @@ export function makeVariantFilterConfig(
         lineageFilterConfigs: organismConstants.lineageFilters,
         mutationFilterConfig: { enabled: enableMutationFilter },
         variantQueryConfig: {
-            enabled: enableVariantQuery ?? organismConstants.useAdvancedQuery,
+            enabled: enableVariantQuery ?? organismConstants.useVariantQuery,
+        },
+        advancedFilterConfig: {
+            enabled: organismConstants.useAdvancedQuery,
         },
     };
 }
@@ -55,7 +62,7 @@ export function VariantSelector({
         <div>
             {variantFilterConfig.variantQueryConfig.enabled && (
                 <label className='mb-1 flex cursor-pointer items-center gap-1 text-sm'>
-                    Advanced
+                    Variant query mode
                     <input
                         type='checkbox'
                         className='checkbox checkbox-xs'
@@ -66,7 +73,7 @@ export function VariantSelector({
             )}
 
             {isInVariantQueryMode ? (
-                <AdvancedQueryFilter
+                <VariantQueryFilter
                     onInput={(event) => {
                         onVariantFilterChange({
                             ...variantFilter,
@@ -109,6 +116,17 @@ export function VariantSelector({
                                     mutations,
                                 });
                             }}
+                        />
+                    )}
+                    {variantFilterConfig.advancedFilterConfig.enabled && (
+                        <AdvancedQueryFilter
+                            onInput={(newValue) => {
+                                onVariantFilterChange({
+                                    ...variantFilter,
+                                    advancedQuery: newValue,
+                                });
+                            }}
+                            value={variantFilter.advancedQuery ?? ''}
                         />
                     )}
                 </div>

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -35,7 +35,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
             {
                 Array.from(pageState.filters).map(([id, { variantFilter, datasetFilter }]) => {
                     const datasetLapisFilter = toLapisFilterWithoutVariant(
-                        { datasetFilter },
+                        datasetFilter,
                         view.organismConstants.additionalFilters,
                     );
                     const timeGranularity = chooseGranularityBasedOnDateRange({

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -30,7 +30,7 @@ const downloadLinks = [...pageState.filters.entries()].map(
             {
                 Array.from(pageState.filters).map(([id, { variantFilter, datasetFilter }]) => {
                     const baselineLapisFilter = toLapisFilterWithoutVariant(
-                        { datasetFilter },
+                        datasetFilter,
                         view.organismConstants.additionalFilters,
                     );
                     const timeGranularity = chooseGranularityBasedOnDateRange({

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -29,6 +29,7 @@ export interface OrganismConstants {
     readonly mainDateField: string;
     readonly additionalFilters: Record<string, string> | undefined;
     readonly aggregatedVisualizations: AggregatedVisualizations;
+    readonly useVariantQuery: boolean;
     readonly useAdvancedQuery: boolean;
     readonly locationFields: string[];
     readonly baselineFilterConfigs: BaselineFilterConfig[];

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -30,7 +30,6 @@ export interface OrganismConstants {
     readonly additionalFilters: Record<string, string> | undefined;
     readonly aggregatedVisualizations: AggregatedVisualizations;
     readonly useVariantQuery: boolean;
-    readonly useAdvancedQuery: boolean;
     readonly locationFields: string[];
     readonly baselineFilterConfigs: BaselineFilterConfig[];
     readonly lineageFilters: LineageFilterConfig[];
@@ -254,6 +253,7 @@ export function getPathoplexusFilters({
             label: 'Data use terms',
         },
         ...getCompletenessFilters(completenessSuffixes),
+        { type: 'advancedQuery' },
     ];
 }
 
@@ -323,5 +323,6 @@ export function getGenspectrumLoculusFilters({
             label: 'NCBI release date',
         },
         ...getCompletenessFilters(completenessSuffixes),
+        { type: 'advancedQuery' },
     ];
 }

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -13,6 +13,7 @@ export type DatasetFilter = {
     textFilters: TextFilterState;
     dateFilters: DateFilterState;
     numberFilters: NumberFilterState;
+    advancedQuery?: string;
 };
 
 export type LocationFilterState = {
@@ -39,6 +40,7 @@ export type VariantFilter = {
     mutations?: LapisMutationQuery;
     lineages?: LapisLineageQuery;
     variantQuery?: string;
+    advancedQuery?: string;
 };
 
 export type VariantData<VariantFilterType = VariantFilter> = {

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -54,7 +54,8 @@ class CchfConstants implements OrganismConstants {
     public readonly mainDateField: string;
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -55,7 +55,6 @@ class CchfConstants implements OrganismConstants {
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -1,6 +1,11 @@
 import { dateRangeOptionPresets, type MutationAnnotation, views } from '@genspectrum/dashboard-components/util';
 
-import { getIntegerFromSearch, getLapisVariantQuery, setSearchFromLapisVariantQuery } from './helpers.ts';
+import {
+    getIntegerFromSearch,
+    getLapisVariantQuery,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from './helpers.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -36,6 +41,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 import { defaultDateRangeOption } from '../util/defaultDateRangeOption.ts';
 import { formatUrl } from '../util/formatUrl.ts';
 import { setSearchFromTextFilters } from './pageStateHandlers/textFilterFromToUrl.ts';
+import { advancedQueryUrlParam } from '../components/genspectrum/AdvancedQueryFilter.tsx';
 
 const earliestDate = '2020-01-06';
 const hostField = 'host';
@@ -75,6 +81,7 @@ class CovidConstants implements OrganismConstants {
             filterType: 'lineage' as const,
         },
     ];
+    public readonly useVariantQuery = true;
     public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         {
@@ -215,6 +222,7 @@ class CovidSingleVariantStateHandler
         setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         setSearchFromLapisVariantQuery(
             search,

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -82,7 +82,6 @@ class CovidConstants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = true;
-    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         {
             type: 'location',
@@ -122,6 +121,7 @@ class CovidConstants implements OrganismConstants {
             placeholderText: 'Exposure location',
             label: 'Exposure location',
         },
+        { type: 'advancedQuery' },
     ];
     public readonly hostField: string = hostField;
     public readonly originatingLabField = 'originatingLab';

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -50,7 +50,6 @@ class EbolaSudanConstants implements OrganismConstants {
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -49,7 +49,8 @@ class EbolaSudanConstants implements OrganismConstants {
     public readonly mainDateField: string;
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -50,7 +50,8 @@ class EbolaZaireConstants implements OrganismConstants {
     public readonly mainDateField: string;
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -51,7 +51,6 @@ class EbolaZaireConstants implements OrganismConstants {
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -59,7 +59,6 @@ class H1n1pdmConstants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -58,7 +58,8 @@ class H1n1pdmConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -58,7 +58,8 @@ class H3n2Constants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -59,7 +59,6 @@ class H3n2Constants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -53,7 +53,6 @@ class H5n1Constants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -52,7 +52,8 @@ class H5n1Constants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/helpers.ts
+++ b/website/src/views/helpers.ts
@@ -1,4 +1,5 @@
 import type { VariantFilter } from './View.ts';
+import { advancedQueryUrlParamForVariant } from '../components/genspectrum/AdvancedQueryFilter.tsx';
 import type { MutationFilter } from '../components/genspectrum/GsMutationFilter.tsx';
 
 export const setSearchFromString = (
@@ -81,9 +82,12 @@ export const getLapisVariantQuery = (
         })
         .reduce((acc, curr) => ({ ...acc, ...curr }), {});
 
+    const advancedQuery = getStringFromSearch(search, advancedQueryUrlParamForVariant);
+
     return {
         mutations: { ...getLapisMutationsQueryFromSearch(search) },
         lineages: { ...lineageQuery },
+        advancedQuery,
     };
 };
 
@@ -108,5 +112,6 @@ export const setSearchFromLapisVariantQuery = (
                 setSearchFromString(search, filter, query.lineages[filter]);
             }
         });
+        setSearchFromString(search, advancedQueryUrlParamForVariant, query.advancedQuery);
     }
 };

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -57,7 +57,6 @@ class InfluenzaAConstants implements OrganismConstants {
         }),
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly hostField: string = GENSPECTRUM_LOCULUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -56,7 +56,8 @@ class InfluenzaAConstants implements OrganismConstants {
             completenessSuffixes: [],
         }),
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly hostField: string = GENSPECTRUM_LOCULUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -50,7 +50,8 @@ class InfluenzaBConstants implements OrganismConstants {
             completenessSuffixes: [],
         }),
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly hostField: string = GENSPECTRUM_LOCULUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -51,7 +51,6 @@ class InfluenzaBConstants implements OrganismConstants {
         }),
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly hostField: string = GENSPECTRUM_LOCULUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -57,7 +57,8 @@ class MpoxConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: () => {

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -58,7 +58,6 @@ class MpoxConstants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: () => {

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -27,7 +27,6 @@ const mockConstants: OrganismConstants = {
     },
     accessionDownloadFields: [],
     useVariantQuery: false,
-    useAdvancedQuery: true,
     baselineFilterConfigs: [
         {
             type: 'text',

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -100,7 +100,8 @@ describe('CompareSideBySideStateHandler', () => {
         const url = new URL(
             'http://example.com/covid/compare-side-by-side?' +
                 'columns=3' +
-                '&lineage%241=B.1.1.7&date%241=Last+7+Days' +
+                '&lineage%241=B.1.1.7&advancedQuery%241=country%3DUS&date%241=Last+7+Days' +
+                '&advancedQueryVariant%241=123T' +
                 '&variantQuery%242=C234G' +
                 '&',
         );
@@ -130,12 +131,14 @@ describe('CompareSideBySideStateHandler', () => {
                 textFilters: {},
                 locationFilters: {},
                 numberFilters: {},
+                advancedQuery: 'country=US',
             },
             variantFilter: {
                 lineages: {
                     lineage: 'B.1.1.7',
                 },
                 mutations: {},
+                advancedQuery: '123T',
             },
         });
 
@@ -163,10 +166,12 @@ describe('CompareSideBySideStateHandler', () => {
                             dateFilters: { date: mockDateRangeOption },
                             textFilters: {},
                             numberFilters: {},
+                            advancedQuery: 'country=US',
                         },
                         variantFilter: {
                             lineages: { lineage: 'B.1.1.7' },
                             mutations: {},
+                            advancedQuery: '123T',
                         },
                     },
                 ],
@@ -193,7 +198,8 @@ describe('CompareSideBySideStateHandler', () => {
         expect(url).toBe(
             '/covid/compare-side-by-side?' +
                 'columns=2' +
-                '&lineage%240=B.1.1.7&date%240=Last+7+Days' +
+                '&lineage%240=B.1.1.7&advancedQueryVariant%240=123T' +
+                '&date%240=Last+7+Days&advancedQuery%240=country%3DUS' +
                 '&variantQuery%241=C234G&date%241=Last+7+Days' +
                 '&',
         );
@@ -238,6 +244,7 @@ describe('CompareSideBySideStateHandler', () => {
             },
         );
         expect(lapisFilter).toStrictEqual({
+            advancedQuery: undefined,
             dateFrom: '2024-11-22',
             dateTo: '2024-11-29',
             country: 'US',
@@ -270,6 +277,34 @@ describe('CompareSideBySideStateHandler', () => {
             country: 'US',
             someTextField: 'SomeText',
             variantQuery: 'C234G',
+        });
+    });
+
+    it('should convert variant filter with advancedQuery to Lapis filter', () => {
+        const lapisFilter = handler.variantFilterToLapisFilter(
+            {
+                dateFilters: { date: mockDateRangeOption },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
+                textFilters: {
+                    someTextField: 'SomeText',
+                },
+                numberFilters: {},
+                advancedQuery: 'country = US',
+            },
+            {
+                lineages: { lineage: 'B.1.1.7' },
+                mutations: {},
+                advancedQuery: '123T',
+            },
+        );
+        expect(lapisFilter).toStrictEqual({
+            dateFrom: '2024-11-22',
+            dateTo: '2024-11-29',
+            country: 'US',
+            someTextField: 'SomeText',
+            lineage: 'B.1.1.7',
+            advancedQuery: '(country = US) and (123T)',
         });
     });
 });

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -26,7 +26,8 @@ const mockConstants: OrganismConstants = {
         compareSideBySide: [],
     },
     accessionDownloadFields: [],
-    useAdvancedQuery: false,
+    useVariantQuery: false,
+    useAdvancedQuery: true,
     baselineFilterConfigs: [
         {
             type: 'text',

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -27,7 +27,6 @@ const mockConstants: OrganismConstants = {
     },
     accessionDownloadFields: [],
     useVariantQuery: true,
-    useAdvancedQuery: true,
     baselineFilterConfigs: [
         {
             type: 'text',

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -26,6 +26,7 @@ const mockConstants: OrganismConstants = {
         compareSideBySide: [],
     },
     accessionDownloadFields: [],
+    useVariantQuery: true,
     useAdvancedQuery: true,
     baselineFilterConfigs: [
         {
@@ -256,6 +257,7 @@ describe('CompareToBaselinePageStateHandler', () => {
             {
                 displayName: 'B.1.1.7 + D614G + S:A123T',
                 lapisFilter: {
+                    advancedQuery: undefined,
                     aminoAcidMutations: ['S:A123T'],
                     dateFrom: '2024-11-22',
                     dateTo: '2024-11-29',
@@ -278,6 +280,7 @@ describe('CompareToBaselinePageStateHandler', () => {
         const baselineLapisFilter = handler.baselineFilterToLapisFilter(pageState);
 
         expect(baselineLapisFilter).toStrictEqual({
+            advancedQuery: undefined,
             dateFrom: '2024-11-22',
             dateTo: '2024-11-29',
             lineage: 'B.1.1.7',

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -75,25 +75,31 @@ describe('CompareToBaselinePageStateHandler', () => {
         const url = new URL(
             'http://example.com/covid/compare-to-baseline?' +
                 'columns=3' +
-                '&country=US&date=Last 7 Days' +
-                '&lineage=B.2.3.4&nucleotideMutations=C234G' +
+                '&country=US&date=Last 7 Days&advancedQuery=country%3DUS' +
+                '&lineage=B.2.3.4&nucleotideMutations=C234G&advancedQueryVariant=123T' +
                 '&lineage$0=B.1.1.7&nucleotideMutations$0=D614G' +
-                '&lineage$1=A.1.2.3&aminoAcidMutations$1=S:A123T' +
+                '&lineage$1=A.1.2.3&aminoAcidMutations$1=S:A123T&advancedQueryVariant$1=345G' +
                 '&variantQuery$2=A123T' +
                 '&',
         );
 
         const pageState = handler.parsePageStateFromUrl(url);
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        expect(pageState.datasetFilter.locationFilters).toEqual({ 'country,region': { country: 'US' } });
-        expect(pageState.datasetFilter.dateFilters).toEqual({ date: mockDateRangeOption });
+        expect(pageState.datasetFilter).toEqual({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            locationFilters: { 'country,region': { country: 'US' } },
+            dateFilters: { date: mockDateRangeOption },
+            advancedQuery: 'country=US',
+            numberFilters: {},
+            textFilters: {},
+        });
 
         expect(pageState.baselineFilter).toEqual({
             lineages: { lineage: 'B.2.3.4' },
             mutations: {
                 nucleotideMutations: ['C234G'],
             },
+            advancedQuery: '123T',
         });
 
         expect(pageState.variants.size).toBe(3);
@@ -104,6 +110,7 @@ describe('CompareToBaselinePageStateHandler', () => {
         expect(pageState.variants.get(1)).toEqual({
             lineages: { lineage: 'A.1.2.3' },
             mutations: { aminoAcidMutations: ['S:A123T'] },
+            advancedQuery: '345G',
         });
         expect(pageState.variants.get(2)).toEqual({
             variantQuery: 'A123T',
@@ -125,6 +132,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                     {
                         lineages: { lineage: 'A.1.2.3' },
                         mutations: { aminoAcidMutations: ['S:A123T'] },
+                        advancedQuery: '345G',
                     },
                 ],
                 [
@@ -140,6 +148,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
                 numberFilters: {},
+                advancedQuery: 'country=US',
             },
             baselineFilter: {
                 lineages: {
@@ -148,6 +157,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                 mutations: {
                     nucleotideMutations: ['C234G'],
                 },
+                advancedQuery: '123T',
             },
         };
         const url = handler.toUrl(pageState);
@@ -155,10 +165,10 @@ describe('CompareToBaselinePageStateHandler', () => {
             '/covid/compare-to-baseline?' +
                 'columns=3' +
                 '&nucleotideMutations%240=D614G&lineage%240=B.1.1.7' +
-                '&aminoAcidMutations%241=S%3AA123T&lineage%241=A.1.2.3' +
+                '&aminoAcidMutations%241=S%3AA123T&lineage%241=A.1.2.3&advancedQueryVariant%241=345G' +
                 '&variantQuery%242=C234G' +
-                '&country=US&date=Last+7+Days' +
-                '&nucleotideMutations=C234G&lineage=B.2.3.4' +
+                '&country=US&date=Last+7+Days&advancedQuery=country%3DUS' +
+                '&nucleotideMutations=C234G&lineage=B.2.3.4&advancedQueryVariant=123T' +
                 '&',
         );
     });
@@ -247,6 +257,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                     {
                         lineages: { lineage: 'B.1.1.7' },
                         mutations: { nucleotideMutations: ['D614G'], aminoAcidMutations: ['S:A123T'] },
+                        advancedQuery: '123T',
                     },
                 ],
             ]),
@@ -254,9 +265,9 @@ describe('CompareToBaselinePageStateHandler', () => {
         const namedVariantFilter = handler.variantFiltersToNamedLapisFilters(pageState);
         expect(namedVariantFilter).deep.equal([
             {
-                displayName: 'B.1.1.7 + D614G + S:A123T',
+                displayName: 'B.1.1.7 + D614G + S:A123T + 123T',
                 lapisFilter: {
-                    advancedQuery: undefined,
+                    advancedQuery: '123T',
                     aminoAcidMutations: ['S:A123T'],
                     dateFrom: '2024-11-22',
                     dateTo: '2024-11-29',
@@ -273,13 +284,14 @@ describe('CompareToBaselinePageStateHandler', () => {
             baselineFilter: {
                 lineages: { lineage: 'B.1.1.7' },
                 mutations: { nucleotideMutations: ['D614G'] },
+                advancedQuery: '123T',
             },
         };
 
         const baselineLapisFilter = handler.baselineFilterToLapisFilter(pageState);
 
         expect(baselineLapisFilter).toStrictEqual({
-            advancedQuery: undefined,
+            advancedQuery: '123T',
             dateFrom: '2024-11-22',
             dateTo: '2024-11-29',
             lineage: 'B.1.1.7',

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
@@ -4,7 +4,12 @@ import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareToBaselineData, type DatasetFilter, getLineageFilterFields, type VariantFilter } from '../View.ts';
 import { compareToBaselineViewConstants } from '../ViewConstants.ts';
-import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
+import {
+    getLapisVariantQuery,
+    getStringFromSearch,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from '../helpers.ts';
 import { type PageStateHandler, toDisplayName, toLapisFilterFromVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
@@ -12,6 +17,7 @@ import { decodeFiltersFromSearch, searchParamsFromFilterMap } from './multipleFi
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
 import { parseTextFiltersFromUrl, setSearchFromTextFilters } from './textFilterFromToUrl.ts';
 import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
+import { advancedQueryUrlParam } from '../../components/genspectrum/AdvancedQueryFilter.tsx';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class CompareToBaselineStateHandler implements PageStateHandler<CompareToBaselineData> {
@@ -43,6 +49,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
+                advancedQuery: getStringFromSearch(search, advancedQueryUrlParam),
             },
             variants,
             baselineFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
@@ -58,6 +65,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         setSearchFromLapisVariantQuery(
             search,

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
@@ -10,7 +10,7 @@ import {
     setSearchFromLapisVariantQuery,
     setSearchFromString,
 } from '../helpers.ts';
-import { type PageStateHandler, toDisplayName, toLapisFilterFromVariant } from './PageStateHandler.ts';
+import { type PageStateHandler, toDisplayName, toLapisFilterWithVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { decodeFiltersFromSearch, searchParamsFromFilterMap } from './multipleFiltersFromToUrl.ts';
@@ -76,28 +76,26 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
         return formatUrl(this.pathname, search);
     }
 
-    public datasetFilterToLapisFilter(baselineFilter: DatasetFilter): LapisFilter {
-        return toLapisFilterWithoutVariant({ datasetFilter: baselineFilter }, this.constants.additionalFilters);
+    public datasetFilterToLapisFilter(datasetFilter: DatasetFilter): LapisFilter {
+        return toLapisFilterWithoutVariant(datasetFilter, this.constants.additionalFilters);
     }
 
     public baselineFilterToLapisFilter(pageState: CompareToBaselineData): LapisFilter {
-        const datasetFilter = this.datasetFilterToLapisFilter(pageState.datasetFilter);
-
-        return {
-            ...datasetFilter,
-            ...toLapisFilterFromVariant(pageState.baselineFilter),
-        };
+        return toLapisFilterWithVariant({
+            datasetFilter: pageState.datasetFilter,
+            variantFilter: pageState.baselineFilter,
+            additionalFilters: this.constants.additionalFilters,
+        });
     }
 
     public variantFiltersToNamedLapisFilters(pageState: CompareToBaselineData): NamedLapisFilter[] {
-        const datasetFilter = this.datasetFilterToLapisFilter(pageState.datasetFilter);
-
         return Array.from(pageState.variants.values()).map((variantFilter) => {
             return {
-                lapisFilter: {
-                    ...datasetFilter,
-                    ...toLapisFilterFromVariant(variantFilter),
-                },
+                lapisFilter: toLapisFilterWithVariant({
+                    datasetFilter: pageState.datasetFilter,
+                    variantFilter,
+                    additionalFilters: this.constants.additionalFilters,
+                }),
                 displayName: toDisplayName(variantFilter),
             };
         });

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -27,7 +27,6 @@ const mockConstants: OrganismConstants = {
     },
     accessionDownloadFields: [],
     useVariantQuery: true,
-    useAdvancedQuery: true,
     baselineFilterConfigs: [
         {
             type: 'text',

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -26,6 +26,7 @@ const mockConstants: OrganismConstants = {
         compareSideBySide: [],
     },
     accessionDownloadFields: [],
+    useVariantQuery: true,
     useAdvancedQuery: true,
     baselineFilterConfigs: [
         {
@@ -233,6 +234,7 @@ describe('CompareVariantsPageStateHandler', () => {
             {
                 displayName: 'B.1.1.7 + D614G + S:A123T',
                 lapisFilter: {
+                    advancedQuery: undefined,
                     aminoAcidMutations: ['S:A123T'],
                     dateFrom: '2024-11-22',
                     dateTo: '2024-11-29',

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
@@ -10,7 +10,7 @@ import {
     setSearchFromLapisVariantQuery,
     setSearchFromString,
 } from '../helpers.ts';
-import { type PageStateHandler, toDisplayName, toLapisFilterFromVariant } from './PageStateHandler.ts';
+import { type PageStateHandler, toDisplayName, toLapisFilterWithVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { decodeFiltersFromSearch, searchParamsFromFilterMap } from './multipleFiltersFromToUrl.ts';
@@ -71,18 +71,17 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
     }
 
     public datasetFilterToLapisFilter(datasetFilter: DatasetFilter): LapisFilter {
-        return toLapisFilterWithoutVariant({ datasetFilter }, this.constants.additionalFilters);
+        return toLapisFilterWithoutVariant(datasetFilter, this.constants.additionalFilters);
     }
 
     public variantFiltersToNamedLapisFilters(pageState: CompareVariantsData): NamedLapisFilter[] {
-        const baselineFilter = this.datasetFilterToLapisFilter(pageState.datasetFilter);
-
         return Array.from(pageState.variants.values()).map((variantFilter) => {
             return {
-                lapisFilter: {
-                    ...baselineFilter,
-                    ...toLapisFilterFromVariant(variantFilter),
-                },
+                lapisFilter: toLapisFilterWithVariant({
+                    datasetFilter: pageState.datasetFilter,
+                    variantFilter,
+                    additionalFilters: this.constants.additionalFilters,
+                }),
                 displayName: toDisplayName(variantFilter),
             };
         });

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.ts
@@ -4,7 +4,12 @@ import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareVariantsData, type DatasetFilter, getLineageFilterFields, type VariantFilter } from '../View.ts';
 import { compareVariantsViewConstants } from '../ViewConstants.ts';
-import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
+import {
+    getLapisVariantQuery,
+    getStringFromSearch,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from '../helpers.ts';
 import { type PageStateHandler, toDisplayName, toLapisFilterFromVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
@@ -12,6 +17,7 @@ import { decodeFiltersFromSearch, searchParamsFromFilterMap } from './multipleFi
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
 import { parseTextFiltersFromUrl, setSearchFromTextFilters } from './textFilterFromToUrl.ts';
 import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
+import { advancedQueryUrlParam } from '../../components/genspectrum/AdvancedQueryFilter.tsx';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class CompareVariantsPageStateHandler implements PageStateHandler<CompareVariantsData> {
@@ -44,6 +50,7 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
+                advancedQuery: getStringFromSearch(search, advancedQueryUrlParam),
             },
             variants,
         };
@@ -58,6 +65,7 @@ export class CompareVariantsPageStateHandler implements PageStateHandler<Compare
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         return formatUrl(this.pathname, search);
     }

--- a/website/src/views/pageStateHandlers/PageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.ts
@@ -15,6 +15,7 @@ export function toLapisFilterFromVariant(variantFilter: VariantFilter) {
         return {
             ...variantFilter.lineages,
             ...variantFilter.mutations,
+            advancedQuery: variantFilter.advancedQuery,
         };
     }
 }
@@ -28,11 +29,14 @@ export function toDisplayName(variantFilter: VariantFilter) {
         ? Object.values(variantFilter.lineages).filter((lineage) => lineage !== undefined)
         : [];
 
+    const advancedQuery: string[] = variantFilter.advancedQuery ? [variantFilter.advancedQuery] : [];
+
     return [
         ...lineages,
         ...(variantFilter.mutations?.nucleotideMutations ?? []),
         ...(variantFilter.mutations?.aminoAcidMutations ?? []),
         ...(variantFilter.mutations?.nucleotideInsertions ?? []),
         ...(variantFilter.mutations?.aminoAcidInsertions ?? []),
+        ...advancedQuery,
     ].join(' + ');
 }

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -8,12 +8,11 @@ import {
     setSearchFromLapisVariantQuery,
     setSearchFromString,
 } from '../helpers.ts';
-import { type PageStateHandler, toLapisFilterFromVariant } from './PageStateHandler.ts';
+import { type PageStateHandler, toLapisFilterWithVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
 import { parseTextFiltersFromUrl, setSearchFromTextFilters } from './textFilterFromToUrl.ts';
-import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
 import { advancedQueryUrlParam } from '../../components/genspectrum/AdvancedQueryFilter.tsx';
 import { formatUrl } from '../../util/formatUrl.ts';
 
@@ -61,10 +60,11 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
     }
 
     public toLapisFilter(pageState: DatasetAndVariantData) {
-        return {
-            ...toLapisFilterWithoutVariant(pageState, this.constants.additionalFilters),
-            ...toLapisFilterFromVariant(pageState.variantFilter),
-        };
+        return toLapisFilterWithVariant({
+            datasetFilter: pageState.datasetFilter,
+            variantFilter: pageState.variantFilter,
+            additionalFilters: this.constants.additionalFilters,
+        });
     }
 
     public getDefaultPageUrl(): string {

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -2,13 +2,19 @@ import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { sequencingEffortsViewConstants } from '../ViewConstants.ts';
-import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
+import {
+    getLapisVariantQuery,
+    getStringFromSearch,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from '../helpers.ts';
 import { type PageStateHandler, toLapisFilterFromVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
 import { parseTextFiltersFromUrl, setSearchFromTextFilters } from './textFilterFromToUrl.ts';
 import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
+import { advancedQueryUrlParam } from '../../components/genspectrum/AdvancedQueryFilter.tsx';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantData = DatasetAndVariantData>
@@ -32,6 +38,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
+                advancedQuery: getStringFromSearch(search, advancedQueryUrlParam),
             },
             variantFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
         };
@@ -43,6 +50,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         setSearchFromLapisVariantQuery(
             search,

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -27,7 +27,6 @@ const mockConstants: OrganismConstants = {
     },
     accessionDownloadFields: [],
     useVariantQuery: false,
-    useAdvancedQuery: true,
     baselineFilterConfigs: [
         {
             type: 'text',

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -26,7 +26,8 @@ const mockConstants: OrganismConstants = {
         compareSideBySide: [],
     },
     accessionDownloadFields: [],
-    useAdvancedQuery: false,
+    useVariantQuery: false,
+    useAdvancedQuery: true,
     baselineFilterConfigs: [
         {
             type: 'text',
@@ -151,6 +152,7 @@ describe('SingleVariantPageStateHandler', () => {
             },
         });
         expect(lapisFilter).toStrictEqual({
+            advancedQuery: undefined,
             dateFrom: '2024-11-22',
             dateTo: '2024-11-29',
             someLapisNumberFieldFrom: 123,

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -4,13 +4,19 @@ import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { singleVariantViewConstants } from '../ViewConstants.ts';
-import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
+import {
+    getLapisVariantQuery,
+    getStringFromSearch,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from '../helpers.ts';
 import { type PageStateHandler, toLapisFilterFromVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
 import { parseTextFiltersFromUrl, setSearchFromTextFilters } from './textFilterFromToUrl.ts';
 import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
+import { advancedQueryUrlParam } from '../../components/genspectrum/AdvancedQueryFilter.tsx';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantData = DatasetAndVariantData>
@@ -34,6 +40,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
+                advancedQuery: getStringFromSearch(search, advancedQueryUrlParam),
             },
             variantFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
         };
@@ -45,6 +52,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         setSearchFromLapisVariantQuery(
             search,

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -10,7 +10,7 @@ import {
     setSearchFromLapisVariantQuery,
     setSearchFromString,
 } from '../helpers.ts';
-import { type PageStateHandler, toLapisFilterFromVariant } from './PageStateHandler.ts';
+import { type PageStateHandler, toLapisFilterWithVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
@@ -63,14 +63,15 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
     }
 
     public toLapisFilter(pageState: DatasetAndVariantData) {
-        return {
-            ...toLapisFilterWithoutVariant(pageState, this.constants.additionalFilters),
-            ...toLapisFilterFromVariant(pageState.variantFilter),
-        };
+        return toLapisFilterWithVariant({
+            datasetFilter: pageState.datasetFilter,
+            variantFilter: pageState.variantFilter,
+            additionalFilters: this.constants.additionalFilters,
+        });
     }
 
     public toLapisFilterWithoutVariant(pageState: DatasetAndVariantData): LapisFilter {
-        return toLapisFilterWithoutVariant(pageState, this.constants.additionalFilters);
+        return toLapisFilterWithoutVariant(pageState.datasetFilter, this.constants.additionalFilters);
     }
 
     public getDefaultPageUrl() {

--- a/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.spec.ts
+++ b/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.spec.ts
@@ -1,57 +1,54 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Dataset } from '../View.ts';
+import type { DatasetFilter } from '../View.ts';
 import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
 
 describe('toLapisFilterWithoutVariant', () => {
-    const emptyPageState = {
-        datasetFilter: {
-            locationFilters: {},
-            textFilters: {},
-            dateFilters: {},
-            numberFilters: {},
-        },
-    } satisfies Dataset;
+    const emptyFilter: DatasetFilter = {
+        locationFilters: {},
+        textFilters: {},
+        dateFilters: {},
+        numberFilters: {},
+    };
 
     const additionalFilters = {
         someAdditionalFilter: 'someAdditionalFilterValue',
     };
 
     it('should convert empty page state to empty lapis filter', () => {
-        const result = toLapisFilterWithoutVariant(emptyPageState, {});
+        const result = toLapisFilterWithoutVariant(emptyFilter, {});
 
         expect(result).toStrictEqual({});
     });
 
     it('should append additionalFilters to lapis filter', () => {
-        const result = toLapisFilterWithoutVariant(emptyPageState, additionalFilters);
+        const result = toLapisFilterWithoutVariant(emptyFilter, additionalFilters);
 
         expect(result).toStrictEqual(additionalFilters);
     });
 
     it('should convert page state to lapis filter', () => {
-        const pageState = {
-            datasetFilter: {
-                locationFilters: {
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    'country,region': { country: 'SomeCountry' },
-                },
-                dateFilters: {
-                    date: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
-                },
-                textFilters: {
-                    someTextFilter: 'someTextFilterValue',
-                },
-                numberFilters: {
-                    someLapisNumberField: {
-                        min: 0,
-                        max: 234,
-                    },
+        const filter: DatasetFilter = {
+            locationFilters: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'country,region': { country: 'SomeCountry' },
+            },
+            dateFilters: {
+                date: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+            },
+            textFilters: {
+                someTextFilter: 'someTextFilterValue',
+            },
+            numberFilters: {
+                someLapisNumberField: {
+                    min: 0,
+                    max: 234,
                 },
             },
-        } satisfies Dataset;
+            advancedQuery: '123T & 345G',
+        };
 
-        const result = toLapisFilterWithoutVariant(pageState, additionalFilters);
+        const result = toLapisFilterWithoutVariant(filter, additionalFilters);
 
         expect(result).toStrictEqual({
             country: 'SomeCountry',
@@ -61,26 +58,25 @@ describe('toLapisFilterWithoutVariant', () => {
             someLapisNumberFieldFrom: 0,
             someLapisNumberFieldTo: 234,
             someAdditionalFilter: 'someAdditionalFilterValue',
+            advancedQuery: '123T & 345G',
         });
     });
 
     it('should convert page state with partial from/to filters to lapis filter', () => {
-        const pageState = {
-            datasetFilter: {
-                locationFilters: {},
-                dateFilters: {
-                    date: { label: 'SomeLabel', dateFrom: '2024-11-22' },
-                },
-                textFilters: {},
-                numberFilters: {
-                    someLapisNumberField: {
-                        min: 123,
-                    },
+        const filter: DatasetFilter = {
+            locationFilters: {},
+            dateFilters: {
+                date: { label: 'SomeLabel', dateFrom: '2024-11-22' },
+            },
+            textFilters: {},
+            numberFilters: {
+                someLapisNumberField: {
+                    min: 123,
                 },
             },
-        } satisfies Dataset;
+        };
 
-        const result = toLapisFilterWithoutVariant(pageState, additionalFilters);
+        const result = toLapisFilterWithoutVariant(filter, additionalFilters);
 
         expect(result).toStrictEqual({
             dateFrom: '2024-11-22',

--- a/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.ts
+++ b/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.ts
@@ -70,11 +70,16 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: number | undefined },
     );
 
+    const advancedQuery = pageState.datasetFilter.advancedQuery
+        ? { advancedQuery: pageState.datasetFilter.advancedQuery }
+        : {};
+
     return {
         ...locationFilters,
         ...dateFilters,
         ...textFilters,
         ...numberRangeFilters,
         ...additionalFilters,
+        ...advancedQuery,
     };
 }

--- a/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.ts
+++ b/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.ts
@@ -1,12 +1,12 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { Dataset } from '../View.ts';
+import type { DatasetFilter } from '../View.ts';
 
 export function toLapisFilterWithoutVariant(
-    pageState: Dataset,
+    datasetFilter: DatasetFilter,
     additionalFilters: Record<string, string> | undefined,
 ): LapisFilter {
-    const dateFilters = Object.entries(pageState.datasetFilter.dateFilters).reduce(
+    const dateFilters = Object.entries(datasetFilter.dateFilters).reduce(
         (acc, [lapisField, dateRange]) => {
             if (dateRange === undefined || dateRange === null) {
                 return acc;
@@ -24,7 +24,7 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: string | undefined },
     );
 
-    const textFilters = Object.entries(pageState.datasetFilter.textFilters).reduce(
+    const textFilters = Object.entries(datasetFilter.textFilters).reduce(
         (acc, [lapisField, text]) => {
             if (text === undefined) {
                 return acc;
@@ -38,7 +38,7 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: string | undefined },
     );
 
-    const locationFilters = Object.values(pageState.datasetFilter.locationFilters).reduce(
+    const locationFilters = Object.values(datasetFilter.locationFilters).reduce(
         (acc, lapisLocation) => {
             if (lapisLocation === undefined) {
                 return acc;
@@ -52,7 +52,7 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: string | undefined },
     );
 
-    const numberRangeFilters = Object.entries(pageState.datasetFilter.numberFilters).reduce(
+    const numberRangeFilters = Object.entries(datasetFilter.numberFilters).reduce(
         (acc, [lapisField, numberRange]) => {
             if (numberRange === undefined) {
                 return acc;
@@ -70,9 +70,7 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: number | undefined },
     );
 
-    const advancedQuery = pageState.datasetFilter.advancedQuery
-        ? { advancedQuery: pageState.datasetFilter.advancedQuery }
-        : {};
+    const advancedQuery = datasetFilter.advancedQuery ? { advancedQuery: datasetFilter.advancedQuery } : {};
 
     return {
         ...locationFilters,

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -52,7 +52,6 @@ class RsvAConstants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -51,7 +51,8 @@ class RsvAConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -52,7 +52,6 @@ class RsvBConstants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -51,7 +51,8 @@ class RsvBConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -59,7 +59,6 @@ class VictoriaConstants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -58,7 +58,8 @@ class VictoriaConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions,

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -64,7 +64,6 @@ class WestNileConstants implements OrganismConstants {
         },
     ];
     public readonly useVariantQuery = false;
-    public readonly useAdvancedQuery = true;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -63,7 +63,8 @@ class WestNileConstants implements OrganismConstants {
             label: 'Collection device',
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
+    public readonly useAdvancedQuery = true;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;


### PR DESCRIPTION
Resolves #702

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary

This adds the advanced query text field to each page. It is currently only enabled for covid, since we don't have the correct lapis version on loculus. The config I implemented is some kind of workaround, when we have updated all lapis instances, we can remove it and display the advanced query for all pathogens. 

We could think about restructuring the config for the variant filters. For the baseline filters we have a unified way to configure them. It would be nice to have a similar approach there. 

We could also remove the variantQuery in the future. I think the advanced queries can do everything we want to do with the variantQueries.

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

![Screenshot 2025-06-11 094817](https://github.com/user-attachments/assets/01d11b5e-cc70-483b-8766-983ea1011246)


<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
