### PR TITLE
refactor(website): stricter typing for WASAP filter

### DIFF
--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -6,7 +6,10 @@ import { type FC } from 'react';
 import { RESISTANCE_MUTATIONS, resistanceMutationAnnotations } from './resistanceMutations';
 import { wastewaterConfig } from '../../../types/wastewaterConfig';
 import { Loading } from '../../../util/Loading';
-import { type WasapFilter, WasapPageStateHandler } from '../../../views/pageStateHandlers/WasapPageStateHandler';
+import {
+    WasapPageStateHandler,
+    type WasapAnalysisFilter,
+} from '../../../views/pageStateHandlers/WasapPageStateHandler';
 import { GsMutationsOverTime, type InitialMeanProportionInterval } from '../../genspectrum/GsMutationsOverTime';
 import { WasapPageStateSelector } from '../../pageStateSelectors/WasapPageStateSelector';
 import { withQueryProvider } from '../../subscriptions/backendApi/withQueryProvider';
@@ -17,27 +20,30 @@ export type WasapPageProps = {
 
 export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
     const pageStateHandler = useMemo(() => new WasapPageStateHandler(), []);
-    const pageState = useMemo(() => pageStateHandler.parsePageStateFromUrl(currentUrl), [pageStateHandler, currentUrl]);
+    const { base, analysis } = useMemo(
+        () => pageStateHandler.parsePageStateFromUrl(currentUrl),
+        [pageStateHandler, currentUrl],
+    );
 
     const {
         data: displayMutations,
         isPending,
         isError,
     } = useQuery({
-        queryKey: [pageState],
-        queryFn: () => fetchDisplayMutations(pageState),
+        queryKey: [base, analysis],
+        queryFn: () => fetchDisplayMutations(analysis),
     });
 
     let initialMeanProportionInterval: InitialMeanProportionInterval = { min: 0.0, max: 1.0 };
-    if (pageState.analysisMode === 'manual' && pageState.mutations === undefined) {
+    if (analysis.mode === 'manual' && analysis.mutations === undefined) {
         initialMeanProportionInterval = { min: 0.05, max: 0.95 };
     }
 
     const lapisFilter = {
         /* eslint-disable @typescript-eslint/naming-convention */
-        ...(pageState.locationName && { location_name: pageState.locationName }),
-        ...(pageState.samplingDate?.dateFrom && { sampling_dateFrom: pageState.samplingDate.dateFrom }),
-        ...(pageState.samplingDate?.dateTo && { sampling_dateTo: pageState.samplingDate.dateTo }),
+        ...(base.locationName && { location_name: base.locationName }),
+        ...(base.samplingDate?.dateFrom && { sampling_dateFrom: base.samplingDate.dateFrom }),
+        ...(base.samplingDate?.dateTo && { sampling_dateTo: base.samplingDate.dateTo }),
         /* eslint-enable @typescript-eslint/naming-convention */
     };
 
@@ -47,7 +53,11 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
         <gs-app lapis={wastewaterConfig.wasapLapisBaseUrl} mutationAnnotations={memoizedMutationAnnotations}>
             <div className='grid-cols-[300px_1fr] gap-x-4 lg:grid'>
                 <div className='h-fit p-2 shadow-lg'>
-                    <WasapPageStateSelector pageStateHandler={pageStateHandler} initialPageState={pageState} />
+                    <WasapPageStateSelector
+                        pageStateHandler={pageStateHandler}
+                        initialBaseFilterState={base}
+                        initialAnalysisFilterState={analysis}
+                    />
                 </div>
                 {isError ? (
                     <span>There was an error fetching the mutations to display.</span>
@@ -57,14 +67,14 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
                     <div className='h-full pr-4'>
                         <GsMutationsOverTime
                             lapisFilter={lapisFilter}
-                            granularity={pageState.granularity as 'day' | 'week'}
+                            granularity={base.granularity as 'day' | 'week'}
                             lapisDateField='sampling_date'
-                            sequenceType={pageState.sequenceType}
+                            sequenceType={analysis.sequenceType}
                             displayMutations={displayMutations === 'all' ? undefined : displayMutations}
                             pageSizes={[20, 50, 100, 250]}
                             useNewEndpoint={true}
                             initialMeanProportionInterval={initialMeanProportionInterval}
-                            hideGaps={pageState.excludeEmpty ? true : undefined}
+                            hideGaps={base.excludeEmpty ? true : undefined}
                         />
                     </div>
                 )}
@@ -75,43 +85,34 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
 
 export const WasapPage = withQueryProvider(WasapPageInner);
 
-async function fetchDisplayMutations({
-    analysisMode,
-    mutations,
-    sequenceType,
-    variant,
-    minProportion,
-    minCount,
-    excludeVariants,
-    resistanceSet,
-}: WasapFilter): Promise<string[] | 'all'> {
-    switch (analysisMode) {
+async function fetchDisplayMutations(analysis: WasapAnalysisFilter): Promise<string[] | 'all'> {
+    switch (analysis.mode) {
         case 'manual':
-            return mutations ?? 'all';
+            return analysis.mutations ?? 'all';
         case 'variant':
-            if (!variant) {
+            if (!analysis.variant) {
                 return [];
             }
             return fetchMutations(
                 wastewaterConfig.covSpectrumLapisBaseUrl,
-                sequenceType,
-                variant,
-                minProportion,
-                minCount,
+                analysis.sequenceType,
+                analysis.variant,
+                analysis.minProportion,
+                analysis.minCount,
             );
         case 'resistance':
-            return RESISTANCE_MUTATIONS[resistanceSet];
+            return RESISTANCE_MUTATIONS[analysis.resistanceSet];
         case 'untracked': {
-            if (!excludeVariants) {
+            if (!analysis.excludeVariants) {
                 return [];
             }
             const [excludeMutations, allMuts] = await Promise.all([
                 Promise.all(
-                    excludeVariants.map((v) =>
-                        fetchMutations(wastewaterConfig.covSpectrumLapisBaseUrl, sequenceType, v, 0.05, 5),
+                    analysis.excludeVariants.map((v) =>
+                        fetchMutations(wastewaterConfig.covSpectrumLapisBaseUrl, analysis.sequenceType, v, 0.05, 5),
                     ),
                 ).then((r) => r.flat()),
-                fetchMutations(wastewaterConfig.wasapLapisBaseUrl, sequenceType, undefined, 0.05, 5),
+                fetchMutations(wastewaterConfig.wasapLapisBaseUrl, analysis.sequenceType, undefined, 0.05, 5),
             ]);
             return allMuts.filter((m) => !excludeMutations.includes(m));
         }

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -37,7 +37,7 @@ export type WasapVariantFilter = {
 
 export type WasapResistanceFilter = {
     mode: 'resistance';
-    sequenceType: 'amino acid';
+    sequenceType: 'amino acid'; // resistance sets are only defined for amino acid mutations
     resistanceSet: ResistanceSetName;
 };
 
@@ -233,11 +233,6 @@ const defaultExcludeVariants = [
     'XBB.1.9',
     'XFG',
 ];
-
-export const defaultBaseFilter: WasapBaseFilter = {
-    granularity: 'day',
-    excludeEmpty: true,
-};
 
 export const defaultManualFilter: WasapManualFilter = {
     mode: 'manual',

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -12,35 +12,47 @@ import { setSearchFromString } from '../helpers';
 
 export const wasapDateRangeOptions = fineGrainedDefaultDateRangeOptions('2020-01-01');
 
-const defaultExcludeVariants = [
-    'JN.1',
-    'KP.2',
-    'KP.3',
-    'LP.8',
-    'XEC',
-    'B.1.1.7',
-    'B.1.351',
-    'B.1.617.2',
-    'P.1',
-    'B.1.617.1',
-    'NB.1.8.1',
-    'BA.1',
-    'BA.2.12.1',
-    'BA.2.75.2',
-    'BA.2.75',
-    'BA.2.86',
-    'BA.2',
-    'BA.4',
-    'BA.5',
-    'BQ.1.1',
-    'EG.5',
-    'XBB.1.16',
-    'XBB.1.5',
-    'XBB.2.3',
-    'XBB',
-    'XBB.1.9',
-    'XFG',
-];
+export type WasapAnalysisMode = 'manual' | 'variant' | 'resistance' | 'untracked';
+
+export type WasapBaseFilter = {
+    locationName?: string;
+    samplingDate?: DateRangeOption;
+    granularity: string;
+    excludeEmpty: boolean;
+};
+
+export type WasapManualFilter = {
+    mode: 'manual';
+    sequenceType: SequenceType;
+    mutations?: string[];
+};
+
+export type WasapVariantFilter = {
+    mode: 'variant';
+    sequenceType: SequenceType;
+    variant?: string;
+    minProportion: number;
+    minCount: number;
+};
+
+export type WasapResistanceFilter = {
+    mode: 'resistance';
+    sequenceType: 'amino acid';
+    resistanceSet: ResistanceSetName;
+};
+
+export type WasapUntrackedFilter = {
+    mode: 'untracked';
+    sequenceType: SequenceType;
+    excludeVariants?: string[];
+};
+
+export type WasapAnalysisFilter = WasapManualFilter | WasapVariantFilter | WasapResistanceFilter | WasapUntrackedFilter;
+
+export type WasapFilter = {
+    base: WasapBaseFilter;
+    analysis: WasapAnalysisFilter;
+};
 
 const wasapFilterConfig: BaselineFilterConfig[] = [
     {
@@ -95,83 +107,92 @@ const wasapFilterConfig: BaselineFilterConfig[] = [
     },
 ];
 
-export type WasapAnalysisMode = 'manual' | 'variant' | 'resistance' | 'untracked';
-
-export type WasapFilter = {
-    /**
-    /* Sample collection filters
-     */
-    locationName?: string;
-    samplingDate?: DateRangeOption;
-    granularity: string;
-    excludeEmpty: boolean;
-    /**
-     * Analysis mode settings
-     */
-    analysisMode: WasapAnalysisMode;
-    sequenceType: SequenceType;
-    mutations?: string[];
-    variant?: string;
-    minProportion: number;
-    minCount: number;
-    resistanceSet: ResistanceSetName;
-    excludeVariants?: string[];
-};
-
 export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
     parsePageStateFromUrl(url: URL): WasapFilter {
         const texts = parseTextFiltersFromUrl(url.searchParams, wasapFilterConfig);
         const dateRanges = parseDateRangesFromUrl(url.searchParams, wasapFilterConfig);
 
-        const analysisMode = (texts.analysisMode as WasapAnalysisMode | undefined) ?? 'manual';
+        const mode = (texts.analysisMode as WasapAnalysisMode | undefined) ?? 'manual';
         const sequenceType =
-            (texts.sequenceType as SequenceType | undefined) ??
-            (analysisMode === 'resistance' ? 'amino acid' : 'nucleotide');
+            (texts.sequenceType as SequenceType | undefined) ?? (mode === 'resistance' ? 'amino acid' : 'nucleotide');
 
-        return {
+        const base: WasapBaseFilter = {
             locationName: texts.location_name,
             samplingDate: dateRanges.sampling_date,
             granularity: texts.granularity ?? 'day',
             excludeEmpty: texts.excludeEmpty !== 'false',
-            analysisMode,
-            sequenceType,
-            mutations: texts.mutations?.split('|'),
-            variant: texts.variant ?? 'JN.8',
-            minProportion: Number(texts.minProportion ?? '0.05'),
-            minCount: Number(texts.minCount ?? '5'),
-            resistanceSet: (texts.resistanceSet as ResistanceSetName | undefined) ?? resistanceSetNames.ThreeCLPro,
-            excludeVariants: texts.excludeVariants?.split('|') ?? defaultExcludeVariants,
         };
+
+        let analysis: WasapAnalysisFilter;
+
+        switch (mode) {
+            case 'manual':
+                analysis = {
+                    mode,
+                    sequenceType,
+                    mutations: texts.mutations?.split('|'),
+                };
+                break;
+            case 'variant':
+                analysis = {
+                    mode,
+                    sequenceType,
+                    variant: texts.variant ?? 'JN.8',
+                    minProportion: Number(texts.minProportion ?? '0.05'),
+                    minCount: Number(texts.minCount ?? '5'),
+                };
+                break;
+            case 'resistance':
+                analysis = {
+                    mode,
+                    sequenceType: 'amino acid',
+                    resistanceSet:
+                        (texts.resistanceSet as ResistanceSetName | undefined) ?? resistanceSetNames.ThreeCLPro,
+                };
+                break;
+            case 'untracked':
+                analysis = {
+                    mode,
+                    sequenceType,
+                    excludeVariants: texts.excludeVariants?.split('|') ?? defaultExcludeVariants,
+                };
+                break;
+        }
+
+        return { base, analysis };
     }
 
     toUrl(pageState: WasapFilter): string {
         const search = new URLSearchParams();
+        const { base, analysis } = pageState;
+
         // general dataset settings
-        setSearchFromString(search, 'location_name', pageState.locationName);
-        setSearchFromDateRange(search, 'sampling_date', pageState.samplingDate);
-        setSearchFromString(search, 'granularity', pageState.granularity);
-        if (!pageState.excludeEmpty) {
+        setSearchFromString(search, 'location_name', base.locationName);
+        setSearchFromDateRange(search, 'sampling_date', base.samplingDate);
+        setSearchFromString(search, 'granularity', base.granularity);
+        if (!base.excludeEmpty) {
             setSearchFromString(search, 'excludeEmpty', 'false');
         }
+
         // analysis mode dependent settings
-        setSearchFromString(search, 'analysisMode', pageState.analysisMode);
-        switch (pageState.analysisMode) {
+        setSearchFromString(search, 'analysisMode', analysis.mode);
+        switch (analysis.mode) {
             case 'manual':
-                setSearchFromString(search, 'sequenceType', pageState.sequenceType);
-                setSearchFromString(search, 'mutations', pageState.mutations?.join('|'));
+                setSearchFromString(search, 'sequenceType', analysis.sequenceType);
+                setSearchFromString(search, 'mutations', analysis.mutations?.join('|'));
                 break;
             case 'variant':
-                setSearchFromString(search, 'sequenceType', pageState.sequenceType);
-                setSearchFromString(search, 'variant', pageState.variant);
-                setSearchFromString(search, 'minProportion', String(pageState.minProportion));
-                setSearchFromString(search, 'minCount', String(pageState.minCount));
+                setSearchFromString(search, 'sequenceType', analysis.sequenceType);
+                setSearchFromString(search, 'variant', analysis.variant);
+                setSearchFromString(search, 'minProportion', String(analysis.minProportion));
+                setSearchFromString(search, 'minCount', String(analysis.minCount));
                 break;
             case 'resistance':
-                setSearchFromString(search, 'resistanceSet', pageState.resistanceSet);
+                setSearchFromString(search, 'resistanceSet', analysis.resistanceSet);
                 break;
             case 'untracked':
-                setSearchFromString(search, 'sequenceType', pageState.sequenceType);
-                setSearchFromString(search, 'excludeVariants', pageState.excludeVariants?.join('|'));
+                setSearchFromString(search, 'sequenceType', analysis.sequenceType);
+                setSearchFromString(search, 'excludeVariants', analysis.excludeVariants?.join('|'));
                 break;
         }
 
@@ -182,3 +203,62 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
         return wastewaterConfig.pages.covid.path;
     }
 }
+
+const defaultExcludeVariants = [
+    'JN.1',
+    'KP.2',
+    'KP.3',
+    'LP.8',
+    'XEC',
+    'B.1.1.7',
+    'B.1.351',
+    'B.1.617.2',
+    'P.1',
+    'B.1.617.1',
+    'NB.1.8.1',
+    'BA.1',
+    'BA.2.12.1',
+    'BA.2.75.2',
+    'BA.2.75',
+    'BA.2.86',
+    'BA.2',
+    'BA.4',
+    'BA.5',
+    'BQ.1.1',
+    'EG.5',
+    'XBB.1.16',
+    'XBB.1.5',
+    'XBB.2.3',
+    'XBB',
+    'XBB.1.9',
+    'XFG',
+];
+
+export const defaultBaseFilter: WasapBaseFilter = {
+    granularity: 'day',
+    excludeEmpty: true,
+};
+
+export const defaultManualFilter: WasapManualFilter = {
+    mode: 'manual',
+    sequenceType: 'nucleotide',
+};
+
+export const defaultVariantFilter: WasapVariantFilter = {
+    mode: 'variant',
+    sequenceType: 'nucleotide',
+    minProportion: 0.05,
+    minCount: 5,
+};
+
+export const defaultResistanceFilter: WasapResistanceFilter = {
+    mode: 'resistance',
+    sequenceType: 'amino acid',
+    resistanceSet: resistanceSetNames.ThreeCLPro,
+};
+
+export const defaultUntrackedFilter: WasapUntrackedFilter = {
+    mode: 'untracked',
+    sequenceType: 'nucleotide',
+    excludeVariants: defaultExcludeVariants,
+};


### PR DESCRIPTION
### Summary

Refactors the `WasapFilter` into a `base` component and into 4 distinct `analysis` types.

In the PageStateSelector, I'm keeping track of all 4 analysis mode settings, so you can go back-and-forth between modes and not lose your settings.

#### Testing

Not sure whether it's better to add tests in the PR as well, or split into a new one. I think I'd be fine with merging as is, and treating testing as a new PR. To test the components, I think I might also do another refactoring and split things into sub-components that can be tested on their own.

### Screenshot
n/a

## PR Checklist
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by an appropriate test.~~
