### PR TITLE
feat(website): enable collections analysis mode in prod

### DIFF
--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -36,14 +36,12 @@ export function WasapPageStateSelector({
     initialBaseFilterState,
     initialAnalysisFilterState,
     setPageState,
-    isStaging,
 }: {
     config: WasapPageConfig;
     pageStateHandler: PageStateHandler<WasapFilter>;
     initialBaseFilterState: WasapBaseFilter;
     initialAnalysisFilterState: WasapAnalysisFilter;
     setPageState: Dispatch<SetStateAction<WasapFilter>>;
-    isStaging: boolean;
 }) {
     const [baseFilterState, setBaseFilterState] = useState(initialBaseFilterState);
 
@@ -157,7 +155,7 @@ export function WasapPageStateSelector({
                     setSelectedAnalysisMode(e.target.value as WasapAnalysisMode);
                 }}
             >
-                {enabledAnalysisModes(config, isStaging).map((mode) => (
+                {enabledAnalysisModes(config).map((mode) => (
                     <option key={mode} value={mode}>
                         {modeLabel(mode)}
                     </option>

--- a/website/src/components/views/wasap/Wasap.astro
+++ b/website/src/components/views/wasap/Wasap.astro
@@ -1,6 +1,5 @@
 ---
 import { WasapPage } from './WasapPage';
-import { isStaging } from '../../../config';
 import BaseLayout from '../../../layouts/base/BaseLayout.astro';
 import { wastewaterOrganismConfigs, type WastewaterOrganismName } from '../../../types/wastewaterConfig';
 
@@ -10,11 +9,8 @@ type Props = {
 
 const { wastewaterOrganism } = Astro.props;
 const { name } = wastewaterOrganismConfigs[wastewaterOrganism];
-// TODO -- remove isStaging from here, and cascade removing it into the component, after
-// the collections mode is enabled in prod https://github.com/GenSpectrum/dashboards/issues/1029
-const staging = isStaging();
 ---
 
 <BaseLayout title={`Swiss wastewater - ${name}`}>
-    <WasapPage wastewaterOrganism={wastewaterOrganism} isStaging={staging} client:only='react' />
+    <WasapPage wastewaterOrganism={wastewaterOrganism} client:only='react' />
 </BaseLayout>

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -26,10 +26,9 @@ import { usePageState } from '../usePageState.ts';
 
 export type WasapPageProps = {
     wastewaterOrganism: WastewaterOrganismName;
-    isStaging: boolean;
 };
 
-export const WasapPageInner: FC<WasapPageProps> = ({ wastewaterOrganism, isStaging }) => {
+export const WasapPageInner: FC<WasapPageProps> = ({ wastewaterOrganism }) => {
     const config = wastewaterOrganismConfigs[wastewaterOrganism];
     // initialize page state from the URL
     const pageStateHandler = useMemo(() => new WasapPageStateHandler(config), [config]);
@@ -92,7 +91,6 @@ export const WasapPageInner: FC<WasapPageProps> = ({ wastewaterOrganism, isStagi
                             initialBaseFilterState={base}
                             initialAnalysisFilterState={analysis}
                             setPageState={setPageState}
-                            isStaging={isStaging}
                         />
                     </div>
                     {isError ? (

--- a/website/src/components/views/wasap/wasapPageConfig.ts
+++ b/website/src/components/views/wasap/wasapPageConfig.ts
@@ -125,7 +125,7 @@ type CollectionAnalysisModeConfig =
 /**
  * Convenience function to get the list of enabled modes.
  */
-export function enabledAnalysisModes(config: WasapPageConfig, isStaging: boolean): WasapAnalysisMode[] {
+export function enabledAnalysisModes(config: WasapPageConfig): WasapAnalysisMode[] {
     const result: WasapAnalysisMode[] = [];
     if (config.manualAnalysisModeEnabled) {
         result.push('manual');
@@ -139,7 +139,7 @@ export function enabledAnalysisModes(config: WasapPageConfig, isStaging: boolean
     if (config.untrackedAnalysisModeEnabled) {
         result.push('untracked');
     }
-    if (config.collectionAnalysisModeEnabled && isStaging) {
+    if (config.collectionAnalysisModeEnabled) {
         result.push('collection');
     }
     return result;

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -35,7 +35,7 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
         const providedMode = texts.analysisMode as WasapAnalysisMode | undefined;
 
         // config provided defaults
-        const defaultMode = enabledAnalysisModes(this.config, false)[0];
+        const defaultMode = enabledAnalysisModes(this.config)[0];
 
         const mode = providedMode ?? defaultMode;
 


### PR DESCRIPTION
resolves #1029 

### Summary

- Removes the isStaging guard from the collection analysis mode, making it available in production.
- Cleans up the now-unused isStaging parameter propagation through WasapPage, WasapPageStateSelector, and enabledAnalysisModes.
