### PR TITLE
fix(website): fix auth secret regenerating on every server restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       DASHBOARDS_ENVIRONMENT: dashboards-prod
       GITHUB_CLIENT_ID: "dummy"
       GITHUB_CLIENT_SECRET: "dummy"
+      AUTH_SECRET: "e2e-test-auth-secret-do-not-use-in-production"
 
   backend:
     image: ghcr.io/genspectrum/dashboards/backend:${BACKEND_TAG}

--- a/website/.env.e2e
+++ b/website/.env.e2e
@@ -1,2 +1,4 @@
 CONFIG_DIR=../backend/src/main/resources/
 DASHBOARDS_ENVIRONMENT=dashboards-prod
+
+AUTH_SECRET="e2e-test-auth-secret-do-not-use-in-production"

--- a/website/.env.example
+++ b/website/.env.example
@@ -6,3 +6,5 @@ LOG_LEVEL=info
 
 GITHUB_CLIENT_ID="Check https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app"
 GITHUB_CLIENT_SECRET="put a secret of you GitHub app here"
+
+AUTH_SECRET="generate with: openssl rand -base64 32"

--- a/website/src/auth.config.mjs
+++ b/website/src/auth.config.mjs
@@ -4,6 +4,7 @@ import { defineConfig } from 'auth-astro';
 import { getGitHubClientId, getGitHubClientSecret } from './config';
 
 export default defineConfig({
+    secret: process.env.AUTH_SECRET,
     callbacks: {
         session: async ({ session, token }) => {
             session.user.id = token.userIdFromProvider;

--- a/website/src/auth.config.mjs
+++ b/website/src/auth.config.mjs
@@ -28,5 +28,4 @@ export default defineConfig({
             clientSecret: getGitHubClientSecret(),
         }),
     ],
-    secret: crypto.randomUUID(),
 });

--- a/website/tests/auth/loginState.spec.ts
+++ b/website/tests/auth/loginState.spec.ts
@@ -1,32 +1,8 @@
-import { encode } from '@auth/core/jwt';
-import { expect, test, type Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
-const COOKIE_NAME = 'authjs.session-token';
-const TEST_USER_NAME = 'E2E Test User';
+import { test } from '../e2e.fixture.ts';
 
-async function setupAuthCookie(page: Page) {
-    const authSecret = process.env.AUTH_SECRET;
-    if (authSecret === undefined) {
-        throw new Error('AUTH_SECRET environment variable is not set');
-    }
-
-    const token = await encode({
-        token: { userIdFromProvider: 'e2e-test-user', name: TEST_USER_NAME },
-        secret: authSecret,
-        salt: COOKIE_NAME,
-    });
-
-    await page.context().addCookies([
-        {
-            name: COOKIE_NAME,
-            value: token,
-            domain: 'localhost',
-            path: '/',
-            httpOnly: true,
-            sameSite: 'Lax',
-        },
-    ]);
-}
+const TEST_USER_NAME = 'e2e-test';
 
 test('shows Login button when not authenticated', async ({ page }) => {
     await page.goto('/');
@@ -34,19 +10,17 @@ test('shows Login button when not authenticated', async ({ page }) => {
     await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
 });
 
-test('shows account icon instead of Login button when authenticated', async ({ page }) => {
-    await setupAuthCookie(page);
-    await page.goto('/');
+test('shows account icon instead of Login button when authenticated', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/');
 
-    await expect(page.getByRole('button', { name: 'Login' })).not.toBeVisible();
-    await expect(page.locator('.mdi--account[role="button"]')).toBeVisible();
+    await expect(authenticatedPage.getByRole('button', { name: 'Login' })).not.toBeVisible();
+    await expect(authenticatedPage.locator('.mdi--account[role="button"]')).toBeVisible();
 });
 
-test('shows username in dropdown when hovering account icon', async ({ page }) => {
-    await setupAuthCookie(page);
-    await page.goto('/');
+test('shows username in dropdown when hovering account icon', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/');
 
-    await page.locator('.mdi--account[role="button"]').hover();
+    await authenticatedPage.locator('.mdi--account[role="button"]').hover();
 
-    await expect(page.locator('.dropdown-content').getByText(TEST_USER_NAME)).toBeVisible();
+    await expect(authenticatedPage.locator('.dropdown-content').getByText(TEST_USER_NAME)).toBeVisible();
 });

--- a/website/tests/auth/loginState.spec.ts
+++ b/website/tests/auth/loginState.spec.ts
@@ -1,22 +1,17 @@
 import { encode } from '@auth/core/jwt';
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 const COOKIE_NAME = 'authjs.session-token';
+const TEST_USER_NAME = 'E2E Test User';
 
-test('shows Login button when not authenticated', async ({ page }) => {
-    await page.goto('/');
-
-    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
-});
-
-test('shows account icon instead of Login button when authenticated', async ({ page }) => {
+async function setupAuthCookie(page: Page) {
     const authSecret = process.env.AUTH_SECRET;
     if (authSecret === undefined) {
         throw new Error('AUTH_SECRET environment variable is not set');
     }
 
     const token = await encode({
-        token: { userIdFromProvider: 'e2e-test-user' },
+        token: { userIdFromProvider: 'e2e-test-user', name: TEST_USER_NAME },
         secret: authSecret,
         salt: COOKIE_NAME,
     });
@@ -31,9 +26,27 @@ test('shows account icon instead of Login button when authenticated', async ({ p
             sameSite: 'Lax',
         },
     ]);
+}
 
+test('shows Login button when not authenticated', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+});
+
+test('shows account icon instead of Login button when authenticated', async ({ page }) => {
+    await setupAuthCookie(page);
     await page.goto('/');
 
     await expect(page.getByRole('button', { name: 'Login' })).not.toBeVisible();
     await expect(page.locator('.mdi--account[role="button"]')).toBeVisible();
+});
+
+test('shows username in dropdown when hovering account icon', async ({ page }) => {
+    await setupAuthCookie(page);
+    await page.goto('/');
+
+    await page.locator('.mdi--account[role="button"]').hover();
+
+    await expect(page.locator('.dropdown-content').getByText(TEST_USER_NAME)).toBeVisible();
 });

--- a/website/tests/auth/loginState.spec.ts
+++ b/website/tests/auth/loginState.spec.ts
@@ -1,0 +1,39 @@
+import { encode } from '@auth/core/jwt';
+import { expect, test } from '@playwright/test';
+
+const COOKIE_NAME = 'authjs.session-token';
+
+test('shows Login button when not authenticated', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+});
+
+test('shows account icon instead of Login button when authenticated', async ({ page }) => {
+    const authSecret = process.env.AUTH_SECRET;
+    if (authSecret === undefined) {
+        throw new Error('AUTH_SECRET environment variable is not set');
+    }
+
+    const token = await encode({
+        token: { userIdFromProvider: 'e2e-test-user' },
+        secret: authSecret,
+        salt: COOKIE_NAME,
+    });
+
+    await page.context().addCookies([
+        {
+            name: COOKIE_NAME,
+            value: token,
+            domain: 'localhost',
+            path: '/',
+            httpOnly: true,
+            sameSite: 'Lax',
+        },
+    ]);
+
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: 'Login' })).not.toBeVisible();
+    await expect(page.locator('.mdi--account[role="button"]')).toBeVisible();
+});

--- a/website/tests/compareSideBySide.spec.ts
+++ b/website/tests/compareSideBySide.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 import { test } from './e2e.fixture.ts';
-import { organismOptions, organismsWithView } from './helpers.ts';
+import { organismOptions, organismsWithView } from './helpers/organisms.ts';
 import { compareSideBySideViewKey } from '../src/views/viewKeys';
 
 test.describe('The Compare Side-By-Side page', () => {

--- a/website/tests/compareToBaseline.spec.ts
+++ b/website/tests/compareToBaseline.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 import { test } from './e2e.fixture.ts';
-import { organismOptions, organismsWithView } from './helpers.ts';
+import { organismOptions, organismsWithView } from './helpers/organisms.ts';
 import { compareToBaselineViewKey } from '../src/views/viewKeys';
 
 test.describe('The Compare To Baseline page', () => {

--- a/website/tests/compareVariants.spec.ts
+++ b/website/tests/compareVariants.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 import { test } from './e2e.fixture.ts';
-import { organismOptions, organismsWithView } from './helpers.ts';
+import { organismOptions, organismsWithView } from './helpers/organisms.ts';
 import { compareVariantsViewKey } from '../src/views/viewKeys';
 
 test.describe('The Compare Variants page', () => {

--- a/website/tests/e2e.fixture.ts
+++ b/website/tests/e2e.fixture.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test';
+import { test as base, type Page } from '@playwright/test';
 
 import { CompareSideBySidePage } from './CompareSideBySidePage.ts';
 import { CompareToBaselinePage } from './CompareToBaselinePage.ts';
@@ -6,6 +6,7 @@ import { CompareVariantsPage } from './CompareVariantsPage.ts';
 import { SequencingEffortsPage } from './SequencingEffortsPage.ts';
 import { SingleVariantPage } from './SingleVariantPage.ts';
 import { CollectionDetailPage } from './collections/CollectionDetailPage.ts';
+import { setupAuthCookie } from './helpers/auth.ts';
 
 type E2EFixture = {
     compareVariantsPage: CompareVariantsPage;
@@ -14,6 +15,7 @@ type E2EFixture = {
     compareSideBySidePage: CompareSideBySidePage;
     singleVariantPage: SingleVariantPage;
     collectionDetailPage: CollectionDetailPage;
+    authenticatedPage: Page;
 };
 
 export const test = base.extend<E2EFixture>({
@@ -34,5 +36,9 @@ export const test = base.extend<E2EFixture>({
     },
     collectionDetailPage: async ({ page }, use) => {
         await use(new CollectionDetailPage(page));
+    },
+    authenticatedPage: async ({ page }, use) => {
+        await setupAuthCookie(page, 'e2e-test');
+        await use(page);
     },
 });

--- a/website/tests/helpers/auth.ts
+++ b/website/tests/helpers/auth.ts
@@ -1,0 +1,28 @@
+import { encode } from '@auth/core/jwt';
+import { type Page } from '@playwright/test';
+
+const COOKIE_NAME = 'authjs.session-token';
+
+export async function setupAuthCookie(page: Page, userId: string) {
+    const authSecret = process.env.AUTH_SECRET;
+    if (authSecret === undefined) {
+        throw new Error('AUTH_SECRET environment variable is not set');
+    }
+
+    const token = await encode({
+        token: { userIdFromProvider: userId, name: userId },
+        secret: authSecret,
+        salt: COOKIE_NAME,
+    });
+
+    await page.context().addCookies([
+        {
+            name: COOKIE_NAME,
+            value: token,
+            domain: 'localhost',
+            path: '/',
+            httpOnly: true,
+            sameSite: 'Lax',
+        },
+    ]);
+}

--- a/website/tests/helpers/organisms.ts
+++ b/website/tests/helpers/organisms.ts
@@ -1,6 +1,6 @@
-import { allOrganisms, Organisms } from '../src/types/Organism.ts';
-import type { OrganismWithViewKey } from '../src/views/routing.ts';
-import { ServerSide } from '../src/views/serverSideRouting.ts';
+import { allOrganisms, Organisms } from '../../src/types/Organism.ts';
+import type { OrganismWithViewKey } from '../../src/views/routing.ts';
+import { ServerSide } from '../../src/views/serverSideRouting.ts';
 
 export function organismsWithView<ViewKey extends string>(viewKey: ViewKey): OrganismWithViewKey<ViewKey>[] {
     return allOrganisms.filter((organism) => ServerSide.routing.isOrganismWithViewKey(organism, viewKey));

--- a/website/tests/singleVariant.spec.ts
+++ b/website/tests/singleVariant.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 import { test } from './e2e.fixture.ts';
-import { organismOptions, organismsWithView } from './helpers.ts';
+import { organismOptions, organismsWithView } from './helpers/organisms.ts';
 import { singleVariantViewKey } from '../src/views/viewKeys';
 
 test.describe('The Single Variant page', () => {


### PR DESCRIPTION
Remove hardcoded `crypto.randomUUID()` as the auth secret — auth-astro and @auth/core both automatically read AUTH_SECRET from the environment, so the explicit secret field was overriding that and causing all sessions to be invalidated on every restart/deploy.

Add AUTH_SECRET to .env.example with generation instructions.

Fixes #1145

I already rolled out AUTH_SECRET to prod and staging so we can use it. There is also a PR in our servers repo for this.

New auth related tests are added to make sure that a cookie crafted from the value from the environment variable works as a log in token.

I also added a fixture to use an authenticated page directly.

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
