### PR TITLE
feat(website): use new endpoint for all instances of mutations-over-time

### DIFF
--- a/website/src/components/views/analyzeSingleVariant/CovidSingleVariantDataDisplay.tsx
+++ b/website/src/components/views/analyzeSingleVariant/CovidSingleVariantDataDisplay.tsx
@@ -118,6 +118,7 @@ export const CovidSingleVariantDataDisplay: FC<CovidSingleVariantDataDisplayProp
                 sequenceType='nucleotide'
                 granularity={timeGranularity}
                 lapisDateField={view.organismConstants.mainDateField}
+                useNewEndpoint={true}
             />
 
             <GsMutationsOverTime
@@ -125,6 +126,7 @@ export const CovidSingleVariantDataDisplay: FC<CovidSingleVariantDataDisplayProp
                 sequenceType='amino acid'
                 granularity={timeGranularity}
                 lapisDateField={view.organismConstants.mainDateField}
+                useNewEndpoint={true}
             />
         </div>
     );

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyseSingleVariantDataDisplay.tsx
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyseSingleVariantDataDisplay.tsx
@@ -107,12 +107,14 @@ export const GenericAnalyseSingleVariantDataDisplay: FC<GenericAnalyseSingleVari
                 sequenceType='nucleotide'
                 granularity={timeGranularity}
                 lapisDateField={view.organismConstants.mainDateField}
+                useNewEndpoint={true}
             />
             <GsMutationsOverTime
                 lapisFilter={variantLapisFilter}
                 sequenceType='amino acid'
                 granularity={timeGranularity}
                 lapisDateField={view.organismConstants.mainDateField}
+                useNewEndpoint={true}
             />
         </div>
     );


### PR DESCRIPTION
resolves #925 

### Summary

Sets the flag on all components.

As can be seen in the recording below, some cells changed from `belowThreshold` to have a value that is very low. This is fine, IMO.

### Screenshot

https://github.com/user-attachments/assets/c2e469af-f762-4625-9c67-abe06836255a

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
