### PR TITLE
chore(dashboards): fix linter warning

### DIFF
--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -41,10 +41,7 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
         /* eslint-enable @typescript-eslint/naming-convention */
     };
 
-    const memoizedMutationAnnotations = useMemo(
-        () => JSON.stringify(resistanceMutationAnnotations),
-        [resistanceMutationAnnotations],
-    );
+    const memoizedMutationAnnotations = useMemo(() => JSON.stringify(resistanceMutationAnnotations), []);
 
     return (
         <gs-app lapis={wastewaterConfig.wasapLapisBaseUrl} mutationAnnotations={memoizedMutationAnnotations}>


### PR DESCRIPTION
Remove dependency array from `useMemo` that contained only a reference to a variable that wasn't part of the component.