### PR TITLE
feat(website): use multi-select lineage filter for untracked mutations

### DIFF
--- a/website/src/components/genspectrum/GsLineageFilter.tsx
+++ b/website/src/components/genspectrum/GsLineageFilter.tsx
@@ -10,15 +10,19 @@ export function GsLineageFilter<Lineage extends string>({
     placeholderText,
     width,
     onLineageChange = () => {},
+    onLineageMultiChange = () => {},
     hideCounts,
+    multiSelect,
 }: {
     lapisField: Lineage;
-    value?: string;
+    value?: string | string[];
     lapisFilter: LapisFilter;
     placeholderText?: string;
     width?: string;
     onLineageChange?: (lineage: { [key in Lineage]: string | undefined }) => void;
+    onLineageMultiChange?: (lineage: { [key in Lineage]: string[] | undefined }) => void;
     hideCounts?: true;
+    multiSelect?: true;
 }) {
     const lineageFilterRef = useRef<HTMLElement>();
 
@@ -39,15 +43,38 @@ export function GsLineageFilter<Lineage extends string>({
         };
     }, [onLineageChange]);
 
+    useEffect(() => {
+        const currentLineageFilterRef = lineageFilterRef.current;
+        if (!currentLineageFilterRef) {
+            return;
+        }
+
+        const handleLineageMultiChange = (event: CustomEvent) => {
+            onLineageMultiChange(event.detail);
+        };
+
+        currentLineageFilterRef.addEventListener(gsEventNames.lineageFilterMultiChanged, handleLineageMultiChange);
+
+        return () => {
+            currentLineageFilterRef.removeEventListener(
+                gsEventNames.lineageFilterMultiChanged,
+                handleLineageMultiChange,
+            );
+        };
+    }, [onLineageMultiChange]);
+
+    const valueProperty = value === undefined ? (multiSelect ? '[]' : '') : multiSelect ? JSON.stringify(value) : value;
+
     return (
         <gs-lineage-filter
             lapisField={lapisField}
             placeholderText={placeholderText}
-            value={value ?? ''}
+            value={valueProperty}
             width={width}
             ref={lineageFilterRef}
             lapisFilter={JSON.stringify(lapisFilter)}
             hideCounts={hideCounts}
+            multiSelect={multiSelect}
         ></gs-lineage-filter>
     );
 }

--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -169,6 +169,7 @@ export function WasapPageStateSelector({
                                 <UntrackedFilter
                                     pageState={untrackedFilter}
                                     setPageState={setUntrackedFilter}
+                                    clinicalSequenceLapisBaseUrl={wastewaterConfig.wasap.covSpectrum.lapisBaseUrl}
                                     cladeLineageQueryResult={cladeLineageQueryResult}
                                 />
                             );


### PR DESCRIPTION
resolves #843 

### Summary

In the dashboard-components we now have the `multiSelect` lineage filter! This PR makes use of it.

### Screenshot

https://github.com/user-attachments/assets/818f6843-016a-4bdd-b56e-30c1a96d904a

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
