### PR TITLE
fix: fix e2e tests after h1n1pdm clade schema has changed

### DIFF
--- a/website/src/views/h1n1pdm.ts
+++ b/website/src/views/h1n1pdm.ts
@@ -73,7 +73,7 @@ class H1n1pdmConstants implements OrganismConstants {
     public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
-            lineages: { cladeHA: '6B.1A.5a.2a.1', cladeNA: 'C.5.3' },
+            lineages: { cladeHA: 'C.1.9.3', cladeNA: 'C.5.3' },
         },
     ];
 
@@ -122,7 +122,7 @@ export class H1n1pdmCompareSideBySideView extends BaseView<
             {},
             {
                 lineages: {
-                    [CLADE_HA_FIELD_NAME]: '6B.1A.5a.2a.1',
+                    [CLADE_HA_FIELD_NAME]: 'C.1.9.3',
                     [CLADE_NA_FIELD_NAME]: 'C.5.3',
                 },
             },

--- a/website/tests/helpers.ts
+++ b/website/tests/helpers.ts
@@ -10,7 +10,7 @@ export const organismOptions = {
     [Organisms.covid]: { lineage: 'JN.1*', lineageFieldPlaceholder: 'Nextclade pango lineage' },
     [Organisms.influenzaA]: { lineage: 'H1', lineageFieldPlaceholder: 'HA subtype' },
     [Organisms.h5n1]: { lineage: '2.3.4.4b', lineageFieldPlaceholder: 'Clade' },
-    [Organisms.h1n1pdm]: { lineage: '6B.1A.5a.2a.1', lineageFieldPlaceholder: 'Clade HA' },
+    [Organisms.h1n1pdm]: { lineage: 'C.1.9.3', lineageFieldPlaceholder: 'Clade HA' },
     [Organisms.h3n2]: { lineage: '3C.2a1b', lineageFieldPlaceholder: 'Clade HA' },
     [Organisms.influenzaB]: { lineage: 'vic', lineageFieldPlaceholder: 'Lineage' },
     [Organisms.victoria]: { lineage: 'V1A.3a.2', lineageFieldPlaceholder: 'Clade HA' },


### PR DESCRIPTION
We just did a reprocessing of all the h1n1pdm data with new nextclade settings, new references.

See changelog here: https://github.com/nextstrain/nextclade_data/pull/405/changes#diff-b06bf45a9186d05aeebaa9bc46cd242984c68e1b8c47226d39d10aa603f31bf5R12

The clade we used belongs to the legacy system now.

I've picked a different one at random to use for testing.