### PR TITLE
feat(website): show descriptions for collection variants

### DIFF
--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -154,6 +154,7 @@ async function fetchCollectionModeData(
     const variantData: {
         name: string;
         queryString: string;
+        description?: string;
     }[] = [];
 
     const invalidVariants: {
@@ -183,6 +184,7 @@ async function fetchCollectionModeData(
         variantData.push({
             name: variant.name,
             queryString: queryString,
+            description: variant.description !== '' ? variant.description : undefined,
         });
     }
 
@@ -195,11 +197,12 @@ async function fetchCollectionModeData(
     // Process results and validate
     const queries: {
         displayLabel: string;
+        description?: string;
         countQuery: string;
         coverageQuery: string;
     }[] = [];
 
-    variantData.forEach(({ name, queryString }, index) => {
+    variantData.forEach(({ name, queryString, description }, index) => {
         const parseResult = parseResults[index];
 
         // Check if parsing failed
@@ -226,6 +229,7 @@ async function fetchCollectionModeData(
         const coverageQuery = `(${queryString}) or (not maybe(${queryString}))`;
         queries.push({
             displayLabel: name,
+            description,
             countQuery: queryString,
             coverageQuery,
         });
@@ -292,6 +296,7 @@ export type WasapCollectionData = {
             displayLabel: string;
             countQuery: string;
             coverageQuery: string;
+            description?: string;
         }[];
     };
     invalidVariants?: {


### PR DESCRIPTION
### Summary

Simply passes through descriptions of they are available. The API always provides a description, but sometimes they are the empty string. For that, we use undefined instead. 

### Screenshot

Description now appears in the tooltip of a variant:

<img width="597" height="312" alt="image" src="https://github.com/user-attachments/assets/48a496e1-489e-41e7-830b-890809ec0fcf" />

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
