### PR TITLE
fix(website): fix div nested in p (replace p with div)

### DIFF
--- a/website/src/components/pageStateSelectors/wasap/InfoBlocks.tsx
+++ b/website/src/components/pageStateSelectors/wasap/InfoBlocks.tsx
@@ -75,10 +75,10 @@ export function DefineClinicalSignatureInfo() {
                 if it appears frequently within a variant and <span className='italic'>rarely</span> outside the
                 variant.
             </p>
-            <p className='text-gray-700'>
+            <div className='text-gray-700'>
                 <BlockMath math='Jaccard_{s,m} = \frac{|S_{m,v}|}{|S_m| + |S_v| - |S_{m,v}|}' />
                 with:
-            </p>
+            </div>
             <ul className='mt-2 list-disc pl-8 text-gray-700'>
                 <li>
                     {m('S_m')}: The set of sequences with the mutation {m('m')}

--- a/website/src/layouts/OrganismPage/DataPageLayout.tsx
+++ b/website/src/layouts/OrganismPage/DataPageLayout.tsx
@@ -1,11 +1,11 @@
 import type { FC, PropsWithChildren } from 'react';
 
-import { LapisUnreachableWrapperClient } from '../../components/LapisUnreachableWrapperClient.tsx';
-import type { DataOrigin } from '../../types/dataOrigins.ts';
-import { type BreadcrumbElement, Breadcrumbs } from '../Breadcrumbs.tsx';
 import { AccessionsDownloadButton, type DownloadLink } from './AccessionsDownloadButton.tsx';
 import { LastUpdatedInfo } from './LastUpdatedInfo.tsx';
+import { LapisUnreachableWrapperClient } from '../../components/LapisUnreachableWrapperClient.tsx';
 import { withQueryProvider } from '../../components/subscriptions/backendApi/withQueryProvider.tsx';
+import type { DataOrigin } from '../../types/dataOrigins.ts';
+import { type BreadcrumbElement, Breadcrumbs } from '../Breadcrumbs.tsx';
 import { DataInfo } from '../base/footer/DataInfo.tsx';
 
 export type DataPageLayoutProps = PropsWithChildren<{


### PR DESCRIPTION
resolves #998

### Summary

The `p` was just to set the font color, I am now using a `div`.

No screenshot, looks the same, but no more warning in the console.

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
