### PR TITLE
fix(website): use up-to-date lineage suggestion for H3N2

### DIFF
--- a/website/src/views/h3n2.ts
+++ b/website/src/views/h3n2.ts
@@ -73,7 +73,7 @@ class H3n2Constants implements OrganismConstants {
     public readonly accessionDownloadFields = INFLUENZA_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
-            lineages: { cladeHA: '3C.2a1b.2a.2a.3a.1' },
+            lineages: { cladeHA: 'K' },
         },
     ];
 

--- a/website/tests/helpers.ts
+++ b/website/tests/helpers.ts
@@ -11,7 +11,7 @@ export const organismOptions = {
     [Organisms.influenzaA]: { lineage: 'H1', lineageFieldPlaceholder: 'HA subtype' },
     [Organisms.h5n1]: { lineage: '2.3.4.4b', lineageFieldPlaceholder: 'Clade' },
     [Organisms.h1n1pdm]: { lineage: 'C.1.9.3', lineageFieldPlaceholder: 'Clade HA' },
-    [Organisms.h3n2]: { lineage: '3C.2a1b', lineageFieldPlaceholder: 'Clade HA' },
+    [Organisms.h3n2]: { lineage: 'K', lineageFieldPlaceholder: 'Clade HA' },
     [Organisms.influenzaB]: { lineage: 'vic', lineageFieldPlaceholder: 'Lineage' },
     [Organisms.victoria]: { lineage: 'V1A.3a.2', lineageFieldPlaceholder: 'Clade HA' },
     [Organisms.westNile]: { lineage: '1A', lineageFieldPlaceholder: 'Lineage' },


### PR DESCRIPTION

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Probably the lineages changed with https://github.com/GenSpectrum/servers/pull/450? The lineage mentioned there doesn't exist anymore. And the e2e tests were failing due to this.

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
