### PR TITLE
feat(website): for W-ASAP set Zürich as the default city to filter for

### DIFF
--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -124,7 +124,7 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
             (texts.sequenceType as SequenceType | undefined) ?? (mode === 'resistance' ? 'amino acid' : 'nucleotide');
 
         const base: WasapBaseFilter = {
-            locationName: texts.location_name,
+            locationName: texts.location_name ?? 'Zürich (ZH)',
             samplingDate: dateRanges.sampling_date,
             granularity: texts.granularity ?? 'day',
             excludeEmpty: texts.excludeEmpty !== 'false',


### PR DESCRIPTION
### Summary

This sets Zürich as the default city that we filter for.

Now the state to not filter for any city also cannot be represented anymore, so it becomes impossible to not filter for a city.

But I've been told that this is actually fine, because it makes no sense to put all data from all cities together.

### Screenshot

n/a

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
