### PR TITLE
feat(website): restrict mutation types on wastewater dashboard

### DIFF
--- a/website/src/components/genspectrum/GsMutationFilter.tsx
+++ b/website/src/components/genspectrum/GsMutationFilter.tsx
@@ -1,5 +1,5 @@
 import '@genspectrum/dashboard-components/components';
-import { gsEventNames } from '@genspectrum/dashboard-components/util';
+import { type MutationType, gsEventNames } from '@genspectrum/dashboard-components/util';
 import { useEffect, useRef } from 'react';
 
 export type MutationFilter = {
@@ -12,10 +12,12 @@ export type MutationFilter = {
 export function GsMutationFilter({
     initialValue,
     width,
+    enabledMutationTypes,
     onMutationChange = () => {},
 }: {
     width?: string;
     initialValue?: MutationFilter | string[] | undefined;
+    enabledMutationTypes?: MutationType[];
     onMutationChange: (mutationFilter: MutationFilter | undefined) => void;
 }) {
     const mutationFilterRef = useRef<HTMLElement>();
@@ -47,6 +49,9 @@ export function GsMutationFilter({
             <gs-mutation-filter
                 width={width}
                 initialValue={JSON.stringify(initialValue ?? [])}
+                enabledMutationTypes={
+                    enabledMutationTypes !== undefined ? JSON.stringify(enabledMutationTypes) : undefined
+                }
                 ref={mutationFilterRef}
             ></gs-mutation-filter>
         </label>

--- a/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
@@ -1,4 +1,9 @@
-import { type SequenceType, type DateRangeOption } from '@genspectrum/dashboard-components/util';
+import {
+    type SequenceType,
+    type DateRangeOption,
+    mutationType,
+    type MutationType,
+} from '@genspectrum/dashboard-components/util';
 import React, { Fragment, useId, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton';
@@ -119,6 +124,10 @@ function ManualAnalysisFilter({
     pageState: WasapFilter;
     setPageState: (newState: WasapFilter) => void;
 }) {
+    const enabledMutationTypes: MutationType[] =
+        pageState.sequenceType === 'nucleotide'
+            ? [mutationType.nucleotideMutations]
+            : [mutationType.aminoAcidMutations];
     return (
         <>
             <SequenceTypeSelector
@@ -129,6 +138,7 @@ function ManualAnalysisFilter({
                 }}
             />
             <GsMutationFilter
+                enabledMutationTypes={enabledMutationTypes}
                 initialValue={pageState.mutations}
                 onMutationChange={(mutationFilter) => {
                     if (pageState.sequenceType === 'nucleotide') {


### PR DESCRIPTION
resolves #808 

### Summary

After it's now possible to restrict the mutation type input, we want only to be able to input _mutations_ (not insertions) and only Nuc or AA, depending on the selected sequence type. This has been implemented here.

### Screenshot

https://github.com/user-attachments/assets/d02d1529-5ed9-4eb6-8bb7-76dddb77c8ba

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
