### PR TITLE
feat(website): connect real RSV-A W-ASAP backend

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -28,7 +28,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         resistanceAnalysisModeEnabled: true,
         untrackedAnalysisModeEnabled: true,
         resistanceMutationSets: covidResistanceMutations,
-        lapisBaseUrl: 'https://lapis.wasap.genspectrum.org',
+        lapisBaseUrl: 'https://lapis.wasap.genspectrum.org/covid',
         samplingDateField: 'samplingDate',
         locationNameField: 'locationName',
         clinicalLapis: {
@@ -80,7 +80,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         },
         manualAnalysisModeEnabled: true,
         variantAnalysisModeEnabled: true,
-        lapisBaseUrl: 'https://lapis.wasap.genspectrum.org', // TODO https://github.com/GenSpectrum/dashboards/issues/949
+        lapisBaseUrl: 'https://lapis.wasap.genspectrum.org/rsva',
         samplingDateField: 'samplingDate',
         locationNameField: 'locationName',
         clinicalLapis: {
@@ -88,9 +88,9 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
             dateField: 'sampleCollectionDateRangeLower',
             lineageField: 'lineage',
         },
-        browseDataUrl: 'https://db.wasap.genspectrum.org/covid/search', // TODO https://github.com/GenSpectrum/dashboards/issues/949
+        browseDataUrl: 'https://db.wasap.genspectrum.org/rsva/search',
         browseDataDescription: 'Browse the data in the W-ASAP Loculus instance.',
-        defaultLocationName: 'Zürich (ZH)',
+        defaultLocationName: 'Geneva',
         clinicalSequenceCountWarningThreshold: 50,
         filterDefaults: {
             manual: {


### PR DESCRIPTION
resolves #949 

### Summary

@gordonkoehn brought RSV-A online in the backend, so now we can connect it!

The structure for the COVID endpoint also changed, so this PR also changes that.

### Screenshot

The recording below shows the real RSV-A data that we can now read.


https://github.com/user-attachments/assets/d0cf4e10-c0e4-4608-a54d-d2c4b646a427



## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
