### PR TITLE
feat(website): add number fields to the sliders on the W-ASAP dashboard

### DIFF
--- a/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
@@ -212,36 +212,24 @@ function VariantExplorerFilter({
                     />
                 </gs-app>
             </LabeledField>
-            <LabeledField label='Min. proportion'>
-                <div className='mb-2 w-full'>
-                    <input
-                        className='w-full'
-                        type='range'
-                        min='0'
-                        max='1'
-                        step='0.01'
-                        value={pageState.minProportion}
-                        onChange={(e) => {
-                            setPageState({ ...pageState, minProportion: parseFloat(e.target.value) });
-                        }}
-                    />
-                </div>
-            </LabeledField>
-            <LabeledField label='Min. count'>
-                <div className='mb-2 w-full'>
-                    <input
-                        className='w-full'
-                        type='range'
-                        min='1'
-                        max='250'
-                        step='1'
-                        value={pageState.minCount}
-                        onChange={(e) => {
-                            setPageState({ ...pageState, minCount: parseInt(e.target.value) });
-                        }}
-                    />
-                </div>
-            </LabeledField>
+            <NumericInput
+                label='Min. proportion'
+                value={pageState.minProportion}
+                min={0}
+                max={1}
+                step={0.01}
+                parser={parseFloat}
+                onChange={(v) => setPageState({ ...pageState, minProportion: v })}
+            />
+            <NumericInput
+                label='Min. count'
+                value={pageState.minCount}
+                min={1}
+                max={250}
+                step={1}
+                parser={parseInt}
+                onChange={(v) => setPageState({ ...pageState, minCount: v })}
+            />
         </>
     );
 }
@@ -400,5 +388,48 @@ function LabeledField({ label, children }: { label: string; children: React.Reac
             </div>
             {children}
         </label>
+    );
+}
+
+function NumericInput({
+    label,
+    value,
+    min,
+    max,
+    step,
+    onChange,
+    parser = parseFloat,
+}: {
+    label: string;
+    value: number;
+    min: number;
+    max: number;
+    step: number;
+    onChange: (v: number) => void;
+    parser?: (v: string) => number;
+}) {
+    return (
+        <LabeledField label={label}>
+            <div className='mb-2 w-full'>
+                <input
+                    className='input input-bordered mb-2 w-full'
+                    type='number'
+                    min={min}
+                    max={max}
+                    step={step}
+                    value={value}
+                    onChange={(e) => onChange(parser(e.target.value))}
+                />
+                <input
+                    className='accent-primary w-full'
+                    type='range'
+                    min={min}
+                    max={max}
+                    step={step}
+                    value={value}
+                    onChange={(e) => onChange(parser(e.target.value))}
+                />
+            </div>
+        </LabeledField>
     );
 }

--- a/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/WasapPageStateSelector.tsx
@@ -218,7 +218,6 @@ function VariantExplorerFilter({
                 min={0}
                 max={1}
                 step={0.01}
-                parser={parseFloat}
                 onChange={(v) => setPageState({ ...pageState, minProportion: v })}
             />
             <NumericInput
@@ -227,8 +226,7 @@ function VariantExplorerFilter({
                 min={1}
                 max={250}
                 step={1}
-                parser={parseInt}
-                onChange={(v) => setPageState({ ...pageState, minCount: v })}
+                onChange={(v) => setPageState({ ...pageState, minCount: Math.round(v) })}
             />
         </>
     );
@@ -398,7 +396,6 @@ function NumericInput({
     max,
     step,
     onChange,
-    parser = parseFloat,
 }: {
     label: string;
     value: number;
@@ -406,7 +403,6 @@ function NumericInput({
     max: number;
     step: number;
     onChange: (v: number) => void;
-    parser?: (v: string) => number;
 }) {
     return (
         <LabeledField label={label}>
@@ -418,7 +414,12 @@ function NumericInput({
                     max={max}
                     step={step}
                     value={value}
-                    onChange={(e) => onChange(parser(e.target.value))}
+                    onChange={(e) => {
+                        const parsedNumber = Number(e.target.value);
+                        if (Number.isFinite(parsedNumber)) {
+                            onChange(parsedNumber);
+                        }
+                    }}
                 />
                 <input
                     className='accent-primary w-full'
@@ -427,7 +428,7 @@ function NumericInput({
                     max={max}
                     step={step}
                     value={value}
-                    onChange={(e) => onChange(parser(e.target.value))}
+                    onChange={(e) => onChange(Number(e.target.value))}
                 />
             </div>
         </LabeledField>


### PR DESCRIPTION
resolves #807 

### Summary

- Adds an input field above the slider

The issue description mentions that the range is not indicated, but by sliding to both ends of the slider, you know the range. The design looks similar to https://components.genspectrum.org/?path=/story/input-number-range-filter--default - which also doesn't have start and end labels.

### Screenshot

<img width="296" height="391" alt="image" src="https://github.com/user-attachments/assets/30395988-d605-449b-9810-20fe240b50cb" />

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
