### PR TITLE
feat(website): use open cov-spectrum instance for W-ASAP dashboard

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -23,7 +23,7 @@ export const wastewaterConfig = {
         covSpectrum: {
             lapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
             cladeField: 'nextstrainClade',
-            lineageField: 'pangoLineage',
+            lineageField: 'nextcladePangoLineage',
         },
     },
     pages: {


### PR DESCRIPTION
@chaoran-chen suggested this change:

> ok, so for the open data, we use the pangoLineage and nextcladePangoLineage provided in the metadata file by Nextstrain. Nextstrain runs Nextclade themselves but pangoLineage is coming from NCBI datasets. We don't know (yet) how NCBI generates the field but a hypothesis is that they use pangolin but that they don't rerun it (immediately) on all older sequences when they update to a new version, i.e., new lineages are only assigned to new sequences. If that's the case, someone should fix it and ensure that the same pangolin version/dataset is used for all sequences to be consistent. A question would be who this someone is: NCBI, Nextstrain or CoV-Spectrum.

> In the meantime, I would recommend using nextcladePangoLineage where the values are consistent.
