### PR TITLE
feat(website): add CBG to About Us text

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -32,8 +32,9 @@ import { Page } from '../types/pages';
                 An interactive platform to help scientists and public health professionals query and analyze pathogen
                 sequences. The core team is based at the <Link external href='https://bsse.ethz.ch/cevo'
                     >cEvo group</Link
-                > at ETH Zurich and at the <Link external href='https://sib.swiss/'
-                    >Swiss Institute of Bioinformatics (SIB)</Link
+                > and <Link external href='https://bsse.ethz.ch/cbg'>CBG group</Link> at ETH Zurich and at the <Link
+                    external
+                    href='https://sib.swiss/'>Swiss Institute of Bioinformatics (SIB)</Link
                 >; in addition, we are grateful for our many contributors from around the globe: you can find <Link
                     external
                     href='https://github.com/GenSpectrum#contributors-'>our team here</Link


### PR DESCRIPTION
This adds the Computational Biology Group (CBG) to the About Us section given their contributions to the wastewater pages.