### PR TITLE
feat(backend): disable subscription endpoints in prod

### DIFF
--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsController.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsController.kt
@@ -8,6 +8,7 @@ import org.genspectrum.dashboardsbackend.api.SubscriptionUpdate
 import org.genspectrum.dashboardsbackend.api.TriggerEvaluationResponse
 import org.genspectrum.dashboardsbackend.model.subscription.SubscriptionModel
 import org.genspectrum.dashboardsbackend.model.triggerevaluation.TriggerEvaluationModel
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
+@ConditionalOnExpression("'\${DASHBOARDS_ENVIRONMENT:}' != 'prod'")
 @RestController
 class SubscriptionsController(
     private val subscriptionModel: SubscriptionModel,

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsController.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsController.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
+// TODO: Remove once subscriptions are ready for prod (https://github.com/GenSpectrum/dashboards/issues/1163)
 @ConditionalOnExpression("'\${DASHBOARDS_ENVIRONMENT:}' != 'prod'")
 @RestController
 class SubscriptionsController(

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsController.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/SubscriptionsController.kt
@@ -8,7 +8,7 @@ import org.genspectrum.dashboardsbackend.api.SubscriptionUpdate
 import org.genspectrum.dashboardsbackend.api.TriggerEvaluationResponse
 import org.genspectrum.dashboardsbackend.model.subscription.SubscriptionModel
 import org.genspectrum.dashboardsbackend.model.triggerevaluation.TriggerEvaluationModel
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 // TODO: Remove once subscriptions are ready for prod (https://github.com/GenSpectrum/dashboards/issues/1163)
-@ConditionalOnExpression("'\${DASHBOARDS_ENVIRONMENT:}' != 'prod'")
+@ConditionalOnProperty(name = ["dashboards.features.subscriptions.enabled"], matchIfMissing = true)
 @RestController
 class SubscriptionsController(
     private val subscriptionModel: SubscriptionModel,

--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -1,4 +1,7 @@
 dashboards:
+  features:
+    subscriptions:
+      enabled: false
   organisms:
     covid:
       lapis:


### PR DESCRIPTION
## Summary
- Subscription endpoints are not ready for production yet
- Added `@ConditionalOnProperty` to `SubscriptionsController` so it is only registered when the `dashboards.features.subscriptions.enabled` is set to true. If it's missing, it's also enabled. But for prod we set it to disabled.

## Tests
- Running with staging has the controller enabled ✅ 
- Running with prod returns 404 ✅ 
- All tests passed locally ✅ 