### PR TITLE
feat(website): add Loading component with spinner to the W-ASAP dashboard

### DIFF
--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -5,6 +5,7 @@ import { type FC } from 'react';
 
 import { RESISTANCE_MUTATIONS, resistanceMutationAnnotations } from './resistanceMutations';
 import { wastewaterConfig } from '../../../types/wastewaterConfig';
+import { Loading } from '../../../util/Loading';
 import { type WasapFilter, WasapPageStateHandler } from '../../../views/pageStateHandlers/WasapPageStateHandler';
 import { GsMutationsOverTime, type InitialMeanProportionInterval } from '../../genspectrum/GsMutationsOverTime';
 import { WasapPageStateSelector } from '../../pageStateSelectors/WasapPageStateSelector';
@@ -54,7 +55,7 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
                 {isError ? (
                     <span>There was an error fetching the mutations to display.</span>
                 ) : isPending ? (
-                    <span>Loading mutations to display ...</span>
+                    <Loading />
                 ) : (
                     <div className='h-full pr-4'>
                         <GsMutationsOverTime

--- a/website/src/util/Loading.tsx
+++ b/website/src/util/Loading.tsx
@@ -1,0 +1,10 @@
+import React, { type FC } from 'react';
+
+export const Loading: FC = () => (
+    <div
+        aria-label='Loading'
+        className='flex h-full w-full items-center justify-center rounded-md border-2 border-gray-100'
+    >
+        <div className='loading loading-spinner loading-md text-neutral-500' />
+    </div>
+);


### PR DESCRIPTION
### Summary

Adds a `Loading` component which displays the spinner used in other places already.

### Screenshot

(the loading component is only shown for a split second, before the plot component is then loaded, around 2 seconds into the video.)

https://github.com/user-attachments/assets/59cd71c4-f5a4-4dbc-9a5c-984de7962b4c

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
