### PR TITLE
feat(website): add simple text field for advanced queries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "127.0.0.1:4321:4321"
     environment:
       BACKEND_URL: http://backend:8080
-      DASHBOARDS_ENVIRONMENT: dashboards-prod
+      PUBLIC_DASHBOARDS_ENVIRONMENT: dashboards-prod
       GITHUB_CLIENT_ID: "dummy"
       GITHUB_CLIENT_SECRET: "dummy"
 

--- a/website/.env.e2e
+++ b/website/.env.e2e
@@ -1,2 +1,2 @@
 CONFIG_DIR=../backend/src/main/resources/
-DASHBOARDS_ENVIRONMENT=dashboards-prod
+PUBLIC_DASHBOARDS_ENVIRONMENT=dashboards-prod

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,6 +1,6 @@
 CONFIG_DIR=../backend/src/main/resources/
 BACKEND_URL=http://localhost:8080
-DASHBOARDS_ENVIRONMENT=dashboards-prod
+PUBLIC_DASHBOARDS_ENVIRONMENT=dashboards-prod
 LOG_DIR=./logs
 LOG_LEVEL=info
 

--- a/website/README.md
+++ b/website/README.md
@@ -42,7 +42,7 @@ The website needs the following environment variables:
   Actually there should only be two reasonable values:
     - `../backend/src/main/resources/` for local development (reusing the backend configuration)
     - `/config` in the Docker container (which contains copies of the backend configuration files)
-- `DASHBOARDS_ENVIRONMENT`: Toggle between different configurations.
+- `PUBLIC_DASHBOARDS_ENVIRONMENT`: Toggle between different configurations.
   This will read the corresponding configuration yaml files from the directory specified in the `CONFIG_DIR` environment
   variable.
 - `BACKEND_URL`: The URL of the backend server (typically the corresponding Docker compose service).

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -1,12 +1,20 @@
-import type { ChangeEventHandler } from 'react';
+import { type ChangeEvent, type FC, useEffect, useState } from 'react';
 
-export function AdvancedQueryFilter({
-    value,
-    onInput,
-}: {
+export const advancedQueryUrlParamForVariant = 'advancedQueryVariant';
+export const advancedQueryUrlParam = 'advancedQuery';
+
+type AdvancedQueryFilterProps = {
     value?: string;
-    onInput?: ChangeEventHandler<HTMLInputElement>;
-}) {
+    onInput?: (newValue: string | undefined) => void;
+};
+
+export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput }) => {
+    const [inputValue, setInputValue] = useState(value);
+
+    useEffect(() => {
+        setInputValue(value);
+    }, [value]);
+
     return (
         <label className='form-control'>
             <div className='label'>
@@ -15,9 +23,15 @@ export function AdvancedQueryFilter({
             <input
                 className='input input-bordered w-full'
                 placeholder={'Advanced query: A123T & ins_123:TA'}
-                value={value}
-                onInput={onInput}
+                value={inputValue}
+                onInput={(event: ChangeEvent<HTMLInputElement>) => {
+                    const newValue = event.target.value;
+                    setInputValue(newValue === '' ? undefined : newValue);
+                }}
+                onBlur={() => {
+                    onInput?.(inputValue);
+                }}
             ></input>
         </label>
     );
-}
+};

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -15,6 +15,10 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
         setInputValue(value);
     }, [value]);
 
+    if (import.meta.env.PUBLIC_DASHBOARDS_ENVIRONMENT !== 'dashboards-staging') {
+        return null;
+    }
+
     return (
         <label className='form-control'>
             <div className='label'>

--- a/website/src/components/genspectrum/VariantQueryFilter.tsx
+++ b/website/src/components/genspectrum/VariantQueryFilter.tsx
@@ -1,0 +1,23 @@
+import type { ChangeEventHandler } from 'react';
+
+export function VariantQueryFilter({
+    value,
+    onInput,
+}: {
+    value?: string;
+    onInput?: ChangeEventHandler<HTMLInputElement>;
+}) {
+    return (
+        <label className='form-control'>
+            <div className='label'>
+                <span className='label-text'>Variant query</span>
+            </div>
+            <input
+                className='input input-bordered w-full'
+                placeholder={'Variant query: A123T & ins_123:TA'}
+                value={value}
+                onInput={onInput}
+            ></input>
+        </label>
+    );
+}

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -2,6 +2,7 @@ import type { DateRangeOption, LapisFilter } from '@genspectrum/dashboard-compon
 
 import type { DatasetFilter } from '../../views/View.ts';
 import { locationFieldsToFilterIdentifier } from '../../views/pageStateHandlers/locationFilterFromToUrl.ts';
+import { AdvancedQueryFilter } from '../genspectrum/AdvancedQueryFilter.tsx';
 import { GsDateRangeFilter } from '../genspectrum/GsDateRangeFilter.tsx';
 import { GsLocationFilter } from '../genspectrum/GsLocationFilter.tsx';
 import { GsNumerRangeFilter } from '../genspectrum/GsNumerRangeFilter.tsx';
@@ -39,7 +40,8 @@ export type BaselineFilterConfig =
       } & DateRangeFilterConfig)
     | ({ type: 'text' } & TextInputConfig)
     | ({ type: 'location' } & LocationFilterConfig)
-    | ({ type: 'number' } & NumberRangeFilterConfig);
+    | ({ type: 'number' } & NumberRangeFilterConfig)
+    | { type: 'advancedQuery' };
 
 export function BaselineSelector({
     baselineFilterConfigs,
@@ -156,6 +158,20 @@ export function BaselineSelector({
                                     }}
                                 />
                             </label>
+                        );
+                    }
+                    case 'advancedQuery': {
+                        return (
+                            <AdvancedQueryFilter
+                                key={'advancedQuery'}
+                                onInput={(newValue) => {
+                                    setDatasetFilter({
+                                        ...datasetFilter,
+                                        advancedQuery: newValue,
+                                    });
+                                }}
+                                value={datasetFilter.advancedQuery ?? ''}
+                            />
                         );
                     }
                 }

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -23,7 +23,7 @@ export function CompareSideBySidePageStateSelector({
 }) {
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
     const variantFilterConfig = useMemo(
-        () => makeVariantFilterConfig(view.organismConstants, { enableMutationFilter: true }),
+        () => makeVariantFilterConfig(view.organismConstants),
         [view.organismConstants],
     );
     const [pageState, setPageState] = useState(initialPageState);

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -25,9 +25,7 @@ export function CompareVariantsPageStateSelector({
 
     const variantFilterConfigs = useMemo(() => {
         return new Map(
-            pageState.variants
-                .entries()
-                .map(([id]) => [id, makeVariantFilterConfig(view.organismConstants, { enableMutationFilter: true })]),
+            pageState.variants.entries().map(([id]) => [id, makeVariantFilterConfig(view.organismConstants)]),
         );
     }, [pageState.variants, view.organismConstants]);
 

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -24,7 +24,7 @@ export function CompareVariantsToBaselineStateSelector({
     const [pageState, setPageState] = useState(initialPageState);
 
     const variantFilterConfig = useMemo(
-        () => makeVariantFilterConfig(view.organismConstants, { enableMutationFilter: true }),
+        () => makeVariantFilterConfig(view.organismConstants),
         [view.organismConstants],
     );
 

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -3,12 +3,13 @@ import { useMemo, useState } from 'react';
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector } from './BaselineSelector.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
-import { makeVariantFilterConfig, VariantSelector } from './VariantSelector.tsx';
 import type { OrganismsConfig } from '../../config.ts';
 import { Inset } from '../../styles/Inset.tsx';
 import type { DatasetAndVariantData } from '../../views/View.ts';
+import { getMutationFilter } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { sequencingEffortsViewKey } from '../../views/viewKeys.ts';
+import { GsMutationFilter } from '../genspectrum/GsMutationFilter.tsx';
 
 export function SequencingEffortsPageStateSelector({
     organismViewKey,
@@ -20,14 +21,7 @@ export function SequencingEffortsPageStateSelector({
     initialPageState: DatasetAndVariantData;
 }) {
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
-    const variantFilterConfig = useMemo(
-        () =>
-            makeVariantFilterConfig(view.organismConstants, {
-                enableMutationFilter: false,
-                enableVariantQuery: false,
-            }),
-        [view.organismConstants],
-    );
+
     const [pageState, setPageState] = useState(initialPageState);
 
     const currentLapisFilter = useMemo(() => {
@@ -38,7 +32,7 @@ export function SequencingEffortsPageStateSelector({
         <div className='flex flex-col gap-4'>
             <div>
                 <SelectorHeadline>Filter dataset</SelectorHeadline>
-                <Inset className='flex flex-col gap-6 p-2'>
+                <Inset className='flex flex-col gap-2 p-2'>
                     <BaselineSelector
                         baselineFilterConfigs={view.organismConstants.baselineFilterConfigs}
                         lapisFilter={currentLapisFilter}
@@ -50,16 +44,21 @@ export function SequencingEffortsPageStateSelector({
                             }));
                         }}
                     />
-                    <VariantSelector
-                        onVariantFilterChange={(newVariantFilter) => {
+                    <GsMutationFilter
+                        initialValue={
+                            pageState.variantFilter.mutations === undefined
+                                ? undefined
+                                : getMutationFilter(pageState.variantFilter.mutations)
+                        }
+                        onMutationChange={(mutations) => {
                             setPageState((previousState) => ({
                                 ...previousState,
-                                variantFilter: newVariantFilter,
+                                variantFilter: {
+                                    ...previousState.variantFilter,
+                                    mutations,
+                                },
                             }));
                         }}
-                        variantFilterConfig={variantFilterConfig}
-                        variantFilter={pageState.variantFilter}
-                        lapisFilter={currentLapisFilter}
                     />
                 </Inset>
             </div>

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -2,14 +2,13 @@ import { useMemo, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector } from './BaselineSelector.tsx';
+import { LineageFilterInput } from './LineageFilterInput.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
 import type { OrganismsConfig } from '../../config.ts';
 import { Inset } from '../../styles/Inset.tsx';
 import type { DatasetAndVariantData } from '../../views/View.ts';
-import { getMutationFilter } from '../../views/helpers.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
 import type { sequencingEffortsViewKey } from '../../views/viewKeys.ts';
-import { GsMutationFilter } from '../genspectrum/GsMutationFilter.tsx';
 
 export function SequencingEffortsPageStateSelector({
     organismViewKey,
@@ -44,22 +43,25 @@ export function SequencingEffortsPageStateSelector({
                             }));
                         }}
                     />
-                    <GsMutationFilter
-                        initialValue={
-                            pageState.variantFilter.mutations === undefined
-                                ? undefined
-                                : getMutationFilter(pageState.variantFilter.mutations)
-                        }
-                        onMutationChange={(mutations) => {
-                            setPageState((previousState) => ({
-                                ...previousState,
-                                variantFilter: {
-                                    ...previousState.variantFilter,
-                                    mutations,
-                                },
-                            }));
-                        }}
-                    />
+                    {view.organismConstants.lineageFilters.map((lineageFilterConfig) => (
+                        <LineageFilterInput
+                            lineageFilterConfig={lineageFilterConfig}
+                            onLineageChange={(lineage) => {
+                                setPageState((previousState) => ({
+                                    ...previousState,
+                                    variantFilter: {
+                                        lineages: {
+                                            ...previousState.variantFilter.lineages,
+                                            [lineageFilterConfig.lapisField]: lineage,
+                                        },
+                                    },
+                                }));
+                            }}
+                            key={lineageFilterConfig.lapisField}
+                            lapisFilter={currentLapisFilter}
+                            value={pageState.variantFilter.lineages?.[lineageFilterConfig.lapisField]}
+                        />
+                    ))}
                 </Inset>
             </div>
             <div className='sticky bottom-0 w-full pb-5 backdrop-blur-xs'>

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -21,7 +21,7 @@ export function SingleVariantPageStateSelector({
 }) {
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
     const variantFilterConfig = useMemo(
-        () => makeVariantFilterConfig(view.organismConstants, { enableMutationFilter: true }),
+        () => makeVariantFilterConfig(view.organismConstants),
         [view.organismConstants],
     );
     const [pageState, setPageState] = useState(initialPageState);

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -11,28 +11,20 @@ import { VariantQueryFilter } from '../genspectrum/VariantQueryFilter.tsx';
 
 export type VariantFilterConfig = {
     lineageFilterConfigs?: LineageFilterConfig[];
-    mutationFilterConfig: {
-        enabled: boolean;
-    };
     variantQueryConfig: {
         enabled: boolean;
     };
 };
 
 type Options = {
-    enableMutationFilter: boolean;
     enableVariantQuery?: boolean;
 };
 
-export function makeVariantFilterConfig(
-    organismConstants: OrganismConstants,
-    { enableMutationFilter, enableVariantQuery }: Options,
-) {
+export function makeVariantFilterConfig(organismConstants: OrganismConstants, options?: Options): VariantFilterConfig {
     return {
         lineageFilterConfigs: organismConstants.lineageFilters,
-        mutationFilterConfig: { enabled: enableMutationFilter },
         variantQueryConfig: {
-            enabled: enableVariantQuery ?? organismConstants.useVariantQuery,
+            enabled: options?.enableVariantQuery ?? organismConstants.useVariantQuery,
         },
     };
 }
@@ -96,22 +88,20 @@ export function VariantSelector({
                             value={variantFilter.lineages?.[lineageFilterConfig.lapisField]}
                         />
                     ))}
-                    {variantFilterConfig.mutationFilterConfig.enabled && (
-                        <GsMutationFilter
-                            initialValue={
-                                variantFilter.mutations === undefined
-                                    ? undefined
-                                    : getMutationFilter(variantFilter.mutations)
-                            }
-                            onMutationChange={(mutations) => {
-                                onVariantFilterChange({
-                                    ...variantFilter,
-                                    variantQuery: undefined,
-                                    mutations,
-                                });
-                            }}
-                        />
-                    )}
+                    <GsMutationFilter
+                        initialValue={
+                            variantFilter.mutations === undefined
+                                ? undefined
+                                : getMutationFilter(variantFilter.mutations)
+                        }
+                        onMutationChange={(mutations) => {
+                            onVariantFilterChange({
+                                ...variantFilter,
+                                variantQuery: undefined,
+                                mutations,
+                            });
+                        }}
+                    />
                     <AdvancedQueryFilter
                         onInput={(newValue) => {
                             onVariantFilterChange({

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -7,6 +7,7 @@ import type { VariantFilter } from '../../views/View.ts';
 import { getMutationFilter } from '../../views/helpers.ts';
 import { AdvancedQueryFilter } from '../genspectrum/AdvancedQueryFilter.tsx';
 import { GsMutationFilter } from '../genspectrum/GsMutationFilter.tsx';
+import { VariantQueryFilter } from '../genspectrum/VariantQueryFilter.tsx';
 
 export type VariantFilterConfig = {
     lineageFilterConfigs?: LineageFilterConfig[];
@@ -14,6 +15,9 @@ export type VariantFilterConfig = {
         enabled: boolean;
     };
     variantQueryConfig: {
+        enabled: boolean;
+    };
+    advancedFilterConfig: {
         enabled: boolean;
     };
 };
@@ -31,7 +35,10 @@ export function makeVariantFilterConfig(
         lineageFilterConfigs: organismConstants.lineageFilters,
         mutationFilterConfig: { enabled: enableMutationFilter },
         variantQueryConfig: {
-            enabled: enableVariantQuery ?? organismConstants.useAdvancedQuery,
+            enabled: enableVariantQuery ?? organismConstants.useVariantQuery,
+        },
+        advancedFilterConfig: {
+            enabled: true,
         },
     };
 }
@@ -55,7 +62,7 @@ export function VariantSelector({
         <div>
             {variantFilterConfig.variantQueryConfig.enabled && (
                 <label className='mb-1 flex cursor-pointer items-center gap-1 text-sm'>
-                    Advanced
+                    Variant query mode
                     <input
                         type='checkbox'
                         className='checkbox checkbox-xs'
@@ -66,7 +73,7 @@ export function VariantSelector({
             )}
 
             {isInVariantQueryMode ? (
-                <AdvancedQueryFilter
+                <VariantQueryFilter
                     onInput={(event) => {
                         onVariantFilterChange({
                             ...variantFilter,
@@ -109,6 +116,17 @@ export function VariantSelector({
                                     mutations,
                                 });
                             }}
+                        />
+                    )}
+                    {variantFilterConfig.advancedFilterConfig.enabled && (
+                        <AdvancedQueryFilter
+                            onInput={(newValue) => {
+                                onVariantFilterChange({
+                                    ...variantFilter,
+                                    advancedQuery: newValue,
+                                });
+                            }}
+                            value={variantFilter.advancedQuery ?? ''}
                         />
                     )}
                 </div>

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -17,9 +17,6 @@ export type VariantFilterConfig = {
     variantQueryConfig: {
         enabled: boolean;
     };
-    advancedFilterConfig: {
-        enabled: boolean;
-    };
 };
 
 type Options = {
@@ -36,9 +33,6 @@ export function makeVariantFilterConfig(
         mutationFilterConfig: { enabled: enableMutationFilter },
         variantQueryConfig: {
             enabled: enableVariantQuery ?? organismConstants.useVariantQuery,
-        },
-        advancedFilterConfig: {
-            enabled: true,
         },
     };
 }
@@ -118,17 +112,15 @@ export function VariantSelector({
                             }}
                         />
                     )}
-                    {variantFilterConfig.advancedFilterConfig.enabled && (
-                        <AdvancedQueryFilter
-                            onInput={(newValue) => {
-                                onVariantFilterChange({
-                                    ...variantFilter,
-                                    advancedQuery: newValue,
-                                });
-                            }}
-                            value={variantFilter.advancedQuery ?? ''}
-                        />
-                    )}
+                    <AdvancedQueryFilter
+                        onInput={(newValue) => {
+                            onVariantFilterChange({
+                                ...variantFilter,
+                                advancedQuery: newValue,
+                            });
+                        }}
+                        value={variantFilter.advancedQuery ?? ''}
+                    />
                 </div>
             )}
         </div>

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -35,7 +35,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
             {
                 Array.from(pageState.filters).map(([id, { variantFilter, datasetFilter }]) => {
                     const datasetLapisFilter = toLapisFilterWithoutVariant(
-                        { datasetFilter },
+                        datasetFilter,
                         view.organismConstants.additionalFilters,
                     );
                     const timeGranularity = chooseGranularityBasedOnDateRange({

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -98,7 +98,7 @@ function getConfigDir(): string {
 }
 
 function getEnvironment() {
-    return processEnvOrMetaEnv('DASHBOARDS_ENVIRONMENT', environmentSchema);
+    return processEnvOrMetaEnv('PUBLIC_DASHBOARDS_ENVIRONMENT', environmentSchema);
 }
 
 export function isLoginEnabled() {

--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -3,3 +3,12 @@
 // declare module 'set-cookie-parser' is added, because tsc checks our dependency auth-astro/server,
 // which uses set-cookie-parser, and it doesn't have types.
 declare module 'set-cookie-parser';
+
+interface ImportMetaEnv {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    readonly PUBLIC_DASHBOARDS_ENVIRONMENT: 'dashboards-staging' | 'dashboards-prod';
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -30,7 +30,7 @@ const downloadLinks = [...pageState.filters.entries()].map(
             {
                 Array.from(pageState.filters).map(([id, { variantFilter, datasetFilter }]) => {
                     const baselineLapisFilter = toLapisFilterWithoutVariant(
-                        { datasetFilter },
+                        datasetFilter,
                         view.organismConstants.additionalFilters,
                     );
                     const timeGranularity = chooseGranularityBasedOnDateRange({

--- a/website/src/views/OrganismConstants.ts
+++ b/website/src/views/OrganismConstants.ts
@@ -29,7 +29,7 @@ export interface OrganismConstants {
     readonly mainDateField: string;
     readonly additionalFilters: Record<string, string> | undefined;
     readonly aggregatedVisualizations: AggregatedVisualizations;
-    readonly useAdvancedQuery: boolean;
+    readonly useVariantQuery: boolean;
     readonly locationFields: string[];
     readonly baselineFilterConfigs: BaselineFilterConfig[];
     readonly lineageFilters: LineageFilterConfig[];
@@ -250,6 +250,7 @@ export function getPathoplexusFilters({
             label: 'Data use terms',
         },
         ...getCompletenessFilters(completenessSuffixes),
+        { type: 'advancedQuery' },
     ];
 }
 
@@ -316,5 +317,6 @@ export function getGenspectrumLoculusFilters({
             label: 'NCBI release date',
         },
         ...getCompletenessFilters(completenessSuffixes),
+        { type: 'advancedQuery' },
     ];
 }

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -13,6 +13,7 @@ export type DatasetFilter = {
     textFilters: TextFilterState;
     dateFilters: DateFilterState;
     numberFilters: NumberFilterState;
+    advancedQuery?: string;
 };
 
 export type LocationFilterState = {
@@ -39,6 +40,7 @@ export type VariantFilter = {
     mutations?: LapisMutationQuery;
     lineages?: LapisLineageQuery;
     variantQuery?: string;
+    advancedQuery?: string;
 };
 
 export type VariantData<VariantFilterType = VariantFilter> = {

--- a/website/src/views/cchf.ts
+++ b/website/src/views/cchf.ts
@@ -54,7 +54,7 @@ class CchfConstants implements OrganismConstants {
     public readonly mainDateField: string;
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/covid.ts
+++ b/website/src/views/covid.ts
@@ -1,6 +1,11 @@
 import { dateRangeOptionPresets, type MutationAnnotation, views } from '@genspectrum/dashboard-components/util';
 
-import { getIntegerFromSearch, getLapisVariantQuery, setSearchFromLapisVariantQuery } from './helpers.ts';
+import {
+    getIntegerFromSearch,
+    getLapisVariantQuery,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from './helpers.ts';
 import { type OrganismsConfig } from '../config.ts';
 import {
     BaseView,
@@ -36,6 +41,7 @@ import type { BaselineFilterConfig } from '../components/pageStateSelectors/Base
 import { ALL_TIMES_LABEL, defaultDateRangeOption } from '../util/defaultDateRangeOption.ts';
 import { formatUrl } from '../util/formatUrl.ts';
 import { setSearchFromTextFilters } from './pageStateHandlers/textFilterFromToUrl.ts';
+import { advancedQueryUrlParam } from '../components/genspectrum/AdvancedQueryFilter.tsx';
 
 const earliestDate = '2020-01-06';
 const hostField = 'host';
@@ -75,7 +81,7 @@ class CovidConstants implements OrganismConstants {
             filterType: 'lineage' as const,
         },
     ];
-    public readonly useAdvancedQuery = true;
+    public readonly useVariantQuery = true;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         {
             type: 'location',
@@ -113,6 +119,7 @@ class CovidConstants implements OrganismConstants {
             placeholderText: 'Exposure location',
             label: 'Exposure location',
         },
+        { type: 'advancedQuery' },
     ];
     public readonly hostField: string = hostField;
     public readonly originatingLabField = 'originatingLab';
@@ -213,6 +220,7 @@ class CovidSingleVariantStateHandler
         setSearchFromLocationFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         setSearchFromLapisVariantQuery(
             search,

--- a/website/src/views/denv1.ts
+++ b/website/src/views/denv1.ts
@@ -51,7 +51,7 @@ class Denv1Constants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/denv2.ts
+++ b/website/src/views/denv2.ts
@@ -51,7 +51,7 @@ class Denv2Constants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/denv3.ts
+++ b/website/src/views/denv3.ts
@@ -51,7 +51,7 @@ class Denv3Constants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/denv4.ts
+++ b/website/src/views/denv4.ts
@@ -51,7 +51,7 @@ class Denv4Constants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/ebolaSudan.ts
+++ b/website/src/views/ebolaSudan.ts
@@ -49,7 +49,7 @@ class EbolaSudanConstants implements OrganismConstants {
     public readonly mainDateField: string;
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/ebolaZaire.ts
+++ b/website/src/views/ebolaZaire.ts
@@ -50,7 +50,7 @@ class EbolaZaireConstants implements OrganismConstants {
     public readonly mainDateField: string;
     public readonly locationFields = PATHOPLEXUS_LOCATION_FIELDS;
     public readonly lineageFilters: LineageFilterConfig[] = [];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -58,7 +58,7 @@ class H1n1pdmConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -58,7 +58,7 @@ class H3n2Constants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/h5n1.ts
+++ b/website/src/views/h5n1.ts
@@ -52,7 +52,7 @@ class H5n1Constants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/helpers.ts
+++ b/website/src/views/helpers.ts
@@ -1,4 +1,5 @@
 import type { VariantFilter } from './View.ts';
+import { advancedQueryUrlParamForVariant } from '../components/genspectrum/AdvancedQueryFilter.tsx';
 import type { MutationFilter } from '../components/genspectrum/GsMutationFilter.tsx';
 
 export const setSearchFromString = (
@@ -81,9 +82,12 @@ export const getLapisVariantQuery = (
         })
         .reduce((acc, curr) => ({ ...acc, ...curr }), {});
 
+    const advancedQuery = getStringFromSearch(search, advancedQueryUrlParamForVariant);
+
     return {
         mutations: { ...getLapisMutationsQueryFromSearch(search) },
         lineages: { ...lineageQuery },
+        advancedQuery,
     };
 };
 
@@ -108,5 +112,6 @@ export const setSearchFromLapisVariantQuery = (
                 setSearchFromString(search, filter, query.lineages[filter]);
             }
         });
+        setSearchFromString(search, advancedQueryUrlParamForVariant, query.advancedQuery);
     }
 };

--- a/website/src/views/influenza-a.ts
+++ b/website/src/views/influenza-a.ts
@@ -55,7 +55,7 @@ class InfluenzaAConstants implements OrganismConstants {
             completenessSuffixes: [],
         }),
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly hostField: string = GENSPECTRUM_LOCULUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/influenza-b.ts
+++ b/website/src/views/influenza-b.ts
@@ -49,7 +49,7 @@ class InfluenzaBConstants implements OrganismConstants {
             completenessSuffixes: [],
         }),
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly hostField: string = GENSPECTRUM_LOCULUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;

--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -57,7 +57,7 @@ class MpoxConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: () => {

--- a/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareSideBySidePageStateHandler.spec.ts
@@ -26,7 +26,7 @@ const mockConstants: OrganismConstants = {
         compareSideBySide: [],
     },
     accessionDownloadFields: [],
-    useAdvancedQuery: false,
+    useVariantQuery: false,
     baselineFilterConfigs: [
         {
             type: 'text',
@@ -99,7 +99,8 @@ describe('CompareSideBySideStateHandler', () => {
         const url = new URL(
             'http://example.com/covid/compare-side-by-side?' +
                 'columns=3' +
-                '&lineage%241=B.1.1.7&date%241=Last+7+Days' +
+                '&lineage%241=B.1.1.7&advancedQuery%241=country%3DUS&date%241=Last+7+Days' +
+                '&advancedQueryVariant%241=123T' +
                 '&variantQuery%242=C234G' +
                 '&',
         );
@@ -129,12 +130,14 @@ describe('CompareSideBySideStateHandler', () => {
                 textFilters: {},
                 locationFilters: {},
                 numberFilters: {},
+                advancedQuery: 'country=US',
             },
             variantFilter: {
                 lineages: {
                     lineage: 'B.1.1.7',
                 },
                 mutations: {},
+                advancedQuery: '123T',
             },
         });
 
@@ -162,10 +165,12 @@ describe('CompareSideBySideStateHandler', () => {
                             dateFilters: { date: mockDateRangeOption },
                             textFilters: {},
                             numberFilters: {},
+                            advancedQuery: 'country=US',
                         },
                         variantFilter: {
                             lineages: { lineage: 'B.1.1.7' },
                             mutations: {},
+                            advancedQuery: '123T',
                         },
                     },
                 ],
@@ -192,7 +197,8 @@ describe('CompareSideBySideStateHandler', () => {
         expect(url).toBe(
             '/covid/compare-side-by-side?' +
                 'columns=2' +
-                '&lineage%240=B.1.1.7&date%240=Last+7+Days' +
+                '&lineage%240=B.1.1.7&advancedQueryVariant%240=123T' +
+                '&date%240=Last+7+Days&advancedQuery%240=country%3DUS' +
                 '&variantQuery%241=C234G&date%241=Last+7+Days' +
                 '&',
         );
@@ -237,6 +243,7 @@ describe('CompareSideBySideStateHandler', () => {
             },
         );
         expect(lapisFilter).toStrictEqual({
+            advancedQuery: undefined,
             dateFrom: '2024-11-22',
             dateTo: '2024-11-29',
             country: 'US',
@@ -269,6 +276,34 @@ describe('CompareSideBySideStateHandler', () => {
             country: 'US',
             someTextField: 'SomeText',
             variantQuery: 'C234G',
+        });
+    });
+
+    it('should convert variant filter with advancedQuery to Lapis filter', () => {
+        const lapisFilter = handler.variantFilterToLapisFilter(
+            {
+                dateFilters: { date: mockDateRangeOption },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                locationFilters: { 'country,region': { country: 'US' } },
+                textFilters: {
+                    someTextField: 'SomeText',
+                },
+                numberFilters: {},
+                advancedQuery: 'country = US',
+            },
+            {
+                lineages: { lineage: 'B.1.1.7' },
+                mutations: {},
+                advancedQuery: '123T',
+            },
+        );
+        expect(lapisFilter).toStrictEqual({
+            dateFrom: '2024-11-22',
+            dateTo: '2024-11-29',
+            country: 'US',
+            someTextField: 'SomeText',
+            lineage: 'B.1.1.7',
+            advancedQuery: '(country = US) and (123T)',
         });
     });
 });

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.spec.ts
@@ -26,7 +26,7 @@ const mockConstants: OrganismConstants = {
         compareSideBySide: [],
     },
     accessionDownloadFields: [],
-    useAdvancedQuery: true,
+    useVariantQuery: true,
     baselineFilterConfigs: [
         {
             type: 'text',
@@ -74,25 +74,31 @@ describe('CompareToBaselinePageStateHandler', () => {
         const url = new URL(
             'http://example.com/covid/compare-to-baseline?' +
                 'columns=3' +
-                '&country=US&date=Last 7 Days' +
-                '&lineage=B.2.3.4&nucleotideMutations=C234G' +
+                '&country=US&date=Last 7 Days&advancedQuery=country%3DUS' +
+                '&lineage=B.2.3.4&nucleotideMutations=C234G&advancedQueryVariant=123T' +
                 '&lineage$0=B.1.1.7&nucleotideMutations$0=D614G' +
-                '&lineage$1=A.1.2.3&aminoAcidMutations$1=S:A123T' +
+                '&lineage$1=A.1.2.3&aminoAcidMutations$1=S:A123T&advancedQueryVariant$1=345G' +
                 '&variantQuery$2=A123T' +
                 '&',
         );
 
         const pageState = handler.parsePageStateFromUrl(url);
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        expect(pageState.datasetFilter.locationFilters).toEqual({ 'country,region': { country: 'US' } });
-        expect(pageState.datasetFilter.dateFilters).toEqual({ date: mockDateRangeOption });
+        expect(pageState.datasetFilter).toEqual({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            locationFilters: { 'country,region': { country: 'US' } },
+            dateFilters: { date: mockDateRangeOption },
+            advancedQuery: 'country=US',
+            numberFilters: {},
+            textFilters: {},
+        });
 
         expect(pageState.baselineFilter).toEqual({
             lineages: { lineage: 'B.2.3.4' },
             mutations: {
                 nucleotideMutations: ['C234G'],
             },
+            advancedQuery: '123T',
         });
 
         expect(pageState.variants.size).toBe(3);
@@ -103,6 +109,7 @@ describe('CompareToBaselinePageStateHandler', () => {
         expect(pageState.variants.get(1)).toEqual({
             lineages: { lineage: 'A.1.2.3' },
             mutations: { aminoAcidMutations: ['S:A123T'] },
+            advancedQuery: '345G',
         });
         expect(pageState.variants.get(2)).toEqual({
             variantQuery: 'A123T',
@@ -124,6 +131,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                     {
                         lineages: { lineage: 'A.1.2.3' },
                         mutations: { aminoAcidMutations: ['S:A123T'] },
+                        advancedQuery: '345G',
                     },
                 ],
                 [
@@ -139,6 +147,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
                 numberFilters: {},
+                advancedQuery: 'country=US',
             },
             baselineFilter: {
                 lineages: {
@@ -147,6 +156,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                 mutations: {
                     nucleotideMutations: ['C234G'],
                 },
+                advancedQuery: '123T',
             },
         };
         const url = handler.toUrl(pageState);
@@ -154,10 +164,10 @@ describe('CompareToBaselinePageStateHandler', () => {
             '/covid/compare-to-baseline?' +
                 'columns=3' +
                 '&nucleotideMutations%240=D614G&lineage%240=B.1.1.7' +
-                '&aminoAcidMutations%241=S%3AA123T&lineage%241=A.1.2.3' +
+                '&aminoAcidMutations%241=S%3AA123T&lineage%241=A.1.2.3&advancedQueryVariant%241=345G' +
                 '&variantQuery%242=C234G' +
-                '&country=US&date=Last+7+Days' +
-                '&nucleotideMutations=C234G&lineage=B.2.3.4' +
+                '&country=US&date=Last+7+Days&advancedQuery=country%3DUS' +
+                '&nucleotideMutations=C234G&lineage=B.2.3.4&advancedQueryVariant=123T' +
                 '&',
         );
     });
@@ -246,6 +256,7 @@ describe('CompareToBaselinePageStateHandler', () => {
                     {
                         lineages: { lineage: 'B.1.1.7' },
                         mutations: { nucleotideMutations: ['D614G'], aminoAcidMutations: ['S:A123T'] },
+                        advancedQuery: '123T',
                     },
                 ],
             ]),
@@ -253,8 +264,9 @@ describe('CompareToBaselinePageStateHandler', () => {
         const namedVariantFilter = handler.variantFiltersToNamedLapisFilters(pageState);
         expect(namedVariantFilter).deep.equal([
             {
-                displayName: 'B.1.1.7 + D614G + S:A123T',
+                displayName: 'B.1.1.7 + D614G + S:A123T + 123T',
                 lapisFilter: {
+                    advancedQuery: '123T',
                     aminoAcidMutations: ['S:A123T'],
                     dateFrom: '2024-11-22',
                     dateTo: '2024-11-29',
@@ -271,12 +283,14 @@ describe('CompareToBaselinePageStateHandler', () => {
             baselineFilter: {
                 lineages: { lineage: 'B.1.1.7' },
                 mutations: { nucleotideMutations: ['D614G'] },
+                advancedQuery: '123T',
             },
         };
 
         const baselineLapisFilter = handler.baselineFilterToLapisFilter(pageState);
 
         expect(baselineLapisFilter).toStrictEqual({
+            advancedQuery: '123T',
             dateFrom: '2024-11-22',
             dateTo: '2024-11-29',
             lineage: 'B.1.1.7',

--- a/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CompareToBaselinePageStateHandler.ts
@@ -4,14 +4,20 @@ import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type CompareToBaselineData, type DatasetFilter, getLineageFilterFields, type VariantFilter } from '../View.ts';
 import { compareToBaselineViewConstants } from '../ViewConstants.ts';
-import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
-import { type PageStateHandler, toDisplayName, toLapisFilterFromVariant } from './PageStateHandler.ts';
+import {
+    getLapisVariantQuery,
+    getStringFromSearch,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from '../helpers.ts';
+import { type PageStateHandler, toDisplayName, toLapisFilterWithVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { decodeFiltersFromSearch, searchParamsFromFilterMap } from './multipleFiltersFromToUrl.ts';
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
 import { parseTextFiltersFromUrl, setSearchFromTextFilters } from './textFilterFromToUrl.ts';
 import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
+import { advancedQueryUrlParam } from '../../components/genspectrum/AdvancedQueryFilter.tsx';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class CompareToBaselineStateHandler implements PageStateHandler<CompareToBaselineData> {
@@ -43,6 +49,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
+                advancedQuery: getStringFromSearch(search, advancedQueryUrlParam),
             },
             variants,
             baselineFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
@@ -58,6 +65,7 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         setSearchFromLapisVariantQuery(
             search,
@@ -68,28 +76,26 @@ export class CompareToBaselineStateHandler implements PageStateHandler<CompareTo
         return formatUrl(this.pathname, search);
     }
 
-    public datasetFilterToLapisFilter(baselineFilter: DatasetFilter): LapisFilter {
-        return toLapisFilterWithoutVariant({ datasetFilter: baselineFilter }, this.constants.additionalFilters);
+    public datasetFilterToLapisFilter(datasetFilter: DatasetFilter): LapisFilter {
+        return toLapisFilterWithoutVariant(datasetFilter, this.constants.additionalFilters);
     }
 
     public baselineFilterToLapisFilter(pageState: CompareToBaselineData): LapisFilter {
-        const datasetFilter = this.datasetFilterToLapisFilter(pageState.datasetFilter);
-
-        return {
-            ...datasetFilter,
-            ...toLapisFilterFromVariant(pageState.baselineFilter),
-        };
+        return toLapisFilterWithVariant({
+            datasetFilter: pageState.datasetFilter,
+            variantFilter: pageState.baselineFilter,
+            additionalFilters: this.constants.additionalFilters,
+        });
     }
 
     public variantFiltersToNamedLapisFilters(pageState: CompareToBaselineData): NamedLapisFilter[] {
-        const datasetFilter = this.datasetFilterToLapisFilter(pageState.datasetFilter);
-
         return Array.from(pageState.variants.values()).map((variantFilter) => {
             return {
-                lapisFilter: {
-                    ...datasetFilter,
-                    ...toLapisFilterFromVariant(variantFilter),
-                },
+                lapisFilter: toLapisFilterWithVariant({
+                    datasetFilter: pageState.datasetFilter,
+                    variantFilter,
+                    additionalFilters: this.constants.additionalFilters,
+                }),
                 displayName: toDisplayName(variantFilter),
             };
         });

--- a/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CompareVariantsPageStateHandler.spec.ts
@@ -26,7 +26,7 @@ const mockConstants: OrganismConstants = {
         compareSideBySide: [],
     },
     accessionDownloadFields: [],
-    useAdvancedQuery: true,
+    useVariantQuery: true,
     baselineFilterConfigs: [
         {
             type: 'text',
@@ -70,18 +70,23 @@ describe('CompareVariantsPageStateHandler', () => {
         const url = new URL(
             'http://example.com/covid/compareVariants?' +
                 'columns=3' +
-                '&country=US&date=Last 7 Days' +
+                '&country=US&date=Last 7 Days&advancedQuery=country%3DUS' +
                 '&lineage$0=B.1.1.7&nucleotideMutations$0=D614G' +
-                '&lineage$1=A.1.2.3&aminoAcidMutations$1=S:A123T' +
+                '&lineage$1=A.1.2.3&aminoAcidMutations$1=S:A123T&advancedQueryVariant$1=123T' +
                 '&variantQuery$2=C234G' +
                 '&',
         );
 
         const pageState = handler.parsePageStateFromUrl(url);
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        expect(pageState.datasetFilter.locationFilters).toEqual({ 'country,region': { country: 'US' } });
-        expect(pageState.datasetFilter.dateFilters).toEqual({ date: mockDateRangeOption });
+        expect(pageState.datasetFilter).toEqual({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            locationFilters: { 'country,region': { country: 'US' } },
+            dateFilters: { date: mockDateRangeOption },
+            numberFilters: {},
+            textFilters: {},
+            advancedQuery: 'country=US',
+        });
 
         expect(pageState.variants.size).toBe(3);
         expect(pageState.variants.get(0)).toEqual({
@@ -91,6 +96,7 @@ describe('CompareVariantsPageStateHandler', () => {
         expect(pageState.variants.get(1)).toEqual({
             lineages: { lineage: 'A.1.2.3' },
             mutations: { aminoAcidMutations: ['S:A123T'] },
+            advancedQuery: '123T',
         });
         expect(pageState.variants.get(2)).toEqual({
             variantQuery: 'C234G',
@@ -112,6 +118,7 @@ describe('CompareVariantsPageStateHandler', () => {
                     {
                         lineages: { lineage: 'A.1.2.3' },
                         mutations: { aminoAcidMutations: ['S:A123T'] },
+                        advancedQuery: '123T',
                     },
                 ],
                 [
@@ -127,6 +134,7 @@ describe('CompareVariantsPageStateHandler', () => {
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
                 numberFilters: {},
+                advancedQuery: 'country=US',
             },
         };
         const url = handler.toUrl(pageState);
@@ -134,10 +142,11 @@ describe('CompareVariantsPageStateHandler', () => {
             '/covid/compare-variants?' +
                 'columns=3' +
                 '&nucleotideMutations%240=D614G&lineage%240=B.1.1.7' +
-                '&aminoAcidMutations%241=S%3AA123T&lineage%241=A.1.2.3' +
+                '&aminoAcidMutations%241=S%3AA123T&lineage%241=A.1.2.3&advancedQueryVariant%241=123T' +
                 '&variantQuery%242=C234G' +
                 '&country=US' +
                 '&date=Last+7+Days' +
+                '&advancedQuery=country%3DUS' +
                 '&',
         );
     });
@@ -200,23 +209,32 @@ describe('CompareVariantsPageStateHandler', () => {
             ...mockDefaultPageState.datasetFilter,
             // eslint-disable-next-line @typescript-eslint/naming-convention
             locationFilters: { 'country,region': { country: 'US' } },
+            advancedQuery: 'country=US',
         });
         expect(lapisFilter).toStrictEqual({
             dateFrom: '2024-11-22',
             dateTo: '2024-11-29',
             country: 'US',
+            advancedQuery: 'country=US',
         });
     });
 
     it('should convert the page state to a named variant filter', () => {
         const pageState: CompareVariantsData = {
-            ...mockDefaultPageState,
+            datasetFilter: {
+                locationFilters: {},
+                dateFilters: { date: mockDateRangeOption },
+                textFilters: {},
+                numberFilters: {},
+                advancedQuery: 'country=US',
+            },
             variants: new Map([
                 [
                     1,
                     {
                         lineages: { lineage: 'B.1.1.7' },
                         mutations: { nucleotideMutations: ['D614G'], aminoAcidMutations: ['S:A123T'] },
+                        advancedQuery: '123T',
                     },
                 ],
                 [
@@ -230,8 +248,9 @@ describe('CompareVariantsPageStateHandler', () => {
         const namedVariantFilter = handler.variantFiltersToNamedLapisFilters(pageState);
         expect(namedVariantFilter).deep.equal([
             {
-                displayName: 'B.1.1.7 + D614G + S:A123T',
+                displayName: 'B.1.1.7 + D614G + S:A123T + 123T',
                 lapisFilter: {
+                    advancedQuery: '(country=US) and (123T)',
                     aminoAcidMutations: ['S:A123T'],
                     dateFrom: '2024-11-22',
                     dateTo: '2024-11-29',
@@ -242,6 +261,7 @@ describe('CompareVariantsPageStateHandler', () => {
             {
                 displayName: 'C234G',
                 lapisFilter: {
+                    advancedQuery: 'country=US',
                     dateFrom: '2024-11-22',
                     dateTo: '2024-11-29',
                     variantQuery: 'C234G',

--- a/website/src/views/pageStateHandlers/PageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/PageStateHandler.ts
@@ -1,4 +1,5 @@
-import { type VariantFilter } from '../View.ts';
+import { type DatasetAndVariantData, type VariantFilter } from '../View.ts';
+import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
 
 export interface PageStateHandler<PageState extends object> {
     parsePageStateFromUrl(url: URL): PageState;
@@ -8,15 +9,38 @@ export interface PageStateHandler<PageState extends object> {
     getDefaultPageUrl(): string;
 }
 
-export function toLapisFilterFromVariant(variantFilter: VariantFilter) {
+type FilterData = DatasetAndVariantData & { additionalFilters: Record<string, string> | undefined };
+
+export function toLapisFilterWithVariant({ variantFilter, datasetFilter, additionalFilters }: FilterData) {
     if (variantFilter.variantQuery) {
-        return { variantQuery: variantFilter.variantQuery };
+        return {
+            ...toLapisFilterWithoutVariant(datasetFilter, additionalFilters),
+            variantQuery: variantFilter.variantQuery,
+        };
     } else {
         return {
+            ...toLapisFilterWithoutVariant(datasetFilter, additionalFilters),
             ...variantFilter.lineages,
             ...variantFilter.mutations,
+            advancedQuery: concatenateAdvancedQueries(datasetFilter.advancedQuery, variantFilter.advancedQuery),
         };
     }
+}
+
+function concatenateAdvancedQueries(
+    datasetAdvancedQuery: string | undefined,
+    variantAdvancedQuery: string | undefined,
+) {
+    if (datasetAdvancedQuery === undefined && variantAdvancedQuery === undefined) {
+        return undefined;
+    }
+    if (datasetAdvancedQuery === undefined) {
+        return variantAdvancedQuery;
+    }
+    if (variantAdvancedQuery === undefined) {
+        return datasetAdvancedQuery;
+    }
+    return `(${datasetAdvancedQuery}) and (${variantAdvancedQuery})`;
 }
 
 export function toDisplayName(variantFilter: VariantFilter) {
@@ -28,11 +52,14 @@ export function toDisplayName(variantFilter: VariantFilter) {
         ? Object.values(variantFilter.lineages).filter((lineage) => lineage !== undefined)
         : [];
 
+    const advancedQuery: string[] = variantFilter.advancedQuery ? [variantFilter.advancedQuery] : [];
+
     return [
         ...lineages,
         ...(variantFilter.mutations?.nucleotideMutations ?? []),
         ...(variantFilter.mutations?.aminoAcidMutations ?? []),
         ...(variantFilter.mutations?.nucleotideInsertions ?? []),
         ...(variantFilter.mutations?.aminoAcidInsertions ?? []),
+        ...advancedQuery,
     ].join(' + ');
 }

--- a/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SequencingEffortsPageStateHandler.ts
@@ -2,13 +2,18 @@ import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { sequencingEffortsViewConstants } from '../ViewConstants.ts';
-import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
-import { type PageStateHandler, toLapisFilterFromVariant } from './PageStateHandler.ts';
+import {
+    getLapisVariantQuery,
+    getStringFromSearch,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from '../helpers.ts';
+import { type PageStateHandler, toLapisFilterWithVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
 import { parseTextFiltersFromUrl, setSearchFromTextFilters } from './textFilterFromToUrl.ts';
-import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
+import { advancedQueryUrlParam } from '../../components/genspectrum/AdvancedQueryFilter.tsx';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantData = DatasetAndVariantData>
@@ -32,6 +37,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
+                advancedQuery: getStringFromSearch(search, advancedQueryUrlParam),
             },
             variantFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
         };
@@ -43,6 +49,7 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         setSearchFromLapisVariantQuery(
             search,
@@ -53,10 +60,11 @@ export class SequencingEffortsStateHandler<PageState extends DatasetAndVariantDa
     }
 
     public toLapisFilter(pageState: DatasetAndVariantData) {
-        return {
-            ...toLapisFilterWithoutVariant(pageState, this.constants.additionalFilters),
-            ...toLapisFilterFromVariant(pageState.variantFilter),
-        };
+        return toLapisFilterWithVariant({
+            datasetFilter: pageState.datasetFilter,
+            variantFilter: pageState.variantFilter,
+            additionalFilters: this.constants.additionalFilters,
+        });
     }
 
     public getDefaultPageUrl(): string {

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.spec.ts
@@ -26,7 +26,7 @@ const mockConstants: OrganismConstants = {
         compareSideBySide: [],
     },
     accessionDownloadFields: [],
-    useAdvancedQuery: false,
+    useVariantQuery: false,
     baselineFilterConfigs: [
         {
             type: 'text',
@@ -83,23 +83,34 @@ describe('SingleVariantPageStateHandler', () => {
     it('should parse page state from URL, including variants', () => {
         const url = new URL(
             'http://example.com/covid/single-variant?' +
-                'country=US&date=Last 7 Days' +
-                '&lineage=B.2.3.4&nucleotideMutations=C234G&' +
+                'country=US' +
+                '&date=Last 7 Days' +
+                '&lineage=B.2.3.4' +
+                '&nucleotideMutations=C234G' +
+                '&advancedQuery=123T' +
+                '&advancedQueryVariant=345G+%26+567C' +
                 '&',
         );
 
         const pageState = handler.parsePageStateFromUrl(url);
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        expect(pageState.datasetFilter.locationFilters).toEqual({ 'country,region': { country: 'US' } });
-        expect(pageState.datasetFilter.dateFilters).toEqual({ date: mockDateRangeOption });
+        expect(pageState.datasetFilter).toEqual({
+            locationFilters: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'country,region': { country: 'US' },
+            },
+            dateFilters: { date: mockDateRangeOption },
+            advancedQuery: '123T',
+            numberFilters: {},
+            textFilters: {},
+        });
 
         expect(pageState.variantFilter).toEqual({
             lineages: { lineage: 'B.2.3.4' },
             mutations: {
                 nucleotideMutations: ['C234G'],
             },
-            variantQuery: undefined,
+            advancedQuery: '345G & 567C',
         });
     });
 
@@ -108,6 +119,7 @@ describe('SingleVariantPageStateHandler', () => {
             variantFilter: {
                 lineages: { lineage: 'B.1.1.7' },
                 mutations: { nucleotideMutations: ['D614G'] },
+                advancedQuery: '345G & 567C',
             },
             datasetFilter: {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -115,6 +127,7 @@ describe('SingleVariantPageStateHandler', () => {
                 dateFilters: { date: mockDateRangeOption },
                 textFilters: {},
                 numberFilters: {},
+                advancedQuery: 'country = Germany & 123T',
             },
         };
         const url = handler.toUrl(pageState);
@@ -122,7 +135,10 @@ describe('SingleVariantPageStateHandler', () => {
             '/covid/single-variant?' +
                 'country=US' +
                 '&date=Last+7+Days' +
-                '&nucleotideMutations=D614G&lineage=B.1.1.7' +
+                '&advancedQuery=country+%3D+Germany+%26+123T' +
+                '&nucleotideMutations=D614G' +
+                '&lineage=B.1.1.7' +
+                '&advancedQueryVariant=345G+%26+567C' +
                 '&',
         );
     });
@@ -143,13 +159,27 @@ describe('SingleVariantPageStateHandler', () => {
 
     it('should convert pageState to Lapis filter', () => {
         const lapisFilter = handler.toLapisFilter({
-            ...mockDefaultPageState,
+            datasetFilter: {
+                locationFilters: {},
+                dateFilters: {
+                    date: mockDateRangeOption,
+                },
+                textFilters: {},
+                numberFilters: {
+                    someLapisNumberField: {
+                        min: 123,
+                    },
+                },
+                advancedQuery: 'country = Germany & 123T',
+            },
             variantFilter: {
                 lineages: { lineage: 'B.1.1.7' },
                 mutations: { nucleotideMutations: ['D614G'] },
+                advancedQuery: '345G & 567C',
             },
         });
         expect(lapisFilter).toStrictEqual({
+            advancedQuery: '(country = Germany & 123T) and (345G & 567C)',
             dateFrom: '2024-11-22',
             dateTo: '2024-11-29',
             someLapisNumberFieldFrom: 123,

--- a/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/SingleVariantPageStateHandler.ts
@@ -4,13 +4,19 @@ import { paths } from '../../types/Organism.ts';
 import type { OrganismConstants } from '../OrganismConstants.ts';
 import { type DatasetAndVariantData, getLineageFilterFields } from '../View.ts';
 import { singleVariantViewConstants } from '../ViewConstants.ts';
-import { getLapisVariantQuery, setSearchFromLapisVariantQuery } from '../helpers.ts';
-import { type PageStateHandler, toLapisFilterFromVariant } from './PageStateHandler.ts';
+import {
+    getLapisVariantQuery,
+    getStringFromSearch,
+    setSearchFromLapisVariantQuery,
+    setSearchFromString,
+} from '../helpers.ts';
+import { type PageStateHandler, toLapisFilterWithVariant } from './PageStateHandler.ts';
 import { parseDateRangesFromUrl, setSearchFromDateFilters } from './dateFilterFromToUrl.ts';
 import { parseLocationFiltersFromUrl, setSearchFromLocationFilters } from './locationFilterFromToUrl.ts';
 import { parseNumberRangeFilterFromUrl, setSearchFromNumberRangeFilters } from './numberRangeFilterFromToUrl.ts';
 import { parseTextFiltersFromUrl, setSearchFromTextFilters } from './textFilterFromToUrl.ts';
 import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
+import { advancedQueryUrlParam } from '../../components/genspectrum/AdvancedQueryFilter.tsx';
 import { formatUrl } from '../../util/formatUrl.ts';
 
 export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantData = DatasetAndVariantData>
@@ -34,6 +40,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
                 dateFilters: parseDateRangesFromUrl(search, this.constants.baselineFilterConfigs),
                 textFilters: parseTextFiltersFromUrl(search, this.constants.baselineFilterConfigs),
                 numberFilters: parseNumberRangeFilterFromUrl(search, this.constants.baselineFilterConfigs),
+                advancedQuery: getStringFromSearch(search, advancedQueryUrlParam),
             },
             variantFilter: getLapisVariantQuery(search, getLineageFilterFields(this.constants.lineageFilters)),
         };
@@ -45,6 +52,7 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
         setSearchFromDateFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromTextFilters(search, pageState, this.constants.baselineFilterConfigs);
         setSearchFromNumberRangeFilters(search, pageState, this.constants.baselineFilterConfigs);
+        setSearchFromString(search, advancedQueryUrlParam, pageState.datasetFilter.advancedQuery);
 
         setSearchFromLapisVariantQuery(
             search,
@@ -55,14 +63,15 @@ export class SingleVariantPageStateHandler<PageState extends DatasetAndVariantDa
     }
 
     public toLapisFilter(pageState: DatasetAndVariantData) {
-        return {
-            ...toLapisFilterWithoutVariant(pageState, this.constants.additionalFilters),
-            ...toLapisFilterFromVariant(pageState.variantFilter),
-        };
+        return toLapisFilterWithVariant({
+            datasetFilter: pageState.datasetFilter,
+            variantFilter: pageState.variantFilter,
+            additionalFilters: this.constants.additionalFilters,
+        });
     }
 
     public toLapisFilterWithoutVariant(pageState: DatasetAndVariantData): LapisFilter {
-        return toLapisFilterWithoutVariant(pageState, this.constants.additionalFilters);
+        return toLapisFilterWithoutVariant(pageState.datasetFilter, this.constants.additionalFilters);
     }
 
     public getDefaultPageUrl() {

--- a/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.spec.ts
+++ b/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.spec.ts
@@ -1,57 +1,54 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Dataset } from '../View.ts';
+import type { DatasetFilter } from '../View.ts';
 import { toLapisFilterWithoutVariant } from './toLapisFilterWithoutVariant.ts';
 
 describe('toLapisFilterWithoutVariant', () => {
-    const emptyPageState = {
-        datasetFilter: {
-            locationFilters: {},
-            textFilters: {},
-            dateFilters: {},
-            numberFilters: {},
-        },
-    } satisfies Dataset;
+    const emptyFilter: DatasetFilter = {
+        locationFilters: {},
+        textFilters: {},
+        dateFilters: {},
+        numberFilters: {},
+    };
 
     const additionalFilters = {
         someAdditionalFilter: 'someAdditionalFilterValue',
     };
 
     it('should convert empty page state to empty lapis filter', () => {
-        const result = toLapisFilterWithoutVariant(emptyPageState, {});
+        const result = toLapisFilterWithoutVariant(emptyFilter, {});
 
         expect(result).toStrictEqual({});
     });
 
     it('should append additionalFilters to lapis filter', () => {
-        const result = toLapisFilterWithoutVariant(emptyPageState, additionalFilters);
+        const result = toLapisFilterWithoutVariant(emptyFilter, additionalFilters);
 
         expect(result).toStrictEqual(additionalFilters);
     });
 
     it('should convert page state to lapis filter', () => {
-        const pageState = {
-            datasetFilter: {
-                locationFilters: {
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    'country,region': { country: 'SomeCountry' },
-                },
-                dateFilters: {
-                    date: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
-                },
-                textFilters: {
-                    someTextFilter: 'someTextFilterValue',
-                },
-                numberFilters: {
-                    someLapisNumberField: {
-                        min: 0,
-                        max: 234,
-                    },
+        const filter: DatasetFilter = {
+            locationFilters: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'country,region': { country: 'SomeCountry' },
+            },
+            dateFilters: {
+                date: { label: 'Last 7 Days', dateFrom: '2024-11-22', dateTo: '2024-11-29' },
+            },
+            textFilters: {
+                someTextFilter: 'someTextFilterValue',
+            },
+            numberFilters: {
+                someLapisNumberField: {
+                    min: 0,
+                    max: 234,
                 },
             },
-        } satisfies Dataset;
+            advancedQuery: '123T & 345G',
+        };
 
-        const result = toLapisFilterWithoutVariant(pageState, additionalFilters);
+        const result = toLapisFilterWithoutVariant(filter, additionalFilters);
 
         expect(result).toStrictEqual({
             country: 'SomeCountry',
@@ -61,26 +58,25 @@ describe('toLapisFilterWithoutVariant', () => {
             someLapisNumberFieldFrom: 0,
             someLapisNumberFieldTo: 234,
             someAdditionalFilter: 'someAdditionalFilterValue',
+            advancedQuery: '123T & 345G',
         });
     });
 
     it('should convert page state with partial from/to filters to lapis filter', () => {
-        const pageState = {
-            datasetFilter: {
-                locationFilters: {},
-                dateFilters: {
-                    date: { label: 'SomeLabel', dateFrom: '2024-11-22' },
-                },
-                textFilters: {},
-                numberFilters: {
-                    someLapisNumberField: {
-                        min: 123,
-                    },
+        const filter: DatasetFilter = {
+            locationFilters: {},
+            dateFilters: {
+                date: { label: 'SomeLabel', dateFrom: '2024-11-22' },
+            },
+            textFilters: {},
+            numberFilters: {
+                someLapisNumberField: {
+                    min: 123,
                 },
             },
-        } satisfies Dataset;
+        };
 
-        const result = toLapisFilterWithoutVariant(pageState, additionalFilters);
+        const result = toLapisFilterWithoutVariant(filter, additionalFilters);
 
         expect(result).toStrictEqual({
             dateFrom: '2024-11-22',

--- a/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.ts
+++ b/website/src/views/pageStateHandlers/toLapisFilterWithoutVariant.ts
@@ -1,12 +1,12 @@
 import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 
-import type { Dataset } from '../View.ts';
+import type { DatasetFilter } from '../View.ts';
 
 export function toLapisFilterWithoutVariant(
-    pageState: Dataset,
+    datasetFilter: DatasetFilter,
     additionalFilters: Record<string, string> | undefined,
 ): LapisFilter {
-    const dateFilters = Object.entries(pageState.datasetFilter.dateFilters).reduce(
+    const dateFilters = Object.entries(datasetFilter.dateFilters).reduce(
         (acc, [lapisField, dateRange]) => {
             if (dateRange === undefined || dateRange === null) {
                 return acc;
@@ -24,7 +24,7 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: string | undefined },
     );
 
-    const textFilters = Object.entries(pageState.datasetFilter.textFilters).reduce(
+    const textFilters = Object.entries(datasetFilter.textFilters).reduce(
         (acc, [lapisField, text]) => {
             if (text === undefined) {
                 return acc;
@@ -38,7 +38,7 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: string | undefined },
     );
 
-    const locationFilters = Object.values(pageState.datasetFilter.locationFilters).reduce(
+    const locationFilters = Object.values(datasetFilter.locationFilters).reduce(
         (acc, lapisLocation) => {
             if (lapisLocation === undefined) {
                 return acc;
@@ -52,7 +52,7 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: string | undefined },
     );
 
-    const numberRangeFilters = Object.entries(pageState.datasetFilter.numberFilters).reduce(
+    const numberRangeFilters = Object.entries(datasetFilter.numberFilters).reduce(
         (acc, [lapisField, numberRange]) => {
             if (numberRange === undefined) {
                 return acc;
@@ -70,11 +70,14 @@ export function toLapisFilterWithoutVariant(
         {} as { [key: string]: number | undefined },
     );
 
+    const advancedQuery = datasetFilter.advancedQuery ? { advancedQuery: datasetFilter.advancedQuery } : {};
+
     return {
         ...locationFilters,
         ...dateFilters,
         ...textFilters,
         ...numberRangeFilters,
         ...additionalFilters,
+        ...advancedQuery,
     };
 }

--- a/website/src/views/rsvA.ts
+++ b/website/src/views/rsvA.ts
@@ -51,7 +51,7 @@ class RsvAConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/rsvB.ts
+++ b/website/src/views/rsvB.ts
@@ -51,7 +51,7 @@ class RsvBConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getPathoplexusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/victoria.ts
+++ b/website/src/views/victoria.ts
@@ -58,7 +58,7 @@ class VictoriaConstants implements OrganismConstants {
             filterType: 'text' as const,
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly baselineFilterConfigs: BaselineFilterConfig[] = [
         ...getGenspectrumLoculusFilters({
             dateRangeOptions: fineGrainedDefaultDateRangeOptions(earliestDate),

--- a/website/src/views/westNile.ts
+++ b/website/src/views/westNile.ts
@@ -62,7 +62,7 @@ class WestNileConstants implements OrganismConstants {
             label: 'Collection device',
         },
     ];
-    public readonly useAdvancedQuery = false;
+    public readonly useVariantQuery = false;
     public readonly hostField: string = PATHOPLEXUS_HOST_FIELD;
     public readonly authorsField = LOCULUS_AUTHORS_FIELD;
     public readonly authorAffiliationsField = LOCULUS_AUTHORS_AFFILIATIONS_FIELD;


### PR DESCRIPTION
resolves #702


### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

This adds a text field for an advanced query to every filter section that we have (i.e. dataset filter and variant filter have separate fields). Where necessary, the filters are concatenated with `(query1) and (query2)` before sending them to LAPIS.

Probably we will need some validation of the field. Currently you can easily "break" the page by entering an invalid query and every component will show an error.

I'm also quite sure that we will need some sort of guidance/documentation for users so that they know how to use the field.

You are also likely to see wrong numbers because of https://github.com/GenSpectrum/LAPIS-SILO/issues/830 when playing around with the fields.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![image](https://github.com/user-attachments/assets/0d9c3dda-8eee-4da1-a5ae-2dc911e25a6b)

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
