### PR TITLE
test(website): add a test that validates the wastewater config

### DIFF
--- a/website/src/types/wastewaterConfig.spec.ts
+++ b/website/src/types/wastewaterConfig.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+
+import { wastewaterOrganismConfigs } from './wastewaterConfig';
+
+describe.each(Object.entries(wastewaterOrganismConfigs))('wastewaterConfig %s', (_configName, config) => {
+    test('default resistance set name is valid', () => {
+        if (config.resistanceAnalysisModeEnabled) {
+            const resistanceSetNames = config.resistanceMutationSets.map((s) => s.name);
+            const defaultSetName = config.filterDefaults.resistance.resistanceSet;
+            expect(resistanceSetNames).include(defaultSetName);
+        }
+    });
+});


### PR DESCRIPTION
related to #954 

### Summary

Adds a new test file for the `wastewaterConfig`. It 'tests' the config, making sure that the config is self-consistent.

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
