### PR TITLE
fix(tests): increase timeout

### DIFF
--- a/website/tests/compareSideBySide.spec.ts
+++ b/website/tests/compareSideBySide.spec.ts
@@ -9,6 +9,8 @@ test.describe('The Compare Side-By-Side page', () => {
         test(`should show diagrams after selecting a variant in both columns - ${organism}`, async ({
             compareSideBySidePage,
         }) => {
+            test.setTimeout(60_000); // there is a lot of data to load, so we need the test to run longer
+
             const options = organismOptions[organism];
 
             await compareSideBySidePage.goto(organism);


### PR DESCRIPTION
Trying to merge to main, I see the E2E tests fail: https://github.com/GenSpectrum/dashboards/pull/958

The tests only fail on webkit, but on chromium and firefox they work, but also take long, sometimes 29 seconds. Looking at the site myself, I found the page to load for quite a long time, so I think it's probably genuinely a time issue. 

Here a screenshot from how long the test takes in playwright:

<img width="986" height="266" alt="image" src="https://github.com/user-attachments/assets/617ec3c3-2c73-4ae5-be7a-61f0eb46a1aa" />

