### PR TITLE
feat(website): add status check to LAPIS source to improve 'server unavailable' UX

### DIFF
--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -123,6 +123,14 @@ export class LapisRouteMocker {
     mockPostAminoAcidMutationsMulti(cases: MockCase[]) {
         this.workerOrServer.use(http.post(`${DUMMY_LAPIS_URL}/sample/aminoAcidMutations`, resolver(cases)));
     }
+
+    mockLapisDown() {
+        this.workerOrServer.use(
+            http.all(`${DUMMY_LAPIS_URL}/*`, () => {
+                return Response.error();
+            }),
+        );
+    }
 }
 
 export class BackendRouteMocker {

--- a/website/src/components/LapisUnreachableWrapperClient.browser.spec.tsx
+++ b/website/src/components/LapisUnreachableWrapperClient.browser.spec.tsx
@@ -1,0 +1,69 @@
+import { describe, expect } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+import LapisUnreachableWrapperClient from './LapisUnreachableWrapperClient';
+import { DUMMY_LAPIS_URL } from '../../routeMocker';
+import { it } from '../../test-extend';
+
+describe('LapisUnreachableWrapperClient', () => {
+    it('displays children when LAPIS is reachable', async ({ routeMockers: { lapis } }) => {
+        lapis.mockPostAggregated({}, { data: [{ count: 100 }] });
+
+        const { getByText } = render(
+            <LapisUnreachableWrapperClient lapisUrl={DUMMY_LAPIS_URL}>
+                <div>Content is visible</div>
+            </LapisUnreachableWrapperClient>,
+        );
+
+        await expect.element(getByText('Content is visible')).toBeVisible();
+    });
+
+    it('displays error message when LAPIS is unreachable', async ({ routeMockers: { lapis } }) => {
+        lapis.mockLapisDown();
+
+        const { getByText } = render(
+            <LapisUnreachableWrapperClient lapisUrl={DUMMY_LAPIS_URL}>
+                <div>Content is visible</div>
+            </LapisUnreachableWrapperClient>,
+        );
+
+        await expect.element(getByText('Data Source Unreachable')).toBeVisible();
+        await expect.element(getByText('Unable to connect to the data source')).toBeVisible();
+    });
+
+    it('does not display children when LAPIS is unreachable', async ({ routeMockers: { lapis } }) => {
+        lapis.mockLapisDown();
+
+        const { getByText } = render(
+            <LapisUnreachableWrapperClient lapisUrl={DUMMY_LAPIS_URL}>
+                <div>Content should not be visible</div>
+            </LapisUnreachableWrapperClient>,
+        );
+
+        await expect.poll(() => getByText('Content should not be visible').query()).not.toBeInTheDocument();
+    });
+
+    it('displays error when LAPIS returns invalid response', async ({ routeMockers: { lapis } }) => {
+        lapis.mockPostAggregated({}, { data: [] }, 200);
+
+        const { getByText } = render(
+            <LapisUnreachableWrapperClient lapisUrl={DUMMY_LAPIS_URL}>
+                <div>Content is visible</div>
+            </LapisUnreachableWrapperClient>,
+        );
+
+        await expect.element(getByText('Data Source Unreachable')).toBeVisible();
+    });
+
+    it('displays error when LAPIS returns 500', async ({ routeMockers: { lapis } }) => {
+        lapis.mockPostAggregated({}, { data: [{ count: 100 }] }, 500);
+
+        const { getByText } = render(
+            <LapisUnreachableWrapperClient lapisUrl={DUMMY_LAPIS_URL}>
+                <div>Content is visible</div>
+            </LapisUnreachableWrapperClient>,
+        );
+
+        await expect.element(getByText('Data Source Unreachable')).toBeVisible();
+    });
+});

--- a/website/src/components/LapisUnreachableWrapperClient.tsx
+++ b/website/src/components/LapisUnreachableWrapperClient.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import { type FC, type ReactNode } from 'react';
+
+import { checkLapisHealth } from '../lapis/checkLapisHealth';
+import { withQueryProvider } from './subscriptions/backendApi/withQueryProvider';
+
+type LapisUnreachableWrapperClientProps = {
+    lapisUrl: string;
+    children: ReactNode;
+};
+
+const LapisUnreachableWrapperClientInner: FC<LapisUnreachableWrapperClientProps> = ({ lapisUrl, children }) => {
+    const { data: isReachable, isLoading } = useQuery({
+        queryKey: ['lapis-reachable', lapisUrl],
+        queryFn: () => checkLapisHealth(lapisUrl),
+        retry: 2,
+        retryDelay: 1000,
+        staleTime: 60000, // Consider data fresh for 1 minute
+    });
+
+    if (!isLoading && isReachable === false) {
+        return (
+            <div className='flex h-full w-full items-center justify-center rounded-md border-2 border-red-200 bg-red-50 p-8'>
+                <div className='text-center'>
+                    <h2 className='mb-2 text-xl font-bold text-red-700'>Data Source Unreachable</h2>
+                    <p className='text-red-600'>
+                        Unable to connect to the data source at{' '}
+                        <code className='rounded bg-red-100 px-1'>{lapisUrl}</code>.
+                    </p>
+                    <p className='mt-2 text-sm text-red-500'>
+                        Please try again later or contact support if the problem persists.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    return <>{children}</>;
+};
+
+const LapisUnreachableWrapperClient = withQueryProvider(LapisUnreachableWrapperClientInner);
+
+export default LapisUnreachableWrapperClient;

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -46,11 +46,9 @@ export const WasapPageInner: FC<WasapPageProps> = ({ currentUrl }) => {
     }
 
     const lapisFilter = {
-        /* eslint-disable @typescript-eslint/naming-convention */
         ...(base.locationName && { locationName: base.locationName }),
         ...(base.samplingDate?.dateFrom && { samplingDateFrom: base.samplingDate.dateFrom }),
         ...(base.samplingDate?.dateTo && { samplingDateTo: base.samplingDate.dateTo }),
-        /* eslint-enable @typescript-eslint/naming-convention */
     };
 
     const memoizedMutationAnnotations = useMemo(() => JSON.stringify(resistanceMutationAnnotations), []);

--- a/website/src/lapis/checkLapisHealth.ts
+++ b/website/src/lapis/checkLapisHealth.ts
@@ -1,0 +1,14 @@
+import { getClientLogger } from '../clientLogger.ts';
+import { getTotalCount } from './getTotalCount';
+
+const logger = getClientLogger('checkLapisHealth');
+
+export async function checkLapisHealth(lapisUrl: string): Promise<boolean> {
+    try {
+        await getTotalCount(lapisUrl, {});
+        return true;
+    } catch (error) {
+        logger.error(`LAPIS health check failed: ${JSON.stringify(error)}`);
+        return false;
+    }
+}

--- a/website/src/layouts/OrganismPage/DataPageLayout.astro
+++ b/website/src/layouts/OrganismPage/DataPageLayout.astro
@@ -3,6 +3,7 @@ import type { ComponentProps } from 'astro/types';
 
 import AccessionsDownloadButton from './AccessionsDownloadButton.astro';
 import LastUpdatedInfo from './LastUpdatedInfo.astro';
+import LapisUnreachableWrapperClient from '../../components/LapisUnreachableWrapperClient';
 import type { DataOrigin } from '../../types/dataOrigins';
 import { type BreadcrumbElement, Breadcrumbs } from '../Breadcrumbs';
 import BaseLayout from '../base/BaseLayout.astro';
@@ -24,7 +25,9 @@ const { title, breadcrumbs, dataOrigins, lapisUrl, downloadLinks = [], accession
     <div class='ml-2'>
         <Breadcrumbs breadcrumbs={breadcrumbs} />
     </div>
-    <slot />
+    <LapisUnreachableWrapperClient lapisUrl={lapisUrl} client:only='react'>
+        <slot />
+    </LapisUnreachableWrapperClient>
     <div class='mt-2 flex flex-col items-center justify-center sm:mt-0 sm:flex-row sm:gap-4' slot='secondary-footer'>
         {
             downloadLinks.length > 0 && (


### PR DESCRIPTION
resolves #894 

### Summary

Adds a health check to the W-ASAP dashboard. if the server cannot be reached, display an error message.

**Currently the health check does a call to `/sample/aggregated`**.  Maybe we want to use `/actuator/health`

### Screenshot

<img width="1510" height="859" alt="image" src="https://github.com/user-attachments/assets/f14b421b-458a-461a-8b00-b3e2e97769e8" />

## PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
