### PR TITLE
feat(website): enable login button in prod

### DIFF
--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -106,10 +106,6 @@ function getEnvironment() {
     return processEnvOrMetaEnv('DASHBOARDS_ENVIRONMENT', environmentSchema);
 }
 
-export function isLoginEnabled() {
-    return getEnvironment() !== 'dashboards-prod';
-}
-
 function processEnvOrMetaEnv<T>(key: string, schema: z.ZodType<T>) {
     const envValue = process.env[key] ?? import.meta.env[key];
     const parsedValue = schema.safeParse(envValue);

--- a/website/src/layouts/base/header/CallToAction.astro
+++ b/website/src/layouts/base/header/CallToAction.astro
@@ -1,6 +1,5 @@
 ---
 import LoginState from '../../../components/auth/LoginState.astro';
-import { isLoginEnabled } from '../../../config';
 
 interface Props {
     forceLoggedOutState?: boolean;
@@ -10,5 +9,5 @@ const { forceLoggedOutState = false } = Astro.props;
 ---
 
 <div class='mr-2 flex w-32 justify-end'>
-    {isLoginEnabled() ? <LoginState forceLoggedOutState={forceLoggedOutState} /> : null}
+    <LoginState forceLoggedOutState={forceLoggedOutState} />
 </div>

--- a/website/src/layouts/base/header/HamburgerMenu.astro
+++ b/website/src/layouts/base/header/HamburgerMenu.astro
@@ -5,7 +5,6 @@ import HamburgerMenuItem from './HamburgerMenuItem.astro';
 import HamburgerMenuSection from './HamburgerMenuSection.astro';
 import { getPathogenMegaMenuSections } from './getPathogenMegaMenuSections';
 import { LoginButton } from '../../../components/auth/LoginButton';
-import { isLoginEnabled } from '../../../config';
 import { Page } from '../../../types/pages';
 
 type Props = {
@@ -40,26 +39,24 @@ const showLoggedInState = !forceLoggedOutState && session?.user !== undefined;
         }
         <HamburgerMenuItem href={Page.dataSources} itemType='toplevel'>Data Sources</HamburgerMenuItem>
         {
-            isLoginEnabled() ? (
-                showLoggedInState ? (
-                    <HamburgerMenuSection
-                        navigationEntries={[
-                            { label: session.user?.name ?? 'My Account' },
-                            {
-                                label: 'Subscriptions',
-                                href: '/subscriptions',
-                            },
-                            { label: 'Logout', href: '/logout' },
-                        ]}
-                    >
-                        My Account
-                    </HamburgerMenuSection>
-                ) : (
-                    <HamburgerMenuItem itemType='toplevel'>
-                        <LoginButton client:load />
-                    </HamburgerMenuItem>
-                )
-            ) : null
+            showLoggedInState ? (
+                <HamburgerMenuSection
+                    navigationEntries={[
+                        { label: session.user?.name ?? 'My Account' },
+                        {
+                            label: 'Subscriptions',
+                            href: '/subscriptions',
+                        },
+                        { label: 'Logout', href: '/logout' },
+                    ]}
+                >
+                    My Account
+                </HamburgerMenuSection>
+            ) : (
+                <HamburgerMenuItem itemType='toplevel'>
+                    <LoginButton client:load />
+                </HamburgerMenuItem>
+            )
         }
     </ul>
 </nav>


### PR DESCRIPTION
## Summary

- Removes the `isLoginEnabled()` guard that was hiding the login button in the `dashboards-prod` environment
- Deletes the now-unnecessary `isLoginEnabled` helper from `config.ts`
- Simplifies `CallToAction.astro` and `HamburgerMenu.astro` to render login UI unconditionally

## Testing

I've checked locally that the Login button now shows, when running with DASHBOARDS_ENVIRONMENT `dashboards-prod`