### PR TITLE
feat(website): more relevant date range options for W-ASAP page

### DIFF
--- a/website/src/components/pageStateSelectors/DynamicDateFilter.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/DynamicDateFilter.browser.spec.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { describe, expect } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+import { DynamicDateFilter } from './DynamicDateFilter.tsx';
+import { DUMMY_LAPIS_URL, LapisRouteMocker } from '../../../routeMocker.ts';
+import { it } from '../../../test-extend.ts';
+import { weeklyAndMonthlyDateRangeOptions } from '../../util/weeklyAndMonthlyDateRangeOption.ts';
+
+const baselineOptions = weeklyAndMonthlyDateRangeOptions('2025-03-01');
+
+describe('DynamicDateFilter', () => {
+    it('has multiple options', async ({ routeMockers: { lapis } }) => {
+        setupLapisMocks(lapis);
+
+        const { getByRole, getByText } = render(
+            <gs-app lapis={DUMMY_LAPIS_URL}>
+                <DynamicDateFilter
+                    label='Sampling date'
+                    lapis={DUMMY_LAPIS_URL}
+                    dateFieldName='sampling_date'
+                    baselineOptions={baselineOptions()}
+                    value={undefined}
+                    onChange={() => {}}
+                />
+            </gs-app>,
+        );
+
+        await expect.element(getByText('Select an option')).toBeInTheDocument();
+
+        const select = getByRole('combobox');
+        const options = select.getByRole('option', { includeHidden: true }).elements();
+        expect(options).toHaveLength(8);
+    });
+
+    it('has monthly options that all overlap with the data date range', async ({ routeMockers: { lapis } }) => {
+        setupLapisMocks(lapis);
+
+        const { getByRole, getByText } = render(
+            <gs-app lapis={DUMMY_LAPIS_URL}>
+                <DynamicDateFilter
+                    label='Sampling date'
+                    lapis={DUMMY_LAPIS_URL}
+                    dateFieldName='sampling_date'
+                    baselineOptions={baselineOptions()}
+                    value={undefined}
+                    onChange={() => {}}
+                />
+            </gs-app>,
+        );
+
+        await expect.element(getByText('Select an option')).toBeInTheDocument();
+
+        const select = getByRole('combobox');
+        const options = select.getByRole('option', { includeHidden: true }).elements();
+        const monthOptions = options.filter((e) => {
+            const value = e.getAttribute('value');
+            return value !== null && /^2025-\d\d$/.test(value);
+        });
+        expect(monthOptions).toHaveLength(2);
+        const monthOptionsValues = monthOptions.map((e) => e.getAttribute('value'));
+        expect(monthOptionsValues).toContain('2025-06');
+        expect(monthOptionsValues).toContain('2025-07');
+    });
+
+    it('has weekly options that all overlap with the data date range', async ({ routeMockers: { lapis } }) => {
+        setupLapisMocks(lapis);
+
+        const { getByRole, getByText } = render(
+            <gs-app lapis={DUMMY_LAPIS_URL}>
+                <DynamicDateFilter
+                    label='Sampling date'
+                    lapis={DUMMY_LAPIS_URL}
+                    dateFieldName='sampling_date'
+                    baselineOptions={baselineOptions()}
+                    value={undefined}
+                    onChange={() => {}}
+                />
+            </gs-app>,
+        );
+
+        await expect.element(getByText('Select an option')).toBeInTheDocument();
+
+        const select = getByRole('combobox');
+        const options = select.getByRole('option', { includeHidden: true }).elements();
+        const weekOptions = options.filter((e) => {
+            const value = e.getAttribute('value');
+            return value !== null && /^2025-W\d\d$/.test(value);
+        });
+        expect(weekOptions).toHaveLength(5);
+        const weekOptionsValues = weekOptions.map((e) => e.getAttribute('value'));
+        expect(weekOptionsValues).toEqual(['2025-W24', '2025-W25', '2025-W26', '2025-W27', '2025-W28']);
+    });
+
+    it('has only a single week and single month option for single data date', async ({ routeMockers }) => {
+        routeMockers.lapis.mockReferenceGenome({
+            nucleotideSequences: [{ name: 'main', sequence: 'ATGC' }],
+            genes: [],
+        });
+        routeMockers.lapis.mockPostAggregated(
+            { fields: ['sampling_date'], orderBy: ['sampling_date'] },
+            {
+                data: [
+                    /* eslint-disable @typescript-eslint/naming-convention */
+                    { count: 1, sampling_date: '2025-05-01' },
+                    /* eslint-enable @typescript-eslint/naming-convention */
+                ],
+            },
+        );
+
+        const { getByRole, getByText } = render(
+            <gs-app lapis={DUMMY_LAPIS_URL}>
+                <DynamicDateFilter
+                    label='Sampling date'
+                    lapis={DUMMY_LAPIS_URL}
+                    dateFieldName='sampling_date'
+                    baselineOptions={baselineOptions()}
+                    value={undefined}
+                    onChange={() => {}}
+                />
+            </gs-app>,
+        );
+
+        await expect.element(getByText('Select an option')).toBeInTheDocument();
+
+        const select = getByRole('combobox');
+        const options = select.getByRole('option', { includeHidden: true }).elements();
+        expect(options).toHaveLength(3);
+        const optionsValues = options.map((e) => e.getAttribute('value'));
+        expect(optionsValues).toEqual(['__undefined__', '2025-W18', '2025-05']);
+    });
+});
+
+function setupLapisMocks(lapisRouteMocker: LapisRouteMocker) {
+    lapisRouteMocker.mockReferenceGenome({ nucleotideSequences: [{ name: 'main', sequence: 'ATGC' }], genes: [] });
+    lapisRouteMocker.mockPostAggregated(
+        { fields: ['sampling_date'], orderBy: ['sampling_date'] },
+        {
+            data: [
+                /* eslint-disable @typescript-eslint/naming-convention */
+                { count: 2251132, sampling_date: '2025-06-12' },
+                { count: 4501244, sampling_date: '2025-06-16' },
+                { count: 5928596, sampling_date: '2025-06-18' },
+                { count: 1289822, sampling_date: '2025-06-21' },
+                { count: 1942536, sampling_date: '2025-06-25' },
+                { count: 2250146, sampling_date: '2025-06-27' },
+                { count: 5932947, sampling_date: '2025-06-28' },
+                { count: 6436524, sampling_date: '2025-06-30' },
+                { count: 2250725, sampling_date: '2025-07-03' },
+                { count: 6785938, sampling_date: '2025-07-06' },
+                { count: 4500194, sampling_date: '2025-07-07' },
+                { count: 11253745, sampling_date: '2025-07-11' },
+                { count: 2250440, sampling_date: '2025-07-12' },
+                /* eslint-enable @typescript-eslint/naming-convention */
+            ],
+        },
+    );
+}

--- a/website/src/components/pageStateSelectors/DynamicDateFilter.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/DynamicDateFilter.browser.spec.tsx
@@ -6,8 +6,11 @@ import { DynamicDateFilter } from './DynamicDateFilter.tsx';
 import { DUMMY_LAPIS_URL, LapisRouteMocker } from '../../../routeMocker.ts';
 import { it } from '../../../test-extend.ts';
 import { weeklyAndMonthlyDateRangeOptions } from '../../util/weeklyAndMonthlyDateRangeOption.ts';
+import { withQueryProvider } from '../subscriptions/backendApi/withQueryProvider.tsx';
 
 const baselineOptions = weeklyAndMonthlyDateRangeOptions('2025-03-01');
+
+const WrappedDynamicDateFilter = withQueryProvider(DynamicDateFilter);
 
 describe('DynamicDateFilter', () => {
     it('has multiple options', async ({ routeMockers: { lapis } }) => {
@@ -15,11 +18,11 @@ describe('DynamicDateFilter', () => {
 
         const { getByRole, getByText } = render(
             <gs-app lapis={DUMMY_LAPIS_URL}>
-                <DynamicDateFilter
+                <WrappedDynamicDateFilter
                     label='Sampling date'
                     lapis={DUMMY_LAPIS_URL}
                     dateFieldName='sampling_date'
-                    baselineOptions={baselineOptions()}
+                    baselineOptions={baselineOptions}
                     value={undefined}
                     onChange={() => {}}
                 />
@@ -38,11 +41,11 @@ describe('DynamicDateFilter', () => {
 
         const { getByRole, getByText } = render(
             <gs-app lapis={DUMMY_LAPIS_URL}>
-                <DynamicDateFilter
+                <WrappedDynamicDateFilter
                     label='Sampling date'
                     lapis={DUMMY_LAPIS_URL}
                     dateFieldName='sampling_date'
-                    baselineOptions={baselineOptions()}
+                    baselineOptions={baselineOptions}
                     value={undefined}
                     onChange={() => {}}
                 />
@@ -68,11 +71,11 @@ describe('DynamicDateFilter', () => {
 
         const { getByRole, getByText } = render(
             <gs-app lapis={DUMMY_LAPIS_URL}>
-                <DynamicDateFilter
+                <WrappedDynamicDateFilter
                     label='Sampling date'
                     lapis={DUMMY_LAPIS_URL}
                     dateFieldName='sampling_date'
-                    baselineOptions={baselineOptions()}
+                    baselineOptions={baselineOptions}
                     value={undefined}
                     onChange={() => {}}
                 />
@@ -110,11 +113,11 @@ describe('DynamicDateFilter', () => {
 
         const { getByRole, getByText } = render(
             <gs-app lapis={DUMMY_LAPIS_URL}>
-                <DynamicDateFilter
+                <WrappedDynamicDateFilter
                     label='Sampling date'
                     lapis={DUMMY_LAPIS_URL}
                     dateFieldName='sampling_date'
-                    baselineOptions={baselineOptions()}
+                    baselineOptions={baselineOptions}
                     value={undefined}
                     onChange={() => {}}
                 />

--- a/website/src/components/pageStateSelectors/DynamicDateFilter.tsx
+++ b/website/src/components/pageStateSelectors/DynamicDateFilter.tsx
@@ -1,0 +1,106 @@
+import { type DateRangeOption } from '@genspectrum/dashboard-components/util';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import React from 'react';
+
+import { Loading } from '../../util/Loading';
+import { GsDateRangeFilter } from '../genspectrum/GsDateRangeFilter';
+import { withQueryProvider } from '../subscriptions/backendApi/withQueryProvider';
+
+function DynamicDateFilterInner({
+    label,
+    lapis,
+    dateFieldName,
+    baselineOptions,
+    value,
+    onChange,
+}: {
+    label: string;
+    lapis: string;
+    dateFieldName: string;
+    baselineOptions: DateRangeOption[];
+    value: DateRangeOption | undefined;
+    onChange: (newValue: DateRangeOption | undefined) => void;
+}) {
+    const {
+        data: dateRange,
+        isPending,
+        isError,
+        error,
+    } = useQuery({
+        queryKey: ['dateRange', lapis, dateFieldName],
+        queryFn: () => fetchDateRange(lapis, dateFieldName),
+    });
+
+    return (
+        <label className='form-control'>
+            <div className='label'>
+                <span className='label-text'>{label}</span>
+            </div>
+            {isPending ? (
+                <div className='h-20'>
+                    <Loading />
+                </div>
+            ) : isError ? (
+                <div className='flex h-20 items-center'>
+                    Failed to load date range: {error instanceof Error ? error.message : String(error)}
+                </div>
+            ) : (
+                <GsDateRangeFilter
+                    lapisDateField='sampling_date'
+                    onDateRangeChange={(dateRange: DateRangeOption | null) => onChange(dateRange ?? undefined)}
+                    value={value}
+                    dateRangeOptions={filteredOptions(baselineOptions, dateRange.start, dateRange.end)}
+                />
+            )}
+        </label>
+    );
+}
+
+/**
+ * The `DynamicDateFilter` computes the available date range options dynamically,
+ * based on the available dates in the data, for the given LAPIS and field name.
+ */
+export const DynamicDateFilter = withQueryProvider(DynamicDateFilterInner);
+
+async function fetchDateRange(baseUrl: string, fieldName: string): Promise<{ start: string; end: string }> {
+    const url = `${baseUrl.replace(/\/$/, '')}/sample/aggregated`;
+
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'Content-Type': 'application/json',
+            'accept': 'application/json',
+        },
+        body: JSON.stringify({
+            fields: [fieldName],
+            orderBy: [fieldName],
+        }),
+    });
+
+    if (!res.ok) throw new Error(`HTTP error ${res.status}`);
+
+    const json: { data: Record<string, string>[] } = await res.json();
+    if (!json.data.length) throw new Error('No data returned');
+
+    return {
+        start: json.data[0][fieldName],
+        end: json.data[json.data.length - 1][fieldName],
+    };
+}
+
+/**
+ * Returns only the options from the given list of baseline options, that have at least
+ * partial overlap with the given date range (start, end).
+ */
+function filteredOptions(baselineOptions: DateRangeOption[], start: string, end: string) {
+    const startDate = dayjs(start);
+    const endDate = dayjs(end);
+
+    return baselineOptions.filter(({ dateFrom, dateTo }) => {
+        const from = dayjs(dateFrom);
+        const to = dayjs(dateTo);
+        return !((dateTo !== undefined && to.isBefore(startDate)) || (dateFrom !== undefined && from.isAfter(endDate)));
+    });
+}

--- a/website/src/components/pageStateSelectors/DynamicDateFilter.tsx
+++ b/website/src/components/pageStateSelectors/DynamicDateFilter.tsx
@@ -5,9 +5,12 @@ import React from 'react';
 
 import { Loading } from '../../util/Loading';
 import { GsDateRangeFilter } from '../genspectrum/GsDateRangeFilter';
-import { withQueryProvider } from '../subscriptions/backendApi/withQueryProvider';
 
-function DynamicDateFilterInner({
+/**
+ * The `DynamicDateFilter` computes the available date range options dynamically,
+ * based on the available dates in the data, for the given LAPIS and field name.
+ */
+export function DynamicDateFilter({
     label,
     lapis,
     dateFieldName,
@@ -57,12 +60,6 @@ function DynamicDateFilterInner({
     );
 }
 
-/**
- * The `DynamicDateFilter` computes the available date range options dynamically,
- * based on the available dates in the data, for the given LAPIS and field name.
- */
-export const DynamicDateFilter = withQueryProvider(DynamicDateFilterInner);
-
 async function fetchDateRange(baseUrl: string, fieldName: string): Promise<{ start: string; end: string }> {
     const url = `${baseUrl.replace(/\/$/, '')}/sample/aggregated`;
 
@@ -79,7 +76,12 @@ async function fetchDateRange(baseUrl: string, fieldName: string): Promise<{ sta
         }),
     });
 
-    if (!res.ok) throw new Error(`HTTP error ${res.status}`);
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(
+            `Request to ${url} failed with status ${res.status} ${res.statusText}. Response: ${text.slice(0, 200)}`,
+        );
+    }
 
     const json: { data: Record<string, string>[] } = await res.json();
     if (!json.data.length) throw new Error('No data returned');

--- a/website/src/components/pageStateSelectors/DynamicDateFilter.tsx
+++ b/website/src/components/pageStateSelectors/DynamicDateFilter.tsx
@@ -47,7 +47,7 @@ function DynamicDateFilterInner({
                 </div>
             ) : (
                 <GsDateRangeFilter
-                    lapisDateField='sampling_date'
+                    lapisDateField={dateFieldName}
                     onDateRangeChange={(dateRange: DateRangeOption | null) => onChange(dateRange ?? undefined)}
                     value={value}
                     dateRangeOptions={filteredOptions(baselineOptions, dateRange.start, dateRange.end)}

--- a/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
@@ -1,19 +1,14 @@
-import {
-    type SequenceType,
-    type DateRangeOption,
-    mutationType,
-    type MutationType,
-} from '@genspectrum/dashboard-components/util';
+import { type SequenceType, mutationType, type MutationType } from '@genspectrum/dashboard-components/util';
 import React, { Fragment, useId, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton';
+import { DynamicDateFilter } from './DynamicDateFilter';
 import { SelectorHeadline } from './SelectorHeadline';
 import { Inset } from '../../styles/Inset';
 import { wastewaterConfig } from '../../types/wastewaterConfig';
 import { type PageStateHandler } from '../../views/pageStateHandlers/PageStateHandler';
 import {
     type WasapFilter,
-    wasapDateRangeOptions,
     type WasapAnalysisMode,
     type WasapManualFilter,
     type WasapVariantFilter,
@@ -25,8 +20,8 @@ import {
     defaultUntrackedFilter,
     type WasapBaseFilter,
     type WasapAnalysisFilter,
+    wasapDateRangeOptions,
 } from '../../views/pageStateHandlers/WasapPageStateHandler';
-import { GsDateRangeFilter } from '../genspectrum/GsDateRangeFilter';
 import { GsLineageFilter } from '../genspectrum/GsLineageFilter';
 import { GsMutationFilter } from '../genspectrum/GsMutationFilter';
 import { GsTextFilter } from '../genspectrum/GsTextFilter';
@@ -86,16 +81,15 @@ export function WasapPageStateSelector({
                         value={baseFilterState.locationName}
                     />
                 </LabeledField>
-                <LabeledField label='Sampling date'>
-                    <GsDateRangeFilter
-                        lapisDateField='sampling_date'
-                        onDateRangeChange={(dateRange: DateRangeOption | null) => {
-                            setBaseFilterState({ ...baseFilterState, samplingDate: dateRange ?? undefined });
-                        }}
-                        value={baseFilterState.samplingDate}
-                        dateRangeOptions={wasapDateRangeOptions()}
-                    />
-                </LabeledField>
+
+                <DynamicDateFilter
+                    label='Sampling date'
+                    lapis={wastewaterConfig.wasapLapisBaseUrl}
+                    dateFieldName='sampling_date'
+                    baselineOptions={wasapDateRangeOptions()}
+                    value={baseFilterState.samplingDate}
+                    onChange={(newDateRange?) => setBaseFilterState({ ...baseFilterState, samplingDate: newDateRange })}
+                />
                 <div className='h-2' />
                 <RadioSelect
                     label='Granularity'

--- a/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
@@ -84,8 +84,8 @@ export function WasapPageStateSelector({
 
                 <DynamicDateFilter
                     label='Sampling date'
-                    lapis={wastewaterConfig.wasapLapisBaseUrl}
-                    dateFieldName='sampling_date'
+                    lapis={wastewaterConfig.wasap.lapisBaseUrl}
+                    dateFieldName={wastewaterConfig.wasap.samplingDateField}
                     baselineOptions={wasapDateRangeOptions()}
                     value={baseFilterState.samplingDate}
                     onChange={(newDateRange?) => setBaseFilterState({ ...baseFilterState, samplingDate: newDateRange })}
@@ -199,7 +199,7 @@ function VariantExplorerFilter({
                 onChange={(sequenceType) => setPageState({ ...pageState, sequenceType })}
             />
             <LabeledField label='Variant'>
-                <gs-app lapis={wastewaterConfig.covSpectrumLapisBaseUrl}>
+                <gs-app lapis={wastewaterConfig.wasap.covSpectrumLapisBaseUrl}>
                     <GsLineageFilter
                         lapisField='pangoLineage'
                         lapisFilter={{}}

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -52,7 +52,7 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
     const memoizedMutationAnnotations = useMemo(() => JSON.stringify(resistanceMutationAnnotations), []);
 
     return (
-        <gs-app lapis={wastewaterConfig.wasapLapisBaseUrl} mutationAnnotations={memoizedMutationAnnotations}>
+        <gs-app lapis={wastewaterConfig.wasap.lapisBaseUrl} mutationAnnotations={memoizedMutationAnnotations}>
             <div className='grid-cols-[300px_1fr] gap-x-4 lg:grid'>
                 <div className='h-fit p-2 shadow-lg'>
                     <WasapPageStateSelector
@@ -70,7 +70,7 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
                         <GsMutationsOverTime
                             lapisFilter={lapisFilter}
                             granularity={base.granularity as 'day' | 'week'}
-                            lapisDateField='sampling_date'
+                            lapisDateField={wastewaterConfig.wasap.samplingDateField}
                             sequenceType={analysis.sequenceType}
                             displayMutations={selectedMutations === 'all' ? undefined : selectedMutations}
                             pageSizes={[20, 50, 100, 250]}
@@ -103,7 +103,7 @@ async function fetchMutationSelection(analysis: WasapAnalysisFilter): Promise<st
                 return [];
             }
             return fetchMutations(
-                wastewaterConfig.covSpectrumLapisBaseUrl,
+                wastewaterConfig.wasap.covSpectrumLapisBaseUrl,
                 analysis.sequenceType,
                 analysis.variant,
                 analysis.minProportion,
@@ -118,10 +118,10 @@ async function fetchMutationSelection(analysis: WasapAnalysisFilter): Promise<st
             const [excludeMutations, allMuts] = await Promise.all([
                 Promise.all(
                     analysis.excludeVariants.map((v) =>
-                        fetchMutations(wastewaterConfig.covSpectrumLapisBaseUrl, analysis.sequenceType, v, 0.05, 5),
+                        fetchMutations(wastewaterConfig.wasap.covSpectrumLapisBaseUrl, analysis.sequenceType, v, 0.05, 5),
                     ),
                 ).then((r) => r.flat()),
-                fetchMutations(wastewaterConfig.wasapLapisBaseUrl, analysis.sequenceType, undefined, 0.05, 5),
+                fetchMutations(wastewaterConfig.wasap.lapisBaseUrl, analysis.sequenceType, undefined, 0.05, 5),
             ]);
             return allMuts.filter((m) => !excludeMutations.includes(m));
         }

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -118,7 +118,13 @@ async function fetchMutationSelection(analysis: WasapAnalysisFilter): Promise<st
             const [excludeMutations, allMuts] = await Promise.all([
                 Promise.all(
                     analysis.excludeVariants.map((v) =>
-                        fetchMutations(wastewaterConfig.wasap.covSpectrumLapisBaseUrl, analysis.sequenceType, v, 0.05, 5),
+                        fetchMutations(
+                            wastewaterConfig.wasap.covSpectrumLapisBaseUrl,
+                            analysis.sequenceType,
+                            v,
+                            0.05,
+                            5,
+                        ),
                     ),
                 ).then((r) => r.flat()),
                 fetchMutations(wastewaterConfig.wasap.lapisBaseUrl, analysis.sequenceType, undefined, 0.05, 5),
@@ -148,7 +154,13 @@ async function fetchMutations(
     url.search = new URLSearchParams(params).toString();
 
     const res = await fetch(url.toString());
-    if (!res.ok) throw new Error(`HTTP error ${res.status}`);
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(
+            `Request to ${url} failed with status ${res.status} ${res.statusText}. Response: ${text.slice(0, 200)}`,
+        );
+    }
 
     const json: { data: { mutation: string; count: number }[] } = await res.json();
 

--- a/website/src/pages/swiss-wastewater/covid.astro
+++ b/website/src/pages/swiss-wastewater/covid.astro
@@ -20,7 +20,7 @@ const url = Astro.url;
         },
     ]}
     dataOrigins={[dataOrigins.wise]}
-    lapisUrl={wastewaterConfig.wasapLapisBaseUrl}
+    lapisUrl={wastewaterConfig.wasap.lapisBaseUrl}
 >
     {isStaging() ? <WasapPage currentUrl={url} client:only='react' /> : <span>coming soon!</span>}
 </DataPageLayout>

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -10,8 +10,11 @@ export const wastewaterConfig = {
     browseDataUrl: 'https://wise-loculus.genspectrum.org',
     browseDataDescription: 'Browse the data in the WISE Loculus instance.',
     lapisBaseUrl: 'https://api.wise-loculus.genspectrum.org',
-    wasapLapisBaseUrl: 'https://lapis.wasap.genspectrum.org/',
-    covSpectrumLapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
+    wasap: {
+        lapisBaseUrl: 'https://lapis.wasap.genspectrum.org/',
+        covSpectrumLapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
+        samplingDateField: 'sampling_date',
+    },
     pages: {
         rsv: {
             path: `/${wastewaterPathFragment}/rsv`,

--- a/website/src/util/weeklyAndMonthlyDateRangeOption.spec.ts
+++ b/website/src/util/weeklyAndMonthlyDateRangeOption.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+import { weeklyAndMonthlyDateRangeOptions } from './weeklyAndMonthlyDateRangeOption';
+
+describe('weeklyAndMonthlyDateRangeOptions', () => {
+    const fixedNow = '2025-09-15';
+
+    beforeAll(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(fixedNow));
+    });
+
+    afterAll(() => {
+        vi.useRealTimers();
+    });
+
+    it('should set 2025-09-15 into week 38 with correct week start and end', () => {
+        const getOptions = weeklyAndMonthlyDateRangeOptions('2025-09-15');
+        const options = getOptions();
+
+        const weekLabels = options.filter((o) => o.label.includes('W')).map((o) => o.label);
+        expect(weekLabels).toContain('2025-W38');
+        expect(options[0].dateFrom).toBe('2025-09-15');
+        expect(options[0].dateTo).toBe('2025-09-21');
+    });
+
+    it('should include week with partial overlap', () => {
+        const getOptions = weeklyAndMonthlyDateRangeOptions('2025-09-07');
+        const options = getOptions();
+
+        const weekLabels = options.filter((o) => o.label.includes('W')).map((o) => o.label);
+        expect(weekLabels).toContain('2025-W36');
+        expect(weekLabels).toContain('2025-W37');
+        expect(weekLabels).toContain('2025-W38');
+    });
+
+    it('should set 2025-09-15 into correct month with correct month start and end', () => {
+        const getOptions = weeklyAndMonthlyDateRangeOptions('2025-09-15');
+        const options = getOptions();
+
+        const monthLabels = options.filter((o) => /^\d{4}-\d{2}$/.test(o.label)).map((o) => o.label);
+        expect(monthLabels).toContain('2025-09');
+        const septemberLabel = options.find((o) => o.label === '2025-09');
+        expect(septemberLabel).not.toBeUndefined();
+        expect(septemberLabel?.dateFrom).toBe('2025-09-01');
+        expect(septemberLabel?.dateTo).toBe('2025-09-30');
+    });
+
+    it('should generate monthly ranges from earliestDate to now', () => {
+        const getOptions = weeklyAndMonthlyDateRangeOptions('2025-07-01');
+        const options = getOptions();
+
+        const monthLabels = options.filter((o) => /^\d{4}-\d{2}$/.test(o.label)).map((o) => o.label);
+        expect(monthLabels).toContain('2025-07');
+        expect(monthLabels).toContain('2025-08');
+        expect(monthLabels).toContain('2025-09');
+    });
+
+    it('should return empty when earliestDate is after current date', () => {
+        const getOptions = weeklyAndMonthlyDateRangeOptions('2026-01-01');
+        const options = getOptions();
+        expect(options).toEqual([]);
+    });
+});

--- a/website/src/util/weeklyAndMonthlyDateRangeOption.spec.ts
+++ b/website/src/util/weeklyAndMonthlyDateRangeOption.spec.ts
@@ -15,8 +15,7 @@ describe('weeklyAndMonthlyDateRangeOptions', () => {
     });
 
     it('should set 2025-09-15 into week 38 with correct week start and end', () => {
-        const getOptions = weeklyAndMonthlyDateRangeOptions('2025-09-15');
-        const options = getOptions();
+        const options = weeklyAndMonthlyDateRangeOptions('2025-09-15');
 
         const weekLabels = options.filter((o) => o.label.includes('W')).map((o) => o.label);
         expect(weekLabels).toContain('2025-W38');
@@ -25,8 +24,7 @@ describe('weeklyAndMonthlyDateRangeOptions', () => {
     });
 
     it('should include week with partial overlap', () => {
-        const getOptions = weeklyAndMonthlyDateRangeOptions('2025-09-07');
-        const options = getOptions();
+        const options = weeklyAndMonthlyDateRangeOptions('2025-09-07');
 
         const weekLabels = options.filter((o) => o.label.includes('W')).map((o) => o.label);
         expect(weekLabels).toContain('2025-W36');
@@ -35,8 +33,7 @@ describe('weeklyAndMonthlyDateRangeOptions', () => {
     });
 
     it('should set 2025-09-15 into correct month with correct month start and end', () => {
-        const getOptions = weeklyAndMonthlyDateRangeOptions('2025-09-15');
-        const options = getOptions();
+        const options = weeklyAndMonthlyDateRangeOptions('2025-09-15');
 
         const monthLabels = options.filter((o) => /^\d{4}-\d{2}$/.test(o.label)).map((o) => o.label);
         expect(monthLabels).toContain('2025-09');
@@ -47,8 +44,7 @@ describe('weeklyAndMonthlyDateRangeOptions', () => {
     });
 
     it('should generate monthly ranges from earliestDate to now', () => {
-        const getOptions = weeklyAndMonthlyDateRangeOptions('2025-07-01');
-        const options = getOptions();
+        const options = weeklyAndMonthlyDateRangeOptions('2025-07-01');
 
         const monthLabels = options.filter((o) => /^\d{4}-\d{2}$/.test(o.label)).map((o) => o.label);
         expect(monthLabels).toContain('2025-07');
@@ -57,8 +53,7 @@ describe('weeklyAndMonthlyDateRangeOptions', () => {
     });
 
     it('should return empty when earliestDate is after current date', () => {
-        const getOptions = weeklyAndMonthlyDateRangeOptions('2026-01-01');
-        const options = getOptions();
+        const options = weeklyAndMonthlyDateRangeOptions('2026-01-01');
         expect(options).toEqual([]);
     });
 });

--- a/website/src/util/weeklyAndMonthlyDateRangeOption.ts
+++ b/website/src/util/weeklyAndMonthlyDateRangeOption.ts
@@ -1,0 +1,39 @@
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+
+dayjs.extend(isoWeek);
+
+export function weeklyAndMonthlyDateRangeOptions(earliestDate: string) {
+    const startDate = dayjs(earliestDate);
+    const endDate = dayjs();
+
+    return () => {
+        const options: { label: string; dateFrom: string; dateTo: string }[] = [];
+
+        // Weeks
+        let current = startDate.startOf('isoWeek');
+        while (current.isBefore(endDate) || current.isSame(endDate)) {
+            const weekStart = current.startOf('isoWeek');
+            const weekEnd = current.endOf('isoWeek');
+            options.push({
+                label: `${current.year()}-W${String(current.isoWeek()).padStart(2, '0')}`,
+                dateFrom: weekStart.format('YYYY-MM-DD'),
+                dateTo: weekEnd.format('YYYY-MM-DD'),
+            });
+            current = current.add(1, 'week');
+        }
+
+        // Months
+        current = startDate.startOf('month');
+        while (current.isBefore(endDate) || current.isSame(endDate)) {
+            options.push({
+                label: current.format('YYYY-MM'),
+                dateFrom: current.startOf('month').format('YYYY-MM-DD'),
+                dateTo: current.endOf('month').format('YYYY-MM-DD'),
+            });
+            current = current.add(1, 'month');
+        }
+
+        return options;
+    };
+}

--- a/website/src/util/weeklyAndMonthlyDateRangeOption.ts
+++ b/website/src/util/weeklyAndMonthlyDateRangeOption.ts
@@ -4,10 +4,9 @@ import isoWeek from 'dayjs/plugin/isoWeek';
 dayjs.extend(isoWeek);
 
 export function weeklyAndMonthlyDateRangeOptions(earliestDate: string) {
-    const startDate = dayjs(earliestDate);
-    const endDate = dayjs();
-
     return () => {
+        const startDate = dayjs(earliestDate);
+        const endDate = dayjs();
         const options: { label: string; dateFrom: string; dateTo: string }[] = [];
 
         // Weeks

--- a/website/src/util/weeklyAndMonthlyDateRangeOption.ts
+++ b/website/src/util/weeklyAndMonthlyDateRangeOption.ts
@@ -3,36 +3,39 @@ import isoWeek from 'dayjs/plugin/isoWeek';
 
 dayjs.extend(isoWeek);
 
+/**
+ * Generates a list of date range options of all the weeks and months
+ * that have at least partial overlap with the date range from the given
+ * earliest date until today.
+ */
 export function weeklyAndMonthlyDateRangeOptions(earliestDate: string) {
-    return () => {
-        const startDate = dayjs(earliestDate);
-        const endDate = dayjs();
-        const options: { label: string; dateFrom: string; dateTo: string }[] = [];
+    const startDate = dayjs(earliestDate);
+    const endDate = dayjs();
+    const options: { label: string; dateFrom: string; dateTo: string }[] = [];
 
-        // Weeks
-        let current = startDate.startOf('isoWeek');
-        while (current.isBefore(endDate) || current.isSame(endDate)) {
-            const weekStart = current.startOf('isoWeek');
-            const weekEnd = current.endOf('isoWeek');
-            options.push({
-                label: `${current.year()}-W${String(current.isoWeek()).padStart(2, '0')}`,
-                dateFrom: weekStart.format('YYYY-MM-DD'),
-                dateTo: weekEnd.format('YYYY-MM-DD'),
-            });
-            current = current.add(1, 'week');
-        }
+    // Weeks
+    let current = startDate.startOf('isoWeek');
+    while (current.isBefore(endDate) || current.isSame(endDate)) {
+        const weekStart = current.startOf('isoWeek');
+        const weekEnd = current.endOf('isoWeek');
+        options.push({
+            label: `${current.year()}-W${String(current.isoWeek()).padStart(2, '0')}`,
+            dateFrom: weekStart.format('YYYY-MM-DD'),
+            dateTo: weekEnd.format('YYYY-MM-DD'),
+        });
+        current = current.add(1, 'week');
+    }
 
-        // Months
-        current = startDate.startOf('month');
-        while (current.isBefore(endDate) || current.isSame(endDate)) {
-            options.push({
-                label: current.format('YYYY-MM'),
-                dateFrom: current.startOf('month').format('YYYY-MM-DD'),
-                dateTo: current.endOf('month').format('YYYY-MM-DD'),
-            });
-            current = current.add(1, 'month');
-        }
+    // Months
+    current = startDate.startOf('month');
+    while (current.isBefore(endDate) || current.isSame(endDate)) {
+        options.push({
+            label: current.format('YYYY-MM'),
+            dateFrom: current.startOf('month').format('YYYY-MM-DD'),
+            dateTo: current.endOf('month').format('YYYY-MM-DD'),
+        });
+        current = current.add(1, 'month');
+    }
 
-        return options;
-    };
+    return options;
 }

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -6,11 +6,11 @@ import { parseTextFiltersFromUrl } from './textFilterFromToUrl';
 import { type BaselineFilterConfig } from '../../components/pageStateSelectors/BaselineSelector';
 import { resistanceSetNames, type ResistanceSetName } from '../../components/views/wasap/resistanceMutations';
 import { wastewaterConfig } from '../../types/wastewaterConfig';
-import { fineGrainedDefaultDateRangeOptions } from '../../util/defaultDateRangeOption';
 import { formatUrl } from '../../util/formatUrl';
+import { weeklyAndMonthlyDateRangeOptions } from '../../util/weeklyAndMonthlyDateRangeOption';
 import { setSearchFromString } from '../helpers';
 
-export const wasapDateRangeOptions = fineGrainedDefaultDateRangeOptions('2020-01-01');
+export const wasapDateRangeOptions = weeklyAndMonthlyDateRangeOptions('2025-03-01');
 
 export type WasapAnalysisMode = 'manual' | 'variant' | 'resistance' | 'untracked';
 

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -61,7 +61,7 @@ const wasapFilterConfig: BaselineFilterConfig[] = [
     },
     {
         type: 'date',
-        dateColumn: 'sampling_date',
+        dateColumn: wastewaterConfig.wasap.samplingDateField,
         dateRangeOptions: wasapDateRangeOptions,
     },
     // below are not really LAPIS fields, but we still want to use the URL parsing mechanism
@@ -168,7 +168,7 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
 
         // general dataset settings
         setSearchFromString(search, 'location_name', base.locationName);
-        setSearchFromDateRange(search, 'sampling_date', base.samplingDate);
+        setSearchFromDateRange(search, wastewaterConfig.wasap.samplingDateField, base.samplingDate);
         setSearchFromString(search, 'granularity', base.granularity);
         if (!base.excludeEmpty) {
             setSearchFromString(search, 'excludeEmpty', 'false');

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -10,7 +10,7 @@ import { formatUrl } from '../../util/formatUrl';
 import { weeklyAndMonthlyDateRangeOptions } from '../../util/weeklyAndMonthlyDateRangeOption';
 import { setSearchFromString } from '../helpers';
 
-export const wasapDateRangeOptions = weeklyAndMonthlyDateRangeOptions('2025-03-01');
+export const wasapDateRangeOptions = () => weeklyAndMonthlyDateRangeOptions('2025-03-01');
 
 export type WasapAnalysisMode = 'manual' | 'variant' | 'resistance' | 'untracked';
 


### PR DESCRIPTION
resolves #814 

### Summary

- There is a new `weeklyAndMonthlyDateRangeOptions` function to generate weekly and monthly date range options using labels like `2025-W23` for weeks, and `2025-08` for months.
- There is a `DynamicDateFilter` which takes a field name, looks at the available date range for that field, and then filters down a given list of date range options to the ones that have overlap with the date range of the field.


### Screenshot

<img width="311" height="361" alt="image" src="https://github.com/user-attachments/assets/a51d91aa-d757-4e89-9512-acd34812ebf6" />

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
