### PR TITLE
refactor(website): move lapis functions into common package

### DIFF
--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -67,6 +67,26 @@ export class LapisRouteMocker {
             http.get(`${DUMMY_LAPIS_URL}/sample/lineageDefinition/${fieldName}`, resolver({ statusCode, response })),
         );
     }
+
+    mockPostNucleotideMutations(
+        body: Record<string, unknown>,
+        response: { data: { mutation: string; count: number }[] },
+        statusCode = 200,
+    ) {
+        this.workerOrServer.use(
+            http.post(`${DUMMY_LAPIS_URL}/sample/nucleotideMutations`, resolver({ statusCode, body, response })),
+        );
+    }
+
+    mockPostAminoAcidMutations(
+        body: Record<string, unknown>,
+        response: { data: { mutation: string; count: number }[] },
+        statusCode = 200,
+    ) {
+        this.workerOrServer.use(
+            http.post(`${DUMMY_LAPIS_URL}/sample/aminoAcidMutations`, resolver({ statusCode, body, response })),
+        );
+    }
 }
 
 export class BackendRouteMocker {

--- a/website/src/components/pageStateSelectors/DynamicDateFilter.tsx
+++ b/website/src/components/pageStateSelectors/DynamicDateFilter.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import React from 'react';
 
+import { getDateRange } from '../../lapis/getDateRange';
 import { Loading } from '../../util/Loading';
 import { GsDateRangeFilter } from '../genspectrum/GsDateRangeFilter';
 
@@ -32,7 +33,7 @@ export function DynamicDateFilter({
         error,
     } = useQuery({
         queryKey: ['dateRange', lapis, dateFieldName],
-        queryFn: () => fetchDateRange(lapis, dateFieldName),
+        queryFn: () => getDateRange(lapis, dateFieldName),
     });
 
     return (
@@ -58,38 +59,6 @@ export function DynamicDateFilter({
             )}
         </label>
     );
-}
-
-export async function fetchDateRange(baseUrl: string, fieldName: string): Promise<{ start: string; end: string }> {
-    const url = `${baseUrl.replace(/\/$/, '')}/sample/aggregated`;
-
-    const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            'Content-Type': 'application/json',
-            'accept': 'application/json',
-        },
-        body: JSON.stringify({
-            fields: [fieldName],
-            orderBy: [fieldName],
-        }),
-    });
-
-    if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        throw new Error(
-            `Request to ${url} failed with status ${res.status} ${res.statusText}. Response: ${text.slice(0, 200)}`,
-        );
-    }
-
-    const json: { data: Record<string, string>[] } = await res.json();
-    if (!json.data.length) throw new Error('No data returned');
-
-    return {
-        start: json.data[0][fieldName],
-        end: json.data[json.data.length - 1][fieldName],
-    };
 }
 
 /**

--- a/website/src/lapis/getDateRange.spec.ts
+++ b/website/src/lapis/getDateRange.spec.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { getDateRange } from './getDateRange.ts';
+import { DUMMY_LAPIS_URL } from '../../routeMocker.ts';
+import { astroApiRouteMocker, lapisRouteMocker } from '../../vitest.setup.ts';
+
+describe('getDateRange', () => {
+    beforeEach(() => {
+        astroApiRouteMocker.mockLog();
+    });
+
+    test('should return start and end dates', async () => {
+        const fieldName = 'collectionDate';
+
+        lapisRouteMocker.mockPostAggregated(
+            { fields: [fieldName], orderBy: [fieldName] },
+            {
+                data: [
+                    { collectionDate: '2025-01-01', count: 4 },
+                    { collectionDate: '2025-02-01', count: 5 },
+                ],
+            },
+        );
+
+        const result = await getDateRange(DUMMY_LAPIS_URL, fieldName);
+
+        expect(result).toEqual({ start: '2025-01-01', end: '2025-02-01' });
+    });
+
+    test('should throw when LAPIS request fails', async () => {
+        const fieldName = 'collectionDate';
+
+        lapisRouteMocker.mockPostAggregated({ fields: [fieldName], orderBy: [fieldName] }, { data: [] }, 500);
+
+        await expect(getDateRange(DUMMY_LAPIS_URL, fieldName)).rejects.toThrow(/Failed to fetch date range/);
+    });
+
+    test('should throw when response has no data', async () => {
+        const fieldName = 'collectionDate';
+
+        lapisRouteMocker.mockPostAggregated({ fields: [fieldName], orderBy: [fieldName] }, { data: [] });
+
+        await expect(getDateRange(DUMMY_LAPIS_URL, fieldName)).rejects.toThrow(/No data returned/);
+    });
+
+    test('should throw on unexpected response shape', async () => {
+        const fieldName = 'collectionDate';
+
+        lapisRouteMocker.mockPostAggregated(
+            { fields: [fieldName], orderBy: [fieldName] },
+            // @ts-expect-error intentionally wrong shape
+            { invalid: 'response' },
+        );
+
+        await expect(getDateRange(DUMMY_LAPIS_URL, fieldName)).rejects.toThrow(/Failed to parse date range response/);
+    });
+});

--- a/website/src/lapis/getMutations.spec.ts
+++ b/website/src/lapis/getMutations.spec.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { getMutations } from './getMutations.ts';
+import { DUMMY_LAPIS_URL } from '../../routeMocker.ts';
+import { astroApiRouteMocker, lapisRouteMocker } from '../../vitest.setup.ts';
+
+describe('getMutations', () => {
+    beforeEach(() => {
+        astroApiRouteMocker.mockLog();
+    });
+
+    test('should return filtered mutations', async () => {
+        lapisRouteMocker.mockPostNucleotideMutations(
+            { minProportion: 0.1, pangoLineage: 'B.1.1.7' },
+            {
+                data: [
+                    { mutation: 'A123C', count: 5 },
+                    { mutation: 'G234T', count: 2 },
+                ],
+            },
+        );
+
+        const result = await getMutations(DUMMY_LAPIS_URL, 'nucleotide', 'B.1.1.7', 0.1, 3);
+
+        expect(result).toEqual(['A123C']);
+    });
+
+    test('should throw on failed request', async () => {
+        lapisRouteMocker.mockPostNucleotideMutations(
+            { minProportion: 0.1 },
+            { data: [{ mutation: 'A123C', count: 5 }] },
+            500,
+        );
+
+        await expect(getMutations(DUMMY_LAPIS_URL, 'nucleotide', undefined, 0.1, 1)).rejects.toThrow(
+            /Failed to fetch mutations/,
+        );
+    });
+
+    test('should throw on unexpected response', async () => {
+        // @ts-expect-error wrong shape
+        lapisRouteMocker.mockPostNucleotideMutations({ minProportion: 0.1 }, { data: 'invalid' });
+
+        await expect(getMutations(DUMMY_LAPIS_URL, 'nucleotide', undefined, 0.1, 1)).rejects.toThrow(
+            /Failed to parse mutations response/,
+        );
+    });
+});

--- a/website/src/lapis/getMutations.ts
+++ b/website/src/lapis/getMutations.ts
@@ -1,0 +1,63 @@
+import { type SequenceType } from '@genspectrum/dashboard-components/util';
+import axios from 'axios';
+import { z } from 'zod';
+
+import { getClientLogger } from '../clientLogger.ts';
+
+const mutationsSchema = z.object({
+    data: z.array(
+        z.object({
+            mutation: z.string(),
+            count: z.number(),
+        }),
+    ),
+});
+
+const logger = getClientLogger('getMutations');
+
+/**
+ * Return nucleotide or amino acid mutations matching certain filter criteria.
+ * The underlying request is POST request, but this is still semantically a 'get' operation, hence the name.
+ *
+ * @param lapisUrl The base API URL
+ * @param mutationType nucleotide or amino acid sequences
+ * @param pangoLineage Filter only for sequences belonging to this lineage
+ * @param minProportion The relative frequency a mutation needs to have, relative to the total number of
+ *      unambiguous reads (matching the given other filters)
+ * @param minCount The minimum absolute count a mutation needs to have (after filters are applied) to
+ *      be included in the result
+ * @returns A list of mutation codes
+ */
+export async function getMutations(
+    lapisUrl: string,
+    mutationType: SequenceType,
+    pangoLineage: string | undefined,
+    minProportion: number,
+    minCount: number,
+): Promise<string[]> {
+    const endpoint = mutationType === 'nucleotide' ? 'nucleotideMutations' : 'aminoAcidMutations';
+    const url = `${lapisUrl.replace(/\/$/, '')}/sample/${endpoint}`;
+
+    const body: Record<string, unknown> = { minProportion };
+    if (pangoLineage !== undefined) {
+        body.pangoLineage = pangoLineage;
+    }
+
+    let response;
+    try {
+        response = await axios.post(url, body);
+    } catch (error) {
+        const message = `Failed to fetch mutations: ${JSON.stringify(error)}`;
+        logger.error(message);
+        throw new Error(message);
+    }
+
+    const parsedResponse = mutationsSchema.safeParse(response.data);
+    if (!parsedResponse.success) {
+        const message = `Failed to parse mutations response: ${JSON.stringify(parsedResponse)} (was ${JSON.stringify(response.data)})`;
+        logger.error(message);
+        throw new Error(message);
+    }
+
+    return parsedResponse.data.data.filter((item) => item.count >= minCount).map((item) => item.mutation);
+}

--- a/website/src/lapis/getTotalCount.ts
+++ b/website/src/lapis/getTotalCount.ts
@@ -7,7 +7,6 @@ import { getClientLogger } from '../clientLogger.ts';
 const lapisTotalCountSchema = z.object({
     data: z.tuple([z.object({ count: z.number() })]),
 });
-export type LapisTotalCount = z.infer<typeof lapisTotalCountSchema>;
 
 const logger = getClientLogger('getTotalCount');
 

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -11,7 +11,7 @@ export const wastewaterConfig = {
     browseDataDescription: 'Browse the data in the WISE Loculus instance.',
     lapisBaseUrl: 'https://api.wise-loculus.genspectrum.org',
     wasap: {
-        lapisBaseUrl: 'https://lapis.wasap.genspectrum.org/',
+        lapisBaseUrl: 'https://lapis.wasap.genspectrum.org',
         covSpectrumLapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
         samplingDateField: 'sampling_date',
     },


### PR DESCRIPTION
### Summary

- moves the `fetchMutations` function into `getMutations` in the `lapis` package; there are already other fns like it.
- Also add response schema and testing, better error handling, mocking.
- adds documentation

### Screenshot
n/a

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
