### PR TITLE
feat(website): add info texts for collections

### DIFF
--- a/website/src/components/pageStateSelectors/wasap/InfoBlocks.tsx
+++ b/website/src/components/pageStateSelectors/wasap/InfoBlocks.tsx
@@ -108,6 +108,25 @@ export function DefineClinicalSignatureInfo() {
     );
 }
 
+export function CollectionInfo() {
+    return (
+        <InfoBlock title='Collection'>
+            <p className='text-gray-700'>
+                Collections are sourced from{' '}
+                <a className='link' href='https://cov-spectrum.org/collections'>
+                    CovSpectrum
+                </a>
+                . Only collections whose title contains the word <span className='font-semibold'>wastewater</span> are
+                shown here.
+            </p>
+            <p className='mt-2 text-gray-700'>
+                To add a new collection, create it on CovSpectrum and make sure its title includes the word
+                &ldquo;wastewater&rdquo; so it appears in this list.
+            </p>
+        </InfoBlock>
+    );
+}
+
 export function ExplorationModeInfo() {
     return (
         <InfoBlock title='Exploration Modes'>
@@ -137,6 +156,13 @@ export function ExplorationModeInfo() {
                     attributed to major variants. Variant-specific mutations are computed from clinical sequences from{' '}
                     <a className='link' href='https://cov-spectrum.org'>
                         CovSpectrum
+                    </a>
+                    .
+                </li>
+                <li>
+                    <span className='font-semibold text-gray-900'>Collection:</span> explore mutations defined by a{' '}
+                    <a className='link' href='https://cov-spectrum.org/collections'>
+                        CovSpectrum collection
                     </a>
                     .
                 </li>

--- a/website/src/components/pageStateSelectors/wasap/filters/CollectionAnalysisFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/CollectionAnalysisFilter.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getCollections } from '../../../../covspectrum/getCollections';
 import type { WasapCollectionFilter } from '../../../views/wasap/wasapPageConfig';
+import { CollectionInfo } from '../InfoBlocks';
 import { LabeledField } from '../utils/LabeledField';
 
 export function CollectionAnalysisFilter({
@@ -25,7 +26,7 @@ export function CollectionAnalysisFilter({
     });
 
     return (
-        <LabeledField label='Collection'>
+        <LabeledField label='Collection' info={<CollectionInfo />}>
             {isPending ? (
                 <div className='text-sm text-gray-500'>Loading collections...</div>
             ) : isError ? (


### PR DESCRIPTION
### Summary

- Add the 'Collection' mode to the overview of all modes
- Add specific info box for the 'Collection' dropdown

### Screenshot

<img width="1319" height="312" alt="image" src="https://github.com/user-attachments/assets/9d5675ad-6f8a-49ba-ac2e-55ba56e4edd3" />

<img width="1041" height="312" alt="image" src="https://github.com/user-attachments/assets/c3635133-6dad-4f82-967b-23c429d2b96c" />

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
