### PR TITLE
feat(website): add sequence type selector to untracked mode

### DIFF
--- a/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
@@ -275,13 +275,19 @@ function UntrackedFilter({
     setPageState: (newState: WasapFilter) => void;
 }) {
     return (
-        <LabeledField label='Known variants to exclude'>
-            <input
-                className='input input-bordered'
-                value={pageState.excludeVariants?.join(' ')}
-                onChange={(e) => setPageState({ ...pageState, excludeVariants: e.target.value.split(' ') })}
+        <>
+            <SequenceTypeSelector
+                value={pageState.sequenceType}
+                onChange={(sequenceType) => setPageState({ ...pageState, sequenceType })}
             />
-        </LabeledField>
+            <LabeledField label='Known variants to exclude'>
+                <input
+                    className='input input-bordered'
+                    value={pageState.excludeVariants?.join(' ')}
+                    onChange={(e) => setPageState({ ...pageState, excludeVariants: e.target.value.split(' ') })}
+                />
+            </LabeledField>
+        </>
     );
 }
 

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -108,10 +108,10 @@ async function fetchDisplayMutations({
             const [excludeMutations, allMuts] = await Promise.all([
                 Promise.all(
                     excludeVariants.map((v) =>
-                        fetchMutations(wastewaterConfig.covSpectrumLapisBaseUrl, 'nucleotide', v, 0.05, 5),
+                        fetchMutations(wastewaterConfig.covSpectrumLapisBaseUrl, sequenceType, v, 0.05, 5),
                     ),
                 ).then((r) => r.flat()),
-                fetchMutations(wastewaterConfig.wasapLapisBaseUrl, 'nucleotide', undefined, 0.05, 5),
+                fetchMutations(wastewaterConfig.wasapLapisBaseUrl, sequenceType, undefined, 0.05, 5),
             ]);
             return allMuts.filter((m) => !excludeMutations.includes(m));
         }


### PR DESCRIPTION
resolves #817 

### Summary

This was already partially done, so I only had to add the control to set the setting, and forward it to the fetching as well.

### Screenshot

<img width="303" height="334" alt="image" src="https://github.com/user-attachments/assets/d3ce40a3-1d89-447c-8236-0c0ceff912ea" />

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
