### PR TITLE
fix(website): fix untracked mutations lineageField bug

### DIFF
--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -94,7 +94,7 @@ async function fetchMutationSelection(
                             config.clinicalLapis.lapisBaseUrl,
                             analysis.sequenceType,
                             {
-                                [config.clinicalLapis.lapisBaseUrl]: variant,
+                                [config.clinicalLapis.lineageField]: variant,
                             },
                             0.8,
                             9,


### PR DESCRIPTION
resolves #990

### Summary

In #953 I intruduced a bug by accident, using the wrong config field as the `lineageField`, a silly error made in haste. This PR fixes that.

### Screenshot


https://github.com/user-attachments/assets/5daa6546-11ad-4707-a799-ad47a3828b1b



## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
