### PR TITLE
fix(website): fix breaking dashboards after date range change

### DIFF
--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -12,7 +12,7 @@ dashboards:
     h5n1:
       lapis:
         url: "https://api.loculus.genspectrum.org/h5n1"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -24,7 +24,7 @@ dashboards:
     h1n1pdm:
       lapis:
         url: "https://api.loculus.genspectrum.org/h1n1pdm"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -36,7 +36,7 @@ dashboards:
     h3n2:
       lapis:
         url: "https://api.loculus.genspectrum.org/h3n2"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -48,7 +48,7 @@ dashboards:
     influenzaA:
       lapis:
         url: "https://api.loculus.genspectrum.org/influenza-a"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -60,7 +60,7 @@ dashboards:
     influenzaB:
       lapis:
         url: "https://api.loculus.genspectrum.org/influenza-b"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -72,7 +72,7 @@ dashboards:
     victoria:
       lapis:
         url: "https://api.loculus.genspectrum.org/b-victoria"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -168,7 +168,7 @@ dashboards:
     denv1:
       lapis:
         url: "https://api.loculus.genspectrum.org/denv1"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"
@@ -185,7 +185,7 @@ dashboards:
     denv2:
       lapis:
         url: "https://api.loculus.genspectrum.org/denv2"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"
@@ -202,7 +202,7 @@ dashboards:
     denv3:
       lapis:
         url: "https://api.loculus.genspectrum.org/denv3"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"
@@ -219,7 +219,7 @@ dashboards:
     denv4:
       lapis:
         url: "https://api.loculus.genspectrum.org/denv4"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -12,7 +12,7 @@ dashboards:
     h5n1:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h5n1"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -24,7 +24,7 @@ dashboards:
     h1n1pdm:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h1n1pdm"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -36,7 +36,7 @@ dashboards:
     h3n2:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h3n2"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -48,7 +48,7 @@ dashboards:
     influenzaA:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/influenza-a"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -60,7 +60,7 @@ dashboards:
     influenzaB:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/influenza-b"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -72,7 +72,7 @@ dashboards:
     victoria:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/b-victoria"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"
@@ -173,7 +173,7 @@ dashboards:
     denv1:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/denv1"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"
@@ -190,7 +190,7 @@ dashboards:
     denv2:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/denv2"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"
@@ -207,7 +207,7 @@ dashboards:
     denv3:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/denv3"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"
@@ -224,7 +224,7 @@ dashboards:
     denv4:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/denv4"
-        mainDateField: "sampleCollectionDate"
+        mainDateField: "sampleCollectionDateRangeLower"
         locationFields:
           - "country"
           - "division"

--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -249,7 +249,7 @@ export const testOrganismsConfig = {
     influenzaA: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -259,7 +259,7 @@ export const testOrganismsConfig = {
     h3n2: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -269,7 +269,7 @@ export const testOrganismsConfig = {
     h1n1pdm: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -279,7 +279,7 @@ export const testOrganismsConfig = {
     h5n1: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -289,7 +289,7 @@ export const testOrganismsConfig = {
     influenzaB: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -299,7 +299,7 @@ export const testOrganismsConfig = {
     victoria: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -319,7 +319,7 @@ export const testOrganismsConfig = {
     rsvA: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -329,7 +329,7 @@ export const testOrganismsConfig = {
     rsvB: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -379,7 +379,7 @@ export const testOrganismsConfig = {
     denv1: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -389,7 +389,7 @@ export const testOrganismsConfig = {
     denv2: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -399,7 +399,7 @@ export const testOrganismsConfig = {
     denv3: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -409,7 +409,7 @@ export const testOrganismsConfig = {
     denv4: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',
@@ -419,7 +419,7 @@ export const testOrganismsConfig = {
     measles: {
         lapis: {
             url: DUMMY_LAPIS_URL,
-            mainDateField: 'sampleCollectionDate',
+            mainDateField: 'sampleCollectionDateRangeLower',
             additionalFilters: {
                 versionStatus: 'LATEST_VERSION',
                 isRevocation: 'false',

--- a/website/src/views/View.ts
+++ b/website/src/views/View.ts
@@ -138,4 +138,4 @@ export function getLineageFilterFields(lineageFilters: LineageFilterConfig[]) {
 }
 
 export const PATHOPLEXUS_MAIN_FILTER_DATE_COLUMN = 'sampleCollectionDateRangeLower';
-export const GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN = 'sampleCollectionDate';
+export const GENSPECTRUM_LOCULUS_MAIN_FILTER_DATE_COLUMN = 'sampleCollectionDateRangeLower';


### PR DESCRIPTION
I've deployed a change in the backend to get date ranges where the collection date is not known exactly. This broke some stuff in the frontend.

related to https://github.com/orgs/GenSpectrum/projects/1?pane=issue&itemId=141528156&issue=GenSpectrum%7Cdashboards%7C930

### Screenshot

n/a

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
