### PR TITLE
feat(website): define  untracked exclusion list dynamically

### DIFF
--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -1,4 +1,3 @@
-import type { LapisFilter } from '@genspectrum/dashboard-components/util';
 import { http } from 'msw';
 import type { DefaultBodyType, StrictRequest } from 'msw';
 import type { SetupWorker } from 'msw/browser';
@@ -47,8 +46,8 @@ export class LapisRouteMocker {
     }
 
     mockPostAggregated(
-        body: LapisFilter,
-        response: { data: Record<string, string | boolean | number>[] },
+        body: Record<string, unknown>,
+        response: { data: Record<string, string | boolean | number | null>[] },
         statusCode = 200,
     ) {
         this.workerOrServer.use(

--- a/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
@@ -1,13 +1,17 @@
 import { type SequenceType, mutationType, type MutationType } from '@genspectrum/dashboard-components/util';
+import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import React, { Fragment, useId, useState } from 'react';
 
 import { ApplyFilterButton } from './ApplyFilterButton';
 import { DynamicDateFilter } from './DynamicDateFilter';
 import { SelectorHeadline } from './SelectorHeadline';
+import { getCladeLineages } from '../../lapis/getCladeLineages';
 import { Inset } from '../../styles/Inset';
 import { wastewaterConfig } from '../../types/wastewaterConfig';
+import { Loading } from '../../util/Loading';
 import { type PageStateHandler } from '../../views/pageStateHandlers/PageStateHandler';
 import {
+    type ExcludeSetName,
     type WasapFilter,
     type WasapAnalysisMode,
     type WasapManualFilter,
@@ -65,6 +69,18 @@ export function WasapPageStateSelector({
                 return { base: baseFilterState, analysis: untrackedFilter };
         }
     }
+
+    // data for the 'untracked' analyis mode - loaded here already so it's available when the mode is selected
+    const cladeLineageQueryResult = useQuery({
+        queryKey: ['cladeLineages'],
+        queryFn: () =>
+            getCladeLineages(
+                wastewaterConfig.wasap.covSpectrum.lapisBaseUrl,
+                wastewaterConfig.wasap.covSpectrum.cladeField,
+                wastewaterConfig.wasap.covSpectrum.lineageField,
+                true,
+            ),
+    });
 
     return (
         <div className='flex flex-col gap-4'>
@@ -141,7 +157,13 @@ export function WasapPageStateSelector({
                                 />
                             );
                         case 'untracked':
-                            return <UntrackedFilter pageState={untrackedFilter} setPageState={setUntrackedFilter} />;
+                            return (
+                                <UntrackedFilter
+                                    pageState={untrackedFilter}
+                                    setPageState={setUntrackedFilter}
+                                    cladeLineageQueryResult={cladeLineageQueryResult}
+                                />
+                            );
                     }
                 })()}
             </Inset>
@@ -199,7 +221,7 @@ function VariantExplorerFilter({
                 onChange={(sequenceType) => setPageState({ ...pageState, sequenceType })}
             />
             <LabeledField label='Variant'>
-                <gs-app lapis={wastewaterConfig.wasap.covSpectrumLapisBaseUrl}>
+                <gs-app lapis={wastewaterConfig.wasap.covSpectrum.lapisBaseUrl}>
                     <GsLineageFilter
                         lapisField='pangoLineage'
                         lapisFilter={{}}
@@ -271,10 +293,15 @@ function ResistanceMutationsFilter({
 function UntrackedFilter({
     pageState,
     setPageState,
+    cladeLineageQueryResult: { isPending, isError, data: cladeLineages },
 }: {
     pageState: WasapUntrackedFilter;
     setPageState: (newState: WasapUntrackedFilter) => void;
+    cladeLineageQueryResult: UseQueryResult<Record<string, string>>;
 }) {
+    const defaultLineages = cladeLineages ? Object.values(cladeLineages) : [];
+    defaultLineages.sort();
+
     return (
         <>
             <SequenceTypeSelector
@@ -282,12 +309,56 @@ function UntrackedFilter({
                 onChange={(sequenceType) => setPageState({ ...pageState, sequenceType })}
             />
             <LabeledField label='Known variants to exclude'>
-                <input
-                    className='input input-bordered'
-                    value={pageState.excludeVariants?.join(' ')}
-                    onChange={(e) => setPageState({ ...pageState, excludeVariants: e.target.value.split(' ') })}
-                />
+                <select
+                    className='select select-bordered'
+                    value={pageState.excludeSet}
+                    onChange={(e) => setPageState({ ...pageState, excludeSet: e.target.value as ExcludeSetName })}
+                >
+                    <option value='nextstrain'>Nextstrain clades</option>
+                    <option value='custom'>custom</option>
+                </select>
             </LabeledField>
+            {pageState.excludeSet === 'nextstrain' ? (
+                isPending ? (
+                    <Loading />
+                ) : isError ? (
+                    <span>Failed to load variant list. Please try again or use custom variant list.</span>
+                ) : (
+                    <div className='px-1 py-2 text-sm'>
+                        {defaultLineages.join(', ')}{' '}
+                        <button
+                            className='cursor-pointer underline'
+                            onClick={() => {
+                                setPageState({
+                                    ...pageState,
+                                    excludeSet: 'custom',
+                                    excludeVariants: defaultLineages,
+                                });
+                            }}
+                        >
+                            Customize ...
+                        </button>
+                    </div>
+                )
+            ) : (
+                <>
+                    <div className='h-2' />
+                    <LabeledField label='Custom variant list'>
+                        <textarea
+                            className='input input-bordered h-24 resize-y overflow-auto p-1 whitespace-pre-wrap'
+                            wrap='soft'
+                            placeholder='JN.1* KP.2* XFG* ...'
+                            value={pageState.excludeVariants?.join(' ')}
+                            onChange={(e) =>
+                                setPageState({
+                                    ...pageState,
+                                    excludeVariants: e.target.value.trim().split(/[\s,]+/),
+                                })
+                            }
+                        />
+                    </LabeledField>
+                </>
+            )}
         </>
     );
 }

--- a/website/src/lapis/getCladeLineages.spec.ts
+++ b/website/src/lapis/getCladeLineages.spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { getCladeLineages } from './getCladeLineages.ts';
+import { DUMMY_LAPIS_URL } from '../../routeMocker.ts';
+import { astroApiRouteMocker, lapisRouteMocker } from '../../vitest.setup.ts';
+
+describe('getCladeLineages', () => {
+    beforeEach(() => {
+        astroApiRouteMocker.mockLog();
+    });
+
+    test('should return the lineage with max count for each clade', async () => {
+        const cladeField = 'nextstrainClade';
+        const lineageField = 'pangoLineage';
+
+        lapisRouteMocker.mockPostAggregated(
+            { fields: [cladeField, lineageField], orderBy: [cladeField, { field: 'count', type: 'descending' }] },
+            {
+                data: [
+                    { count: 5, nextstrainClade: null, pangoLineage: 'XBB.1.16.3.3' },
+                    { count: 9001, nextstrainClade: '23B', pangoLineage: 'XBB.1.16' },
+                    { count: 681, nextstrainClade: '23B', pangoLineage: 'XBB.1.16.2' },
+                    { count: 3055, nextstrainClade: '23B', pangoLineage: 'XBB.1.16.1' },
+                    { count: 932, nextstrainClade: '23B', pangoLineage: 'FU.2' },
+                    { count: 4797, nextstrainClade: '23B', pangoLineage: 'XBB.1.16.11' },
+                    { count: 2000, nextstrainClade: '22A', pangoLineage: 'YAA.2' },
+                    { count: 1500, nextstrainClade: '22A', pangoLineage: 'YAA.1' },
+                ],
+            },
+        );
+
+        const result = await getCladeLineages(DUMMY_LAPIS_URL, cladeField, lineageField);
+
+        /* eslint-disable @typescript-eslint/naming-convention */
+        expect(result).toEqual({
+            '23B': 'XBB.1.16',
+            '22A': 'YAA.2',
+        });
+        /* eslint-enable @typescript-eslint/naming-convention */
+    });
+
+    test('should throw on failed request', async () => {
+        const cladeField = 'nextstrainClade';
+        const lineageField = 'pangoLineage';
+
+        lapisRouteMocker.mockPostAggregated(
+            { fields: [cladeField, lineageField], orderBy: [cladeField, { field: 'count', type: 'descending' }] },
+            { data: [] },
+            500,
+        );
+
+        await expect(getCladeLineages(DUMMY_LAPIS_URL, cladeField, lineageField)).rejects.toThrow(
+            /Failed to fetch clade lineages/,
+        );
+    });
+
+    test('should throw on unexpected response shape', async () => {
+        const cladeField = 'nextstrainClade';
+        const lineageField = 'pangoLineage';
+
+        lapisRouteMocker.mockPostAggregated(
+            { fields: [cladeField, lineageField], orderBy: [cladeField, { field: 'count', type: 'descending' }] },
+            // @ts-expect-error intentionally invalid
+            { invalid: 'response' },
+        );
+
+        await expect(getCladeLineages(DUMMY_LAPIS_URL, cladeField, lineageField)).rejects.toThrow(
+            /Failed to parse clade lineages response/,
+        );
+    });
+
+    test('should throw on invalid response field types', async () => {
+        const cladeField = 'nextstrainClade';
+        const lineageField = 'pangoLineage';
+
+        lapisRouteMocker.mockPostAggregated(
+            { fields: [cladeField, lineageField], orderBy: [cladeField, { field: 'count', type: 'descending' }] },
+            {
+                data: [
+                    { count: 10, nextstrainClade: '23B', pangoLineage: 'XBB.1' },
+                    { count: 5, nextstrainClade: 23, pangoLineage: 'XBB.2' },
+                    { count: 5, nextstrainClade: 123, pangoLineage: 'XBB.3' },
+                ],
+            },
+        );
+
+        await expect(getCladeLineages(DUMMY_LAPIS_URL, cladeField, lineageField)).rejects.toThrow(
+            /Unexpected row types in clade lineages response/,
+        );
+    });
+});

--- a/website/src/lapis/getCladeLineages.ts
+++ b/website/src/lapis/getCladeLineages.ts
@@ -1,0 +1,61 @@
+import axios from 'axios';
+
+import { getClientLogger } from '../clientLogger.ts';
+import { aggregatedResponse } from './types.ts';
+
+const logger = getClientLogger('getCladeLineages');
+
+/**
+ * Finds the lineage definition belonging to clades, by looking for the lineage that is most
+ * commonly associated with each clade.
+ * Returns a map, mapping all clades found in the data to their respective lineage.
+ */
+export async function getCladeLineages(
+    baseUrl: string,
+    cladeField: string,
+    lineageField: string,
+    withAsterisk = false,
+): Promise<Record<string, string>> {
+    const url = `${baseUrl.replace(/\/$/, '')}/sample/aggregated`;
+    const body = {
+        fields: [cladeField, lineageField],
+        orderBy: [cladeField, { field: 'count', type: 'descending' }],
+    };
+
+    let response;
+    try {
+        response = await axios.post(url, body);
+    } catch (error) {
+        const message = `Failed to fetch clade lineages: ${JSON.stringify(error)}`;
+        logger.error(message);
+        throw new Error(message);
+    }
+
+    const parsedResponse = aggregatedResponse.safeParse(response.data);
+    if (!parsedResponse.success) {
+        const message = `Failed to parse clade lineages response: ${JSON.stringify(parsedResponse)} (was ${JSON.stringify(response.data)})`;
+        logger.error(message);
+        throw new Error(message);
+    }
+
+    const mapping: Record<string, string> = {};
+
+    for (const row of parsedResponse.data.data) {
+        const clade = row[cladeField];
+        const lineage = row[lineageField];
+
+        if (clade === null || lineage === null || clade === 'recombinant') {
+            continue;
+        }
+
+        if (typeof clade !== 'string' || typeof lineage !== 'string') {
+            throw new Error(`Unexpected row types in clade lineages response: ${JSON.stringify(row)}`);
+        }
+
+        if (!(clade in mapping)) {
+            mapping[clade] = withAsterisk ? `${lineage}*` : lineage;
+        }
+    }
+
+    return mapping;
+}

--- a/website/src/lapis/getDateRange.ts
+++ b/website/src/lapis/getDateRange.ts
@@ -1,16 +1,9 @@
 import axios from 'axios';
-import { z } from 'zod';
 
 import { getClientLogger } from '../clientLogger.ts';
+import { aggregatedResponse } from './types.ts';
 
 const logger = getClientLogger('getDateRange');
-
-const baseResponseValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
-const aggregatedItem = z.object({ count: z.number() }).catchall(baseResponseValueSchema);
-
-const aggregatedResponse = z.object({
-    data: z.array(aggregatedItem),
-});
 
 export async function getDateRange(baseUrl: string, fieldName: string): Promise<{ start: string; end: string }> {
     const url = `${baseUrl.replace(/\/$/, '')}/sample/aggregated`;

--- a/website/src/lapis/types.ts
+++ b/website/src/lapis/types.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+const baseResponseValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+const aggregatedItem = z.object({ count: z.number() }).catchall(baseResponseValueSchema);
+
+export const aggregatedResponse = z.object({
+    data: z.array(aggregatedItem),
+});

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -12,8 +12,12 @@ export const wastewaterConfig = {
     lapisBaseUrl: 'https://api.wise-loculus.genspectrum.org',
     wasap: {
         lapisBaseUrl: 'https://lapis.wasap.genspectrum.org',
-        covSpectrumLapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
         samplingDateField: 'sampling_date',
+        covSpectrum: {
+            lapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
+            cladeField: 'nextstrainClade',
+            lineageField: 'pangoLineage',
+        },
     },
     pages: {
         rsv: {

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -41,9 +41,12 @@ export type WasapResistanceFilter = {
     resistanceSet: ResistanceSetName;
 };
 
+export type ExcludeSetName = 'nextstrain' | 'custom';
+
 export type WasapUntrackedFilter = {
     mode: 'untracked';
     sequenceType: SequenceType;
+    excludeSet: ExcludeSetName;
     excludeVariants?: string[];
 };
 
@@ -103,6 +106,10 @@ const wasapFilterConfig: BaselineFilterConfig[] = [
     },
     {
         type: 'text',
+        lapisField: 'excludeSet',
+    },
+    {
+        type: 'text',
         lapisField: 'excludeVariants',
     },
 ];
@@ -154,7 +161,8 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                 analysis = {
                     mode,
                     sequenceType,
-                    excludeVariants: texts.excludeVariants?.split('|') ?? defaultExcludeVariants,
+                    excludeSet: (texts.excludeSet as ExcludeSetName | undefined) ?? 'nextstrain',
+                    excludeVariants: texts.excludeVariants?.split('|'),
                 };
                 break;
         }
@@ -192,7 +200,10 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                 break;
             case 'untracked':
                 setSearchFromString(search, 'sequenceType', analysis.sequenceType);
-                setSearchFromString(search, 'excludeVariants', analysis.excludeVariants?.join('|'));
+                setSearchFromString(search, 'excludeSet', analysis.excludeSet);
+                if (analysis.excludeSet === 'custom') {
+                    setSearchFromString(search, 'excludeVariants', analysis.excludeVariants?.join('|'));
+                }
                 break;
         }
 
@@ -203,36 +214,6 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
         return wastewaterConfig.pages.covid.path;
     }
 }
-
-const defaultExcludeVariants = [
-    'JN.1',
-    'KP.2',
-    'KP.3',
-    'LP.8',
-    'XEC',
-    'B.1.1.7',
-    'B.1.351',
-    'B.1.617.2',
-    'P.1',
-    'B.1.617.1',
-    'NB.1.8.1',
-    'BA.1',
-    'BA.2.12.1',
-    'BA.2.75.2',
-    'BA.2.75',
-    'BA.2.86',
-    'BA.2',
-    'BA.4',
-    'BA.5',
-    'BQ.1.1',
-    'EG.5',
-    'XBB.1.16',
-    'XBB.1.5',
-    'XBB.2.3',
-    'XBB',
-    'XBB.1.9',
-    'XFG',
-];
 
 export const defaultManualFilter: WasapManualFilter = {
     mode: 'manual',
@@ -255,5 +236,5 @@ export const defaultResistanceFilter: WasapResistanceFilter = {
 export const defaultUntrackedFilter: WasapUntrackedFilter = {
     mode: 'untracked',
     sequenceType: 'nucleotide',
-    excludeVariants: defaultExcludeVariants,
+    excludeSet: 'nextstrain',
 };


### PR DESCRIPTION
resolves #818 

### Summary

- adds a new lapis fetch function that gets the mapping from clade to lineage (with test)
- refactor the UI, so you can explicitly select the Nextstrain clades, or add your own list. The new UI also makes it clear that the list is coming from Nextstrain, and makes it easier to "go back" to that list, in case you edited it.

### Screenshot

https://github.com/user-attachments/assets/64bd35e4-89b3-4ef4-9ecb-2e15858f2267

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
