### PR TITLE
chore(website): add predefined variant for H5N1

### DIFF
--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -78,6 +78,11 @@ class H5n1Constants implements OrganismConstants {
                 aminoAcidMutations: ['NA:V67I'],
             },
         },
+        {
+            mutations: {
+                aminoAcidMutations: ['PB2:D701N'],
+            },
+        },
     ];
 
     // Antiviral susceptibility mutations have been compiled here: https://www.who.int/teams/global-influenza-programme/laboratory-network/quality-assurance/antiviral-susceptibility-influenza/neuraminidase-inhibitor.


### PR DESCRIPTION
This adds `PB2:D701N` as a predefined variant which is mentioned in https://virological.org/t/timing-and-molecular-characterisation-of-the-transmission-to-cattle-of-h5n1-influenza-a-virus-genotype-d1-1-clade-2-3-4-4b/991. (Thanks @anna-parker for the suggestion!)

## PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by an appropriate test.~
