### PR TITLE
feat(components): expose displayMutations parameter on mutationsOverTime component

### DIFF
--- a/website/src/components/genspectrum/GsMutationsOverTime.tsx
+++ b/website/src/components/genspectrum/GsMutationsOverTime.tsx
@@ -8,6 +8,7 @@ export type GsMutationsOverTimeProps = {
     sequenceType: SequenceType;
     granularity: TemporalGranularity;
     lapisDateField: string;
+    displayMutations?: string[];
     height?: string;
     pageSizes?: number[];
 };
@@ -17,6 +18,7 @@ export const GsMutationsOverTime: FC<GsMutationsOverTimeProps> = ({
     sequenceType,
     granularity,
     lapisDateField,
+    displayMutations,
     height,
     pageSizes,
 }) => {
@@ -33,6 +35,7 @@ export const GsMutationsOverTime: FC<GsMutationsOverTimeProps> = ({
                 views='["grid"]'
                 granularity={granularity}
                 lapisDateField={lapisDateField}
+                displayMutations={displayMutations ? JSON.stringify(displayMutations) : undefined}
                 pageSizes={JSON.stringify(pageSizes ?? [10, 20, 30, 40, 50])}
             ></gs-mutations-over-time>
         </ComponentWrapper>


### PR DESCRIPTION
### Summary

Expose the `displayMutations` setting on the MutationsOverTime component so we can set it inside of the dashboards.