### PR TITLE
fix(website): fix default resistance mutation set name

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -56,7 +56,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
             resistance: {
                 mode: 'resistance',
                 sequenceType: 'amino acid',
-                resistanceSet: '3CLPro',
+                resistanceSet: '3CLpro',
             },
             untracked: {
                 mode: 'untracked',


### PR DESCRIPTION
resolves #954 

### Summary

There was indeed a misspelling in the default config.

This PR fixes that, but doesn't add any validation steps - we can do that in a separate step.

### Screenshot

https://github.com/user-attachments/assets/7b2a67e2-aa74-424d-bfc1-5cb9f297a0a4

## PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
