### PR TITLE
fix(website): prevent menu item icons from shrinking if text gets large

### DIFF
--- a/website/src/components/MainMenuItem.astro
+++ b/website/src/components/MainMenuItem.astro
@@ -11,7 +11,7 @@ const { iconType, menuListEntryDecoration, href, external } = Astro.props;
 ---
 
 <li class='flex items-center pt-2'>
-    <span class={`iconify mr-2 ${iconMapping[iconType]}`}></span>
+    <span class={`iconify mr-2 shrink-0 ${iconMapping[iconType]}`}></span>
     <a
         class={`hover:underline hover:decoration-4 ${menuListEntryDecoration} ${external === true ? externalLinkIconCss : ''}`}
         href={href}


### PR DESCRIPTION
resolves #1015 

### Summary

Add `shrink-0` to the icon.

### Screenshot

<img width="275" height="390" alt="image" src="https://github.com/user-attachments/assets/f8cd123b-60dc-4cc6-b64e-3270b680d833" />

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
