### PR TITLE
fix(website): evaluate env variable at runtime whether to show advanced query filter or not

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "127.0.0.1:4321:4321"
     environment:
       BACKEND_URL: http://backend:8080
-      PUBLIC_DASHBOARDS_ENVIRONMENT: dashboards-prod
+      DASHBOARDS_ENVIRONMENT: dashboards-prod
       GITHUB_CLIENT_ID: "dummy"
       GITHUB_CLIENT_SECRET: "dummy"
 

--- a/website/.env.e2e
+++ b/website/.env.e2e
@@ -1,2 +1,2 @@
 CONFIG_DIR=../backend/src/main/resources/
-PUBLIC_DASHBOARDS_ENVIRONMENT=dashboards-prod
+DASHBOARDS_ENVIRONMENT=dashboards-prod

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,6 +1,6 @@
 CONFIG_DIR=../backend/src/main/resources/
 BACKEND_URL=http://localhost:8080
-PUBLIC_DASHBOARDS_ENVIRONMENT=dashboards-prod
+DASHBOARDS_ENVIRONMENT=dashboards-prod
 LOG_DIR=./logs
 LOG_LEVEL=info
 

--- a/website/README.md
+++ b/website/README.md
@@ -42,7 +42,7 @@ The website needs the following environment variables:
   Actually there should only be two reasonable values:
     - `../backend/src/main/resources/` for local development (reusing the backend configuration)
     - `/config` in the Docker container (which contains copies of the backend configuration files)
-- `PUBLIC_DASHBOARDS_ENVIRONMENT`: Toggle between different configurations.
+- `DASHBOARDS_ENVIRONMENT`: Toggle between different configurations.
   This will read the corresponding configuration yaml files from the directory specified in the `CONFIG_DIR` environment
   variable.
 - `BACKEND_URL`: The URL of the backend server (typically the corresponding Docker compose service).

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -6,16 +6,17 @@ export const advancedQueryUrlParam = 'advancedQuery';
 type AdvancedQueryFilterProps = {
     value?: string;
     onInput?: (newValue: string | undefined) => void;
+    enabled: boolean;
 };
 
-export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput }) => {
+export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput, enabled }) => {
     const [inputValue, setInputValue] = useState(value);
 
     useEffect(() => {
         setInputValue(value);
     }, [value]);
 
-    if (import.meta.env.PUBLIC_DASHBOARDS_ENVIRONMENT !== 'dashboards-staging') {
+    if (!enabled) {
         return null;
     }
 

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -48,11 +48,13 @@ export function BaselineSelector({
     datasetFilter,
     setDatasetFilter,
     lapisFilter,
+    enableAdvancedQueryFilter,
 }: {
     datasetFilter: DatasetFilter;
     setDatasetFilter: (datasetFilter: DatasetFilter) => void;
     lapisFilter: LapisFilter;
     baselineFilterConfigs?: BaselineFilterConfig[];
+    enableAdvancedQueryFilter: boolean
 }) {
     return (
         <div className={`flex flex-col gap-2`}>
@@ -171,6 +173,7 @@ export function BaselineSelector({
                                     });
                                 }}
                                 value={datasetFilter.advancedQuery ?? ''}
+                                enabled={enableAdvancedQueryFilter}
                             />
                         );
                     }

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -54,7 +54,7 @@ export function BaselineSelector({
     setDatasetFilter: (datasetFilter: DatasetFilter) => void;
     lapisFilter: LapisFilter;
     baselineFilterConfigs?: BaselineFilterConfig[];
-    enableAdvancedQueryFilter: boolean
+    enableAdvancedQueryFilter: boolean;
 }) {
     return (
         <div className={`flex flex-col gap-2`}>

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -15,11 +15,13 @@ export function CompareSideBySidePageStateSelector({
     initialPageState,
     organismViewKey,
     organismsConfig,
+    enableAdvancedQueryFilter,
 }: {
     filterId: number;
     initialPageState: CompareSideBySideData;
     organismViewKey: OrganismViewKey & `${string}.${typeof compareSideBySideViewKey}`;
     organismsConfig: OrganismsConfig;
+    enableAdvancedQueryFilter: boolean;
 }) {
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
     const variantFilterConfig = useMemo(
@@ -67,6 +69,7 @@ export function CompareSideBySidePageStateSelector({
                                     return { ...previousState, filters: updatedFilters };
                                 });
                             }}
+                            enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                         />
                     </Inset>
                 </div>
@@ -87,6 +90,7 @@ export function CompareSideBySidePageStateSelector({
                             variantFilterConfig={variantFilterConfig}
                             variantFilter={filterOfCurrentId.variantFilter}
                             lapisFilter={currentLapisFilter}
+                            enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                         />
                     </Inset>
                 </div>

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -15,10 +15,12 @@ export function CompareVariantsPageStateSelector({
     organismViewKey,
     organismsConfig,
     initialPageState,
+    enableAdvancedQueryFilter,
 }: {
     organismViewKey: OrganismViewKey & `${string}.${typeof compareVariantsViewKey}`;
     organismsConfig: OrganismsConfig;
     initialPageState: CompareVariantsData;
+    enableAdvancedQueryFilter: boolean;
 }) {
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
     const [pageState, setPageState] = useState(initialPageState);
@@ -48,6 +50,7 @@ export function CompareVariantsPageStateSelector({
                                 datasetFilter: newDatasetFilter,
                             }));
                         }}
+                        enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                     />
                 </Inset>
             </div>
@@ -64,6 +67,7 @@ export function CompareVariantsPageStateSelector({
                             }));
                         }}
                         lapisFilter={currentLapisFilter}
+                        enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                     />
                 </Inset>
             </div>

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -15,10 +15,12 @@ export function CompareVariantsToBaselineStateSelector({
     organismViewKey,
     organismsConfig,
     initialPageState,
+    enableAdvancedQueryFilter,
 }: {
     organismViewKey: OrganismViewKey & `${string}.${typeof compareToBaselineViewKey}`;
     organismsConfig: OrganismsConfig;
     initialPageState: CompareToBaselineData;
+    enableAdvancedQueryFilter: boolean;
 }) {
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
     const [pageState, setPageState] = useState(initialPageState);
@@ -52,6 +54,7 @@ export function CompareVariantsToBaselineStateSelector({
                                     datasetFilter: newDatasetFilter,
                                 }));
                             }}
+                            enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                         />
                     </div>
                 </Inset>
@@ -69,6 +72,7 @@ export function CompareVariantsToBaselineStateSelector({
                         variantFilterConfig={variantFilterConfig}
                         variantFilter={pageState.baselineFilter}
                         lapisFilter={currentLapisFilter}
+                        enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                     />
                 </Inset>
             </div>
@@ -86,6 +90,7 @@ export function CompareVariantsToBaselineStateSelector({
                             }));
                         }}
                         lapisFilter={currentLapisFilter}
+                        enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                     />
                 </Inset>
             </div>

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -4,7 +4,7 @@ import { ApplyFilterButton } from './ApplyFilterButton.tsx';
 import { BaselineSelector } from './BaselineSelector.tsx';
 import { LineageFilterInput } from './LineageFilterInput.tsx';
 import { SelectorHeadline } from './SelectorHeadline.tsx';
-import type { OrganismsConfig } from '../../config.ts';
+import { type OrganismsConfig } from '../../config.ts';
 import { Inset } from '../../styles/Inset.tsx';
 import type { DatasetAndVariantData } from '../../views/View.ts';
 import { type OrganismViewKey, Routing } from '../../views/routing.ts';
@@ -14,10 +14,12 @@ export function SequencingEffortsPageStateSelector({
     organismViewKey,
     organismsConfig,
     initialPageState,
+    enableAdvancedQueryFilter,
 }: {
     organismViewKey: OrganismViewKey & `${string}.${typeof sequencingEffortsViewKey}`;
     organismsConfig: OrganismsConfig;
     initialPageState: DatasetAndVariantData;
+    enableAdvancedQueryFilter: boolean;
 }) {
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
 
@@ -42,6 +44,7 @@ export function SequencingEffortsPageStateSelector({
                                 datasetFilter: newDatasetFilter,
                             }));
                         }}
+                        enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                     />
                     {view.organismConstants.lineageFilters.map((lineageFilterConfig) => (
                         <LineageFilterInput

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.spec.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.spec.tsx
@@ -26,6 +26,7 @@ describe('SingleVariantPageStateSelector', () => {
                     organismViewKey='covid.singleVariantView'
                     organismsConfig={testOrganismsConfig}
                     initialPageState={initialPageState}
+                    enableAdvancedQueryFilter={true}
                 />
             </gs-app>,
         );

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -14,10 +14,12 @@ export function SingleVariantPageStateSelector({
     organismViewKey,
     organismsConfig,
     initialPageState,
+    enableAdvancedQueryFilter,
 }: {
     organismViewKey: OrganismViewKey & `${string}.${typeof singleVariantViewKey}`;
     organismsConfig: OrganismsConfig;
     initialPageState: DatasetAndVariantData;
+    enableAdvancedQueryFilter: boolean;
 }) {
     const view = useMemo(() => new Routing(organismsConfig), [organismsConfig]).getOrganismView(organismViewKey);
     const variantFilterConfig = useMemo(
@@ -47,6 +49,7 @@ export function SingleVariantPageStateSelector({
                                 datasetFilter: newDatasetFilter,
                             }));
                         }}
+                        enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                     />
                 </Inset>
             </div>
@@ -64,6 +67,7 @@ export function SingleVariantPageStateSelector({
                         variantFilterConfig={variantFilterConfig}
                         variantFilter={pageState.variantFilter}
                         lapisFilter={currentLapisFilter}
+                        enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                     />
                 </Inset>
             </div>

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -34,11 +34,13 @@ export function VariantSelector({
     variantFilterConfig,
     variantFilter,
     lapisFilter,
+    enableAdvancedQueryFilter,
 }: {
     variantFilterConfig: VariantFilterConfig;
     onVariantFilterChange: (variantFilter: VariantFilter) => void;
     variantFilter: VariantFilter;
     lapisFilter: LapisFilter;
+    enableAdvancedQueryFilter: boolean;
 }) {
     const [isInVariantQueryMode, setIsInVariantQueryMode] = useState(
         variantFilterConfig.variantQueryConfig.enabled && variantFilter.variantQuery !== undefined,
@@ -110,6 +112,7 @@ export function VariantSelector({
                             });
                         }}
                         value={variantFilter.advancedQuery ?? ''}
+                        enabled={enableAdvancedQueryFilter}
                     />
                 </div>
             )}

--- a/website/src/components/pageStateSelectors/VariantsSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantsSelector.tsx
@@ -8,11 +8,13 @@ export function VariantsSelector({
     variantFilterConfigs,
     setVariantFilters,
     lapisFilter,
+    enableAdvancedQueryFilter,
 }: {
     variantFilters: Map<Id, VariantFilter>;
     variantFilterConfigs: Map<Id, VariantFilterConfig>;
     setVariantFilters: (variantFilters: Map<Id, VariantFilter>) => void;
     lapisFilter: LapisFilter;
+    enableAdvancedQueryFilter: boolean;
 }) {
     const removeVariant = (id: Id) => {
         setVariantFilters(new Map(Array.from(variantFilters).filter(([key]) => key !== id)));
@@ -43,6 +45,7 @@ export function VariantsSelector({
                         variantFilterConfig={filterConfig}
                         onVariantFilterChange={(variantFilter) => updateVariantFilter(id, variantFilter)}
                         lapisFilter={lapisFilter}
+                        enableAdvancedQueryFilter={enableAdvancedQueryFilter}
                     />
                     <button className='text-sm hover:text-gray-500' onClick={() => removeVariant(id)}>
                         Remove

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyzeSingleVariantPage.astro
@@ -1,6 +1,6 @@
 ---
 import { GenericAnalyseSingleVariantDataDisplay } from './GenericAnalyseSingleVariantDataDisplay';
-import { getDashboardsConfig } from '../../../config';
+import { enableAdvancedQueryFilter, getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { Organisms } from '../../../types/Organism';
 import { hasOnlyUndefinedValues } from '../../../util/hasOnlyUndefinedValues';
@@ -53,6 +53,7 @@ const downloadLinks = noVariantSelected
         organismViewKey={organismViewKey}
         organismsConfig={organismConfig}
         initialPageState={pageState}
+        enableAdvancedQueryFilter={enableAdvancedQueryFilter()}
         client:only='react'
     >
         <AnalyzeSingleVariantSelectorFallback slot='fallback' />

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySidePage.astro
@@ -1,6 +1,6 @@
 ---
 import { toDownloadLink } from './toDownloadLink';
-import { getDashboardsConfig, getLapisUrl } from '../../../config';
+import { enableAdvancedQueryFilter, getDashboardsConfig, getLapisUrl } from '../../../config';
 import OrganismViewPageLayout from '../../../layouts/OrganismPage/OrganismViewPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { ComponentHeight } from '../../../views/OrganismConstants';
@@ -65,6 +65,7 @@ const downloadLinks = [...pageState.filters.entries()].map(toDownloadLink(view.p
                                     initialPageState={pageState}
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
+                                    enableAdvancedQueryFilter={enableAdvancedQueryFilter()}
                                     client:only='react'
                                 >
                                     <CompareSideBySideSelectorFallback

--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselinePage.astro
@@ -1,6 +1,6 @@
 ---
 import SelectBaseline from './SelectBaseline.astro';
-import { getDashboardsConfig } from '../../../config';
+import { enableAdvancedQueryFilter, getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { ComponentHeight } from '../../../views/OrganismConstants';
@@ -48,6 +48,7 @@ const downloadLinks = noVariantSelected
         initialPageState={pageState}
         organismViewKey={organismViewKey}
         organismsConfig={getDashboardsConfig().dashboards.organisms}
+        enableAdvancedQueryFilter={enableAdvancedQueryFilter()}
         client:only='react'
     >
         <CompareToBaselineSelectorFallback slot='fallback' numFilters={numeratorLapisFilters.length} />

--- a/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
+++ b/website/src/components/views/compareVariants/GenericCompareVariantsPage.astro
@@ -1,6 +1,6 @@
 ---
 import SelectVariants from './SelectVariants.astro';
-import { getDashboardsConfig } from '../../../config';
+import { enableAdvancedQueryFilter, getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../../util/chooseGranularityBasedOnDateRange';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
@@ -52,6 +52,7 @@ const componentHeight = '540px'; // prevalence over time table with 10 rows
         organismsConfig={getDashboardsConfig().dashboards.organisms}
         initialPageState={pageState}
         client:only='react'
+        enableAdvancedQueryFilter={enableAdvancedQueryFilter()}
     >
         <CompareVariantsSelectorFallback slot='fallback' numFilters={numeratorLapisFilters.length} />
     </CompareVariantsPageStateSelector>

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsPage.astro
@@ -1,6 +1,6 @@
 ---
 import { GenericSequencingEffortsDataDisplay } from './GenericSequencingEffortsDataDisplay';
-import { getDashboardsConfig } from '../../../config';
+import { enableAdvancedQueryFilter, getDashboardsConfig } from '../../../config';
 import SingleVariantOrganismPageLayout from '../../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { type OrganismViewKey, type OrganismWithViewKey } from '../../../views/routing';
 import { ServerSide } from '../../../views/serverSideRouting';
@@ -39,6 +39,7 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
         organismViewKey={organismViewKey}
         organismsConfig={organismConfig}
         initialPageState={pageState}
+        enableAdvancedQueryFilter={enableAdvancedQueryFilter()}
         client:only='react'
     >
         <SequencingEffortsSelectorFallback slot='fallback' />

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -97,8 +97,12 @@ function getConfigDir(): string {
     return processEnvOrMetaEnv('CONFIG_DIR', z.string().min(1));
 }
 
+export function enableAdvancedQueryFilter() {
+    return getEnvironment() === 'dashboards-staging';
+}
+
 function getEnvironment() {
-    return processEnvOrMetaEnv('PUBLIC_DASHBOARDS_ENVIRONMENT', environmentSchema);
+    return processEnvOrMetaEnv('DASHBOARDS_ENVIRONMENT', environmentSchema);
 }
 
 export function isLoginEnabled() {

--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -6,7 +6,7 @@ declare module 'set-cookie-parser';
 
 interface ImportMetaEnv {
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    readonly PUBLIC_DASHBOARDS_ENVIRONMENT: 'dashboards-staging' | 'dashboards-prod';
+    readonly DASHBOARDS_ENVIRONMENT: 'dashboards-staging' | 'dashboards-prod';
 }
 
 interface ImportMeta {

--- a/website/src/pages/covid/compare-side-by-side.astro
+++ b/website/src/pages/covid/compare-side-by-side.astro
@@ -6,7 +6,7 @@ import GsRelativeGrowthAdvantage from '../../components/genspectrum/GsRelativeGr
 import { CompareSideBySidePageStateSelector } from '../../components/pageStateSelectors/CompareSideBySidePageStateSelector';
 import { CompareSideBySideSelectorFallback } from '../../components/pageStateSelectors/FallbackElement';
 import { toDownloadLink } from '../../components/views/compareSideBySide/toDownloadLink';
-import { getDashboardsConfig, getLapisUrl } from '../../config';
+import { enableAdvancedQueryFilter, getDashboardsConfig, getLapisUrl } from '../../config';
 import OrganismViewPageLayout from '../../layouts/OrganismPage/OrganismViewPageLayout.astro';
 import { chooseGranularityBasedOnDateRange } from '../../util/chooseGranularityBasedOnDateRange';
 import { ComponentHeight } from '../../views/OrganismConstants';
@@ -62,6 +62,7 @@ const downloadLinks = [...pageState.filters.entries()].map(
                                     initialPageState={pageState}
                                     organismsConfig={getDashboardsConfig().dashboards.organisms}
                                     organismViewKey={organismViewKey}
+                                    enableAdvancedQueryFilter={enableAdvancedQueryFilter()}
                                     client:only='react'
                                 >
                                     <CompareSideBySideSelectorFallback

--- a/website/src/pages/covid/single-variant.astro
+++ b/website/src/pages/covid/single-variant.astro
@@ -5,7 +5,7 @@ import { SingleVariantPageStateSelector } from '../../components/pageStateSelect
 import { CollectionsList } from '../../components/views/analyzeSingleVariant/CollectionsList';
 import { CovidSingleVariantDataDisplay } from '../../components/views/analyzeSingleVariant/CovidSingleVariantDataDisplay';
 import { sanitizeForFilename } from '../../components/views/compareSideBySide/toDownloadLink';
-import { getDashboardsConfig } from '../../config';
+import { enableAdvancedQueryFilter, getDashboardsConfig } from '../../config';
 import SingleVariantOrganismPageLayout from '../../layouts/OrganismPage/SingleVariantOrganismPageLayout.astro';
 import { hasOnlyUndefinedValues } from '../../util/hasOnlyUndefinedValues';
 import { toDisplayName } from '../../views/pageStateHandlers/PageStateHandler';
@@ -45,6 +45,7 @@ const organismConfig = getDashboardsConfig().dashboards.organisms;
             organismViewKey={organismViewKey}
             organismsConfig={organismConfig}
             initialPageState={pageState}
+            enableAdvancedQueryFilter={enableAdvancedQueryFilter()}
             client:only='react'
         >
             <AnalyzeSingleVariantSelectorFallback slot='fallback' />


### PR DESCRIPTION




### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Follow up to #735:

import.meta.env.PUBLIC_DASHBOARDS_ENVIRONMENT is evaluated a build time, but we need to evaluate at runtime whether to show the AdvancedQueryFilter or not. Then we also don't need to have the env variable public.


### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

## PR Checklist
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~
