### PR TITLE
feat(website): use open cov-spectrum instance for link-outs

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -13,9 +13,9 @@ export const wastewaterConfig = {
     wasap: {
         linkTemplate: {
             nucleotideMutation:
-                'https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?nucMutations={{mutation}}',
+                'https://open.cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?nucMutations={{mutation}}',
             aminoAcidMutation:
-                'https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?aaMutations={{mutation}}',
+                'https://open.cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?aaMutations={{mutation}}',
         },
         lapisBaseUrl: 'https://lapis.wasap.genspectrum.org',
         samplingDateField: 'samplingDate',


### PR DESCRIPTION
### Summary

Most swiss data is also available in the open instance, and we think that the GISAID instance might end up not getting updated anymore. So we switch out link outs over to the open instance.