### PR TITLE
chore(W-ASAP): Migrating LAPIS filters to unified schema

### DIFF
--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -90,9 +90,9 @@ export function WasapPageStateSelector({
                 <LabeledField label='Sampling location'>
                     <GsTextFilter
                         placeholderText='Sampling location'
-                        lapisField='location_name'
+                        lapisField='locationName'
                         lapisFilter={{}}
-                        onInputChange={({ location_name: locationName }) => {
+                        onInputChange={({ locationName }) => {
                             setBaseFilterState({ ...baseFilterState, locationName });
                         }}
                         value={baseFilterState.locationName}

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -47,9 +47,9 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
 
     const lapisFilter = {
         /* eslint-disable @typescript-eslint/naming-convention */
-        ...(base.locationName && { location_name: base.locationName }),
-        ...(base.samplingDate?.dateFrom && { sampling_dateFrom: base.samplingDate.dateFrom }),
-        ...(base.samplingDate?.dateTo && { sampling_dateTo: base.samplingDate.dateTo }),
+        ...(base.locationName && { locationName: base.locationName }),
+        ...(base.samplingDate?.dateFrom && { samplingDateFrom: base.samplingDate.dateFrom }),
+        ...(base.samplingDate?.dateTo && { samplingDateTo: base.samplingDate.dateTo }),
         /* eslint-enable @typescript-eslint/naming-convention */
     };
 

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -18,7 +18,7 @@ export const wastewaterConfig = {
                 'https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?aaMutations={{mutation}}',
         },
         lapisBaseUrl: 'https://lapis.wasap.genspectrum.org',
-        samplingDateField: 'sampling_date',
+        samplingDateField: 'samplingDate',
         covSpectrum: {
             lapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
             cladeField: 'nextstrainClade',

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -89,7 +89,7 @@ export const defaultUntrackedFilter: WasapUntrackedFilter = {
 const wasapFilterConfig: BaselineFilterConfig[] = [
     {
         type: 'text',
-        lapisField: 'location_name',
+        lapisField: 'locationName',
     },
     {
         type: 'date',
@@ -157,8 +157,8 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
             (texts.sequenceType as SequenceType | undefined) ?? (mode === 'resistance' ? 'amino acid' : 'nucleotide');
 
         const base: WasapBaseFilter = {
-            locationName: texts.location_name ?? 'Zürich (ZH)',
-            samplingDate: dateRanges.sampling_date,
+            locationName: texts.locationName ?? 'Zürich (ZH)',
+            samplingDate: dateRanges.samplingDate,
             granularity: texts.granularity ?? 'day',
             excludeEmpty: texts.excludeEmpty !== 'false',
         };
@@ -209,7 +209,7 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
         const { base, analysis } = pageState;
 
         // general dataset settings
-        setSearchFromString(search, 'location_name', base.locationName);
+        setSearchFromString(search, 'locationName', base.locationName);
         // Force the date range to always use the Custom label for URL serialization
         const customDateRange = base.samplingDate ? { ...base.samplingDate, label: CustomDateRangeLabel } : undefined;
         setSearchFromDateRange(search, wastewaterConfig.wasap.samplingDateField, customDateRange);


### PR DESCRIPTION
resolves [Unify the Loculus and SILO metadata fields](https://github.com/cbg-ethz/WisePulse/issues/88)

Migrating from underscore to camelCase LAPIS filters on the Wastewater instance.

