### PR TITLE
fix(website): recompute date range options

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@astrojs/node": "^9.2.2",
                 "@auth/core": "^0.37.4",
-                "@genspectrum/dashboard-components": "^0.19.9",
+                "@genspectrum/dashboard-components": "^0.20.0",
                 "@tanstack/react-query": "^5.80.6",
                 "astro": "^5.9.2",
                 "auth-astro": "^4.2.0",
@@ -1522,9 +1522,9 @@
             "license": "MIT"
         },
         "node_modules/@genspectrum/dashboard-components": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@genspectrum/dashboard-components/-/dashboard-components-0.19.9.tgz",
-            "integrity": "sha512-VgaTRhD8C4DaF205JJud5ffECiMn4o5lph1aCHVr46KYU+QDjOMTZdDULh0Q8mtW9LWvIeoJrTlNCfYNZpWD2g==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@genspectrum/dashboard-components/-/dashboard-components-0.20.0.tgz",
+            "integrity": "sha512-MXo5y6DbGmAh+NgPWSQrirrLkCRW09yH671oBw7BwXWkTy2C7ipZEf/QP0tTtdFPcnBcWuO2YhjJak36r+AFhw==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.5",

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@astrojs/node": "^9.2.2",
         "@auth/core": "^0.37.4",
-        "@genspectrum/dashboard-components": "^0.19.9",
+        "@genspectrum/dashboard-components": "^0.20.0",
         "@tanstack/react-query": "^5.80.6",
         "astro": "^5.9.2",
         "auth-astro": "^4.2.0",

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -14,7 +14,7 @@ export type LocationFilterConfig = {
 };
 
 export type DateRangeFilterConfig = {
-    dateRangeOptions: DateRangeOption[];
+    dateRangeOptions: () => DateRangeOption[];
     earliestDate: string;
     dateColumn: string;
     label?: string;
@@ -76,7 +76,7 @@ export function BaselineSelector({
                                     }}
                                     earliestDate={config.earliestDate}
                                     value={datasetFilter.dateFilters[config.dateColumn]}
-                                    dateRangeOptions={config.dateRangeOptions}
+                                    dateRangeOptions={config.dateRangeOptions()}
                                 />
                             </label>
                         );

--- a/website/src/util/defaultDateRangeOption.ts
+++ b/website/src/util/defaultDateRangeOption.ts
@@ -18,27 +18,33 @@ export const defaultDateRangeOption = {
     before2017: { label: 'Before 2017', dateTo: '2016-12-31' },
 } satisfies { [key: string]: DateRangeOption };
 
-export const defaultDateRangeOptions = [
-    dateRangeOptionPresets.last6Months,
-    dateRangeOptionPresets.lastYear,
-    defaultDateRangeOption.since2020,
-    defaultDateRangeOption.from2010to2019,
-    defaultDateRangeOption.from2000to2009,
-    defaultDateRangeOption.since2000,
-    defaultDateRangeOption.before2000,
-    dateRangeOptionPresets.allTimes,
-];
+export const defaultDateRangeOptions = () => {
+    const presets = dateRangeOptionPresets();
+    return [
+        presets.last6Months,
+        presets.lastYear,
+        defaultDateRangeOption.since2020,
+        defaultDateRangeOption.from2010to2019,
+        defaultDateRangeOption.from2000to2009,
+        defaultDateRangeOption.since2000,
+        defaultDateRangeOption.before2000,
+        presets.allTimes,
+    ];
+};
 
-export const fineGrainedDefaultDateRangeOptions = [
-    dateRangeOptionPresets.lastMonth,
-    dateRangeOptionPresets.last2Months,
-    dateRangeOptionPresets.last3Months,
-    dateRangeOptionPresets.last6Months,
-    dateRangeOptionPresets.lastYear,
-    defaultDateRangeOption.since2020,
-    defaultDateRangeOption.from2010to2019,
-    defaultDateRangeOption.from2000to2009,
-    defaultDateRangeOption.since2000,
-    defaultDateRangeOption.before2000,
-    dateRangeOptionPresets.allTimes,
-];
+export const fineGrainedDefaultDateRangeOptions = () => {
+    const presets = dateRangeOptionPresets();
+    return [
+        presets.lastMonth,
+        presets.last2Months,
+        presets.last3Months,
+        presets.last6Months,
+        presets.lastYear,
+        defaultDateRangeOption.since2020,
+        defaultDateRangeOption.from2010to2019,
+        defaultDateRangeOption.from2000to2009,
+        defaultDateRangeOption.since2000,
+        defaultDateRangeOption.before2000,
+        presets.allTimes,
+    ];
+};

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -203,7 +203,7 @@ export const INFLUENZA_ACCESSION_DOWNLOAD_FIELDS = [
 export const PATHOPLEXUS_HOST_FIELD = 'hostNameScientific';
 
 type FiltersConfig = {
-    dateRangeOptions: DateRangeOption[];
+    dateRangeOptions: () => DateRangeOption[];
     earliestDate: string;
     completenessSuffixes?: SuffixConfig[];
 };

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -46,19 +46,22 @@ const mainLocationFields = ['region', 'country', 'division'];
 const NEXTCLADE_PANGO_LINEAGE_FIELD_NAME = 'nextcladePangoLineage';
 const NEXTSTRAIN_CLADE_FIELD_NAME = 'nextstrainClade';
 
-const dateRangeOptions = [
-    dateRangeOptionPresets.lastMonth,
-    dateRangeOptionPresets.last2Months,
-    dateRangeOptionPresets.last3Months,
-    dateRangeOptionPresets.last6Months,
-    dateRangeOptionPresets.lastYear,
-    defaultDateRangeOption.year2024,
-    defaultDateRangeOption.year2023,
-    defaultDateRangeOption.year2022,
-    defaultDateRangeOption.year2021,
-    defaultDateRangeOption.year2020,
-    dateRangeOptionPresets.allTimes,
-];
+const dateRangeOptions = () => {
+    const presets = dateRangeOptionPresets();
+    return [
+        presets.lastMonth,
+        presets.last2Months,
+        presets.last3Months,
+        presets.last6Months,
+        presets.lastYear,
+        defaultDateRangeOption.year2024,
+        defaultDateRangeOption.year2023,
+        defaultDateRangeOption.year2022,
+        defaultDateRangeOption.year2021,
+        defaultDateRangeOption.year2020,
+        presets.allTimes,
+    ];
+};
 
 class CovidConstants implements OrganismConstants {
     public readonly organism = Organisms.covid;

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -60,23 +60,26 @@ class MpoxConstants implements OrganismConstants {
     public readonly useAdvancedQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
-            dateRangeOptions: [
-                dateRangeOptionPresets.lastMonth,
-                dateRangeOptionPresets.last2Months,
-                dateRangeOptionPresets.last3Months,
-                dateRangeOptionPresets.last6Months,
-                dateRangeOptionPresets.lastYear,
-                defaultDateRangeOption.year2024,
-                defaultDateRangeOption.year2023,
-                defaultDateRangeOption.year2022,
-                defaultDateRangeOption.year2021,
-                defaultDateRangeOption.since2021,
-                defaultDateRangeOption.before2021,
-                defaultDateRangeOption.since2017,
-                defaultDateRangeOption.from2017to2020,
-                defaultDateRangeOption.before2017,
-                dateRangeOptionPresets.allTimes,
-            ],
+            dateRangeOptions: () => {
+                const presets = dateRangeOptionPresets();
+                return [
+                    presets.lastMonth,
+                    presets.last2Months,
+                    presets.last3Months,
+                    presets.last6Months,
+                    presets.lastYear,
+                    defaultDateRangeOption.year2024,
+                    defaultDateRangeOption.year2023,
+                    defaultDateRangeOption.year2022,
+                    defaultDateRangeOption.year2021,
+                    defaultDateRangeOption.since2021,
+                    defaultDateRangeOption.before2021,
+                    defaultDateRangeOption.since2017,
+                    defaultDateRangeOption.from2017to2020,
+                    defaultDateRangeOption.before2017,
+                    presets.allTimes,
+                ];
+            },
             earliestDate: '1960-01-01',
         }),
     ];

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -36,7 +36,7 @@ const mockConstants: OrganismConstants = {
         },
         {
             type: 'date',
-            dateRangeOptions: [mockDateRangeOption],
+            dateRangeOptions: () => [mockDateRangeOption],
             earliestDate: '1999-01-01',
             dateColumn: 'date',
         },

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -36,7 +36,7 @@ const mockConstants: OrganismConstants = {
         },
         {
             type: 'date',
-            dateRangeOptions: [mockDateRangeOption],
+            dateRangeOptions: () => [mockDateRangeOption],
             earliestDate: '1999-01-01',
             dateColumn: 'date',
         },

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -36,7 +36,7 @@ const mockConstants: OrganismConstants = {
         },
         {
             type: 'date',
-            dateRangeOptions: [mockDateRangeOption],
+            dateRangeOptions: () => [mockDateRangeOption],
             earliestDate: '1999-01-01',
             dateColumn: 'date',
         },

--- a/website/src/views/pageStateHandlers/dateFilterFromToUrl.spec.ts
+++ b/website/src/views/pageStateHandlers/dateFilterFromToUrl.spec.ts
@@ -10,13 +10,13 @@ const dateConfigs = [
     {
         type: 'date',
         dateColumn: 'someDateField',
-        dateRangeOptions: [mockDateRangeOption],
+        dateRangeOptions: () => [mockDateRangeOption],
         earliestDate: '1999-01-01',
     },
     {
         type: 'date',
         dateColumn: 'someOtherDateField',
-        dateRangeOptions: [mockDateRangeOption],
+        dateRangeOptions: () => [mockDateRangeOption],
         earliestDate: '1999-01-01',
     },
     {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #721

### Summary

Instead of treating date range options as constants throughout runtime, they are now recomputed when needed, ensuring that date ranges like "last year" get updated.

Many thanks to @anna-parker for spotting the error and debugging!