### PR TITLE
feat(website): use cov-spectrum mutation links for W-ASAP dashboard

### DIFF
--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -53,9 +53,14 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
     };
 
     const memoizedMutationAnnotations = useMemo(() => JSON.stringify(resistanceMutationAnnotations), []);
+    const memoizedLinkTemplate = useMemo(() => JSON.stringify(wastewaterConfig.wasap.linkTemplate), []);
 
     return (
-        <gs-app lapis={wastewaterConfig.wasap.lapisBaseUrl} mutationAnnotations={memoizedMutationAnnotations}>
+        <gs-app
+            lapis={wastewaterConfig.wasap.lapisBaseUrl}
+            mutationAnnotations={memoizedMutationAnnotations}
+            mutationLinkTemplate={memoizedLinkTemplate}
+        >
             <div className='grid-cols-[300px_1fr] gap-x-4 lg:grid'>
                 <div className='h-fit p-2 shadow-lg'>
                     <WasapPageStateSelector

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -11,6 +11,12 @@ export const wastewaterConfig = {
     browseDataDescription: 'Browse the data in the WISE Loculus instance.',
     lapisBaseUrl: 'https://api.wise-loculus.genspectrum.org',
     wasap: {
+        linkTemplate: {
+            nucleotideMutation:
+                'https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?nucMutations={{mutation}}',
+            aminoAcidMutation:
+                'https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?aaMutations={{mutation}}',
+        },
         lapisBaseUrl: 'https://lapis.wasap.genspectrum.org',
         covSpectrumLapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
         samplingDateField: 'sampling_date',


### PR DESCRIPTION
resolves #816 

### Summary

Now with components 1.8.0, the components support link templates, and we can use them for the dashboard!

### Screenshot

https://github.com/user-attachments/assets/88f79127-29f2-46d2-9b23-b9523a57bf33

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
