### PR TITLE
fix(website): repairs broken variant selector in variant explorer (W-ASAP)

### DIFF
--- a/website/src/components/pageStateSelectors/wasap/filters/UntrackedFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/UntrackedFilter.tsx
@@ -77,8 +77,11 @@ export function UntrackedFilter({
                                 lapisFilter={{}}
                                 placeholderText='Variant'
                                 value={pageState.excludeVariants}
-                                onLineageMultiChange={({ pangoLineage }) => {
-                                    setPageState({ ...pageState, excludeVariants: pangoLineage });
+                                onLineageMultiChange={(lineages) => {
+                                    setPageState({
+                                        ...pageState,
+                                        excludeVariants: lineages[clinicalSequenceLapisLineageField],
+                                    });
                                 }}
                                 hideCounts={true}
                                 multiSelect={true}

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -39,8 +39,8 @@ export function VariantExplorerFilter({
                             lapisFilter={{}}
                             placeholderText='Variant'
                             value={pageState.variant}
-                            onLineageChange={({ pangoLineage }) => {
-                                setPageState({ ...pageState, variant: pangoLineage });
+                            onLineageChange={(lineages) => {
+                                setPageState({ ...pageState, variant: lineages[clinicalSequenceLapisLineageField] });
                             }}
                             hideCounts={true}
                         />


### PR DESCRIPTION
resolves #950

### Summary

In #940 the field name was made configurable, but the hardcoded name used in the destructing of the object wasn't changed: https://github.com/GenSpectrum/dashboards/pull/940/files#diff-30ad9ef617a4a872e53ac66e262725a87988183be5674c0b9d412ed5822c7d06L36

The test didn't catch this, because the test also uses the same hardcoded field name (`pangoLineage`): https://github.com/GenSpectrum/dashboards/blob/HEAD/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx#L46-L75

**The fix**: Just use the proper field name to access the the value in the callback parameter. The same problem was also in the "untracked" mode.

Since this was caused by hardcoded variable names, which we have not configured, I don't think it's necessary to adapt the test or create a second case for this.

### Screenshot

https://github.com/user-attachments/assets/4852f4bf-d559-4068-b969-1929f7ffbe87


## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
