### PR TITLE
feat(website): validate the advanced query input before setting it to the page state

### DIFF
--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -7,7 +7,7 @@ import { expect } from 'vitest';
 import { type OrganismsConfig } from './src/config';
 import type { CollectionRaw } from './src/covspectrum/types.ts';
 import type { LapisInfo } from './src/lapis/getLastUpdatedDate.ts';
-import type { ParsedQueryResult } from './src/lapis/parseQuery.ts';
+import type { ParsedQueryResult, ParseQueryRequest } from './src/lapis/parseQuery.ts';
 import type { Collection } from './src/types/Collection.ts';
 import type { ProblemDetail } from './src/types/ProblemDetail.ts';
 import type {
@@ -148,7 +148,7 @@ export class LapisRouteMocker {
         this.workerOrServer.use(http.post(`${DUMMY_LAPIS_URL}/sample/aminoAcidMutations`, resolver(cases)));
     }
 
-    mockPostQueryParse(body: { queries: string[] }, response: { data: ParsedQueryResult[] }, statusCode = 200) {
+    mockPostQueryParse(body: ParseQueryRequest, response: { data: ParsedQueryResult[] }, statusCode = 200) {
         this.workerOrServer.use(
             http.post(`${DUMMY_LAPIS_URL}/query/parse`, resolver([{ statusCode, body, response }])),
         );

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -85,7 +85,7 @@ describe('AdvancedQueryFilter', () => {
         await userEvent.type(getByRole('textbox'), 'invalid!!');
 
         await expect.element(getByLabelText('Error')).toBeVisible();
-        await expect.poll(() => container.querySelector('[data-tip]')?.getAttribute('data-tip')).toBe(
+        await expect.poll(() => container.querySelector('.tooltip-content')?.textContent).toContain(
             'Unexpected token at position 7',
         );
         expect(onInput).not.toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe('AdvancedQueryFilter', () => {
         await userEvent.type(getByRole('textbox'), 'A123T');
 
         await expect.element(getByLabelText('Error')).toBeVisible();
-        await expect.poll(() => container.querySelector('[data-tip]')?.getAttribute('data-tip')).toBe(
+        await expect.poll(() => container.querySelector('.tooltip-content')?.textContent).toContain(
             'Validation is not possible right now.',
         );
         expect(onInput).not.toHaveBeenCalled();

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -78,13 +78,16 @@ describe('AdvancedQueryFilter', () => {
             { data: [{ type: 'failure', error: 'Unexpected token at position 7' }] },
         );
 
-        const { getByRole, getByTitle } = render(
+        const { getByRole, getByLabelText, container } = render(
             <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
         );
 
         await userEvent.type(getByRole('textbox'), 'invalid!!');
 
-        await expect.element(getByTitle('Invalid advanced query: Unexpected token at position 7')).toBeVisible();
+        await expect.element(getByLabelText('Error')).toBeVisible();
+        await expect.poll(() => container.querySelector('[data-tip]')?.getAttribute('data-tip')).toBe(
+            'Unexpected token at position 7',
+        );
         expect(onInput).not.toHaveBeenCalled();
     });
 
@@ -109,13 +112,16 @@ describe('AdvancedQueryFilter', () => {
 
         const onInput = vi.fn();
 
-        const { getByRole, getByTitle } = render(
+        const { getByRole, getByLabelText, container } = render(
             <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
         );
 
         await userEvent.type(getByRole('textbox'), 'A123T');
 
-        await expect.element(getByTitle('Invalid advanced query: Validation is not possible right now.')).toBeVisible();
+        await expect.element(getByLabelText('Error')).toBeVisible();
+        await expect.poll(() => container.querySelector('[data-tip]')?.getAttribute('data-tip')).toBe(
+            'Validation is not possible right now.',
+        );
         expect(onInput).not.toHaveBeenCalled();
     });
 });

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -85,9 +85,9 @@ describe('AdvancedQueryFilter', () => {
         await userEvent.type(getByRole('textbox'), 'invalid!!');
 
         await expect.element(getByLabelText('Error')).toBeVisible();
-        await expect.poll(() => container.querySelector('.tooltip-content')?.textContent).toContain(
-            'Unexpected token at position 7',
-        );
+        await expect
+            .poll(() => container.querySelector('.tooltip-content')?.textContent)
+            .toContain('Unexpected token at position 7');
         expect(onInput).not.toHaveBeenCalled();
     });
 
@@ -119,9 +119,9 @@ describe('AdvancedQueryFilter', () => {
         await userEvent.type(getByRole('textbox'), 'A123T');
 
         await expect.element(getByLabelText('Error')).toBeVisible();
-        await expect.poll(() => container.querySelector('.tooltip-content')?.textContent).toContain(
-            'Validation is not possible right now.',
-        );
+        await expect
+            .poll(() => container.querySelector('.tooltip-content')?.textContent)
+            .toContain('Validation is not possible right now.');
         expect(onInput).not.toHaveBeenCalled();
     });
 });

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -1,10 +1,11 @@
 import { userEvent } from '@vitest/browser/context';
+import { http, delay } from 'msw';
 import { describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { AdvancedQueryFilter } from './AdvancedQueryFilter.tsx';
 import { DUMMY_LAPIS_URL } from '../../../routeMocker.ts';
-import { it } from '../../../test-extend';
+import { it, worker } from '../../../test-extend';
 import { withQueryProvider } from '../../backendApi/withQueryProvider.tsx';
 
 const AdvancedQueryFilterWithProvider = withQueryProvider(AdvancedQueryFilter);
@@ -70,6 +71,22 @@ describe('AdvancedQueryFilter', () => {
 
         await expect.element(getByText('Unexpected token at position 7')).toBeVisible();
         expect(onInput).not.toHaveBeenCalled();
+    });
+
+    it('shows validating indicator while waiting for validation result', async () => {
+        worker.use(
+            http.post(`${DUMMY_LAPIS_URL}/query/parse`, async () => {
+                await delay('infinite');
+            }),
+        );
+
+        const { getByRole, getByLabelText } = render(
+            <AdvancedQueryFilterWithProvider enabled lapisUrl={DUMMY_LAPIS_URL} />,
+        );
+
+        await userEvent.type(getByRole('textbox'), 'A123T');
+
+        await expect.element(getByLabelText('Validating')).toBeVisible();
     });
 
     it('shows network error message when LAPIS is unreachable', async ({ routeMockers }) => {

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -115,9 +115,7 @@ describe('AdvancedQueryFilter', () => {
 
         await userEvent.type(getByRole('textbox'), 'A123T');
 
-        await expect.element(
-            getByTitle('Invalid advanced query: Validation is not possible right now.'),
-        ).toBeVisible();
+        await expect.element(getByTitle('Invalid advanced query: Validation is not possible right now.')).toBeVisible();
         expect(onInput).not.toHaveBeenCalled();
     });
 });

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -1,0 +1,89 @@
+import { userEvent } from '@vitest/browser/context';
+import { describe, expect, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+import { AdvancedQueryFilter } from './AdvancedQueryFilter.tsx';
+import { DUMMY_LAPIS_URL } from '../../../routeMocker.ts';
+import { it } from '../../../test-extend';
+import { withQueryProvider } from '../../backendApi/withQueryProvider.tsx';
+
+const AdvancedQueryFilterWithProvider = withQueryProvider(AdvancedQueryFilter);
+
+describe('AdvancedQueryFilter', () => {
+    it('does not render when disabled', async () => {
+        const { getByRole } = render(<AdvancedQueryFilterWithProvider enabled={false} lapisUrl={DUMMY_LAPIS_URL} />);
+
+        await expect.element(getByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    it('shows input when enabled', async () => {
+        const { getByRole } = render(<AdvancedQueryFilterWithProvider enabled lapisUrl={DUMMY_LAPIS_URL} />);
+
+        await expect.element(getByRole('textbox')).toBeVisible();
+    });
+
+    it('calls onInput with undefined when input is cleared', async () => {
+        const onInput = vi.fn();
+
+        const { getByRole } = render(
+            <AdvancedQueryFilterWithProvider value='A123T' onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
+        );
+
+        const input = getByRole('textbox');
+        await userEvent.clear(input);
+
+        expect(onInput).toHaveBeenCalledWith(undefined);
+    });
+
+    it('validates query and calls onInput with value on success', async ({ routeMockers }) => {
+        const onInput = vi.fn();
+
+        routeMockers.lapis.mockPostQueryParse(
+            { queries: ['A123T'] },
+            { data: [{ type: 'success', filter: { type: 'StringEquals', column: 'x', value: 'y' } }] },
+        );
+
+        const { getByRole } = render(
+            <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
+        );
+
+        const input = getByRole('textbox');
+        await userEvent.type(input, 'A123T');
+
+        await expect.poll(() => onInput).toHaveBeenCalledWith('A123T');
+        expect(onInput).not.toHaveBeenCalledWith(undefined);
+    });
+
+    it('shows error message and does not call onInput on parse failure', async ({ routeMockers }) => {
+        const onInput = vi.fn();
+
+        routeMockers.lapis.mockPostQueryParse(
+            { queries: ['invalid!!'] },
+            { data: [{ type: 'failure', error: 'Unexpected token at position 7' }] },
+        );
+
+        const { getByRole, getByText } = render(
+            <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
+        );
+
+        await userEvent.type(getByRole('textbox'), 'invalid!!');
+
+        await expect.element(getByText('Unexpected token at position 7')).toBeVisible();
+        expect(onInput).not.toHaveBeenCalled();
+    });
+
+    it('shows network error message when LAPIS is unreachable', async ({ routeMockers }) => {
+        routeMockers.lapis.mockLapisDown();
+
+        const onInput = vi.fn();
+
+        const { getByRole, getByText } = render(
+            <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
+        );
+
+        await userEvent.type(getByRole('textbox'), 'A123T');
+
+        await expect.element(getByText('Validation is not possible right now.')).toBeVisible();
+        expect(onInput).not.toHaveBeenCalled();
+    });
+});

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -78,16 +78,14 @@ describe('AdvancedQueryFilter', () => {
             { data: [{ type: 'failure', error: 'Unexpected token at position 7' }] },
         );
 
-        const { getByRole, getByLabelText, container } = render(
+        const { getByRole, getByLabelText, getByText } = render(
             <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
         );
 
         await userEvent.type(getByRole('textbox'), 'invalid!!');
 
         await expect.element(getByLabelText('Error')).toBeVisible();
-        await expect
-            .poll(() => container.querySelector('.tooltip-content')?.textContent)
-            .toContain('Unexpected token at position 7');
+        await expect.element(getByText('Unexpected token at position 7')).toBeVisible();
         expect(onInput).not.toHaveBeenCalled();
     });
 
@@ -112,16 +110,14 @@ describe('AdvancedQueryFilter', () => {
 
         const onInput = vi.fn();
 
-        const { getByRole, getByLabelText, container } = render(
+        const { getByRole, getByLabelText, getByText } = render(
             <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
         );
 
         await userEvent.type(getByRole('textbox'), 'A123T');
 
         await expect.element(getByLabelText('Error')).toBeVisible();
-        await expect
-            .poll(() => container.querySelector('.tooltip-content')?.textContent)
-            .toContain('Validation is not possible right now.');
+        await expect.element(getByText('Validation is not possible right now.')).toBeVisible();
         expect(onInput).not.toHaveBeenCalled();
     });
 });

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -70,7 +70,7 @@ describe('AdvancedQueryFilter', () => {
         await expect.element(getByTitle('Advanced query is valid')).toBeVisible();
     });
 
-    it('shows error message and does not call onInput on parse failure', async ({ routeMockers }) => {
+    it('shows error icon with message tooltip on parse failure', async ({ routeMockers }) => {
         const onInput = vi.fn();
 
         routeMockers.lapis.mockPostQueryParse(
@@ -78,13 +78,13 @@ describe('AdvancedQueryFilter', () => {
             { data: [{ type: 'failure', error: 'Unexpected token at position 7' }] },
         );
 
-        const { getByRole, getByText } = render(
+        const { getByRole, getByTitle } = render(
             <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
         );
 
         await userEvent.type(getByRole('textbox'), 'invalid!!');
 
-        await expect.element(getByText('Unexpected token at position 7')).toBeVisible();
+        await expect.element(getByTitle('Invalid advanced query: Unexpected token at position 7')).toBeVisible();
         expect(onInput).not.toHaveBeenCalled();
     });
 
@@ -104,18 +104,20 @@ describe('AdvancedQueryFilter', () => {
         await expect.element(getByTitle('Validating')).toBeVisible();
     });
 
-    it('shows network error message when LAPIS is unreachable', async ({ routeMockers }) => {
+    it('shows error icon with network error tooltip when LAPIS is unreachable', async ({ routeMockers }) => {
         routeMockers.lapis.mockLapisDown();
 
         const onInput = vi.fn();
 
-        const { getByRole, getByText } = render(
+        const { getByRole, getByTitle } = render(
             <AdvancedQueryFilterWithProvider onInput={onInput} enabled lapisUrl={DUMMY_LAPIS_URL} />,
         );
 
         await userEvent.type(getByRole('textbox'), 'A123T');
 
-        await expect.element(getByText('Validation is not possible right now.')).toBeVisible();
+        await expect.element(
+            getByTitle('Invalid advanced query: Validation is not possible right now.'),
+        ).toBeVisible();
         expect(onInput).not.toHaveBeenCalled();
     });
 });

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -1,5 +1,5 @@
 import { userEvent } from '@vitest/browser/context';
-import { http, delay } from 'msw';
+import { delay, http } from 'msw';
 import { describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
@@ -55,6 +55,21 @@ describe('AdvancedQueryFilter', () => {
         expect(onInput).not.toHaveBeenCalledWith(undefined);
     });
 
+    it('shows checkmark after successful validation', async ({ routeMockers }) => {
+        routeMockers.lapis.mockPostQueryParse(
+            { queries: ['A123T'] },
+            { data: [{ type: 'success', filter: { type: 'StringEquals', column: 'x', value: 'y' } }] },
+        );
+
+        const { getByRole, getByTitle } = render(
+            <AdvancedQueryFilterWithProvider enabled lapisUrl={DUMMY_LAPIS_URL} />,
+        );
+
+        await userEvent.type(getByRole('textbox'), 'A123T');
+
+        await expect.element(getByTitle('Advanced query is valid')).toBeVisible();
+    });
+
     it('shows error message and does not call onInput on parse failure', async ({ routeMockers }) => {
         const onInput = vi.fn();
 
@@ -80,13 +95,13 @@ describe('AdvancedQueryFilter', () => {
             }),
         );
 
-        const { getByRole, getByLabelText } = render(
+        const { getByRole, getByTitle } = render(
             <AdvancedQueryFilterWithProvider enabled lapisUrl={DUMMY_LAPIS_URL} />,
         );
 
         await userEvent.type(getByRole('textbox'), 'A123T');
 
-        await expect.element(getByLabelText('Validating')).toBeVisible();
+        await expect.element(getByTitle('Validating')).toBeVisible();
     });
 
     it('shows network error message when LAPIS is unreachable', async ({ routeMockers }) => {

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -40,7 +40,7 @@ describe('AdvancedQueryFilter', () => {
         const onInput = vi.fn();
 
         routeMockers.lapis.mockPostQueryParse(
-            { queries: ['A123T'] },
+            { queries: ['A123T'], doFullValidation: true },
             { data: [{ type: 'success', filter: { type: 'StringEquals', column: 'x', value: 'y' } }] },
         );
 
@@ -57,7 +57,7 @@ describe('AdvancedQueryFilter', () => {
 
     it('shows checkmark after successful validation', async ({ routeMockers }) => {
         routeMockers.lapis.mockPostQueryParse(
-            { queries: ['A123T'] },
+            { queries: ['A123T'], doFullValidation: true },
             { data: [{ type: 'success', filter: { type: 'StringEquals', column: 'x', value: 'y' } }] },
         );
 
@@ -74,7 +74,7 @@ describe('AdvancedQueryFilter', () => {
         const onInput = vi.fn();
 
         routeMockers.lapis.mockPostQueryParse(
-            { queries: ['invalid!!'] },
+            { queries: ['invalid!!'], doFullValidation: true },
             { data: [{ type: 'failure', error: 'Unexpected token at position 7' }] },
         );
 

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -27,7 +27,7 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
     const userEditedRef = useRef(false);
 
     const { mutate: validateQuery } = useMutation({
-        mutationFn: (query: string) => parseQuery(lapisUrl, [query]),
+        mutationFn: (query: string) => parseQuery(lapisUrl, { queries: [query] }),
         onSuccess: (results, query) => {
             const result = results[0];
             if (result.type === 'success') {
@@ -92,12 +92,13 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                 />
                 {isValidating && <span className='loading loading-spinner loading-xs' title='Validating' />}
                 {isValid && <div className='iconify mdi--check text-success size-4' title='Advanced query is valid' />}
+                {isError && (
+                    <div
+                        className='iconify mdi--alert-circle text-error size-4 cursor-pointer'
+                        title={`Invalid advanced query: ${validationState.message}`}
+                    />
+                )}
             </label>
-            {isError && (
-                <div>
-                    <span className='label-text-alt text-error'>{validationState.message}</span>
-                </div>
-            )}
         </div>
     );
 };

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -99,7 +99,21 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                     <div
                         className={`tooltip tooltip-left lg:tooltip-right z-1000 ${isErrorTooltipOpen ? 'tooltip-open' : ''}`}
                     >
-                        <div className='tooltip-content'>{validationState.message}</div>
+                        <div className='tooltip-content z-1000'>
+                            <div className='flex items-start gap-1'>
+                                <span>{validationState.message}</span>
+                                {isErrorTooltipOpen && (
+                                    <button
+                                        className='iconify mdi--close pointer-events-auto shrink-0 cursor-pointer text-xs'
+                                        aria-label='Close tooltip'
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            setIsErrorTooltipOpen(false);
+                                        }}
+                                    />
+                                )}
+                            </div>
+                        </div>
                         <button
                             className='iconify mdi--alert-circle text-error size-4 cursor-pointer'
                             onClick={() => setIsErrorTooltipOpen((open) => !open)}

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -60,8 +60,7 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
         }, DEBOUNCE_MS);
 
         return () => clearTimeout(timeout);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [inputValue, lapisUrl]);
+    }, [inputValue, lapisUrl, onInput]);
 
     if (!enabled) {
         return null;

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -110,6 +110,7 @@ const ErrorIconWithTooltip: FC<{ message: string }> = ({ message }) => {
                     <span>{message}</span>
                     {isOpen && (
                         <button
+                            type='button'
                             className='iconify mdi--close pointer-events-auto shrink-0 cursor-pointer text-xs'
                             aria-label='Close tooltip'
                             onClick={(e) => {
@@ -121,6 +122,7 @@ const ErrorIconWithTooltip: FC<{ message: string }> = ({ message }) => {
                 </div>
             </div>
             <button
+                type='button'
                 className='iconify mdi--alert-circle text-error size-4 cursor-pointer'
                 onClick={() => setIsOpen((open) => !open)}
                 aria-label='Error'

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -23,6 +23,7 @@ type AdvancedQueryFilterProps = {
 
 export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput, enabled, lapisUrl }) => {
     const [inputValue, setInputValue] = useState(value);
+    const [isErrorTooltipOpen, setIsErrorTooltipOpen] = useState(false);
     const [validationState, setValidationState] = useState<ValidationState>({ type: 'idle' });
     const userEditedRef = useRef(false);
 
@@ -79,7 +80,9 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
             <div className='label'>
                 <span className='label-text'>Advanced query</span>
             </div>
-            <label className={`input input-bordered flex w-full items-center gap-2 ${isError ? 'input-error' : ''}`}>
+            <label
+                className={`input input-bordered isolation-auto flex w-full items-center gap-2 ${isError ? 'input-error' : ''}`}
+            >
                 <input
                     className='grow'
                     placeholder={'Advanced query: A123T & ins_123:TA'}
@@ -93,8 +96,15 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                 {isValidating && <span className='loading loading-spinner loading-xs' title='Validating' />}
                 {isValid && <div className='iconify mdi--check text-success size-4' title='Advanced query is valid' />}
                 {isError && (
-                    <div className='tooltip tooltip-left lg:tooltip-top' data-tip={validationState.message}>
-                        <div className='iconify mdi--alert-circle text-error size-4' aria-label='Error' />
+                    <div
+                        className={`tooltip tooltip-left lg:tooltip-right z-1000 ${isErrorTooltipOpen ? 'tooltip-open' : ''}`}
+                    >
+                        <div className='tooltip-content'>{validationState.message}</div>
+                        <button
+                            className='iconify mdi--alert-circle text-error size-4 cursor-pointer'
+                            onClick={() => setIsErrorTooltipOpen((open) => !open)}
+                            aria-label='Error'
+                        />
                     </div>
                 )}
             </label>

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -23,7 +23,6 @@ type AdvancedQueryFilterProps = {
 
 export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput, enabled, lapisUrl }) => {
     const [inputValue, setInputValue] = useState(value);
-    const [isErrorTooltipOpen, setIsErrorTooltipOpen] = useState(false);
     const [validationState, setValidationState] = useState<ValidationState>({ type: 'idle' });
     const userEditedRef = useRef(false);
 
@@ -95,33 +94,37 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                 />
                 {isValidating && <span className='loading loading-spinner loading-xs' title='Validating' />}
                 {isValid && <div className='iconify mdi--check text-success size-4' title='Advanced query is valid' />}
-                {isError && (
-                    <div
-                        className={`tooltip tooltip-left lg:tooltip-right z-1000 ${isErrorTooltipOpen ? 'tooltip-open' : ''}`}
-                    >
-                        <div className='tooltip-content z-1000'>
-                            <div className='flex items-start gap-1'>
-                                <span>{validationState.message}</span>
-                                {isErrorTooltipOpen && (
-                                    <button
-                                        className='iconify mdi--close pointer-events-auto shrink-0 cursor-pointer text-xs'
-                                        aria-label='Close tooltip'
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            setIsErrorTooltipOpen(false);
-                                        }}
-                                    />
-                                )}
-                            </div>
-                        </div>
-                        <button
-                            className='iconify mdi--alert-circle text-error size-4 cursor-pointer'
-                            onClick={() => setIsErrorTooltipOpen((open) => !open)}
-                            aria-label='Error'
-                        />
-                    </div>
-                )}
+                {isError && <ErrorIconWithTooltip message={validationState.message} />}
             </label>
+        </div>
+    );
+};
+
+const ErrorIconWithTooltip: FC<{ message: string }> = ({ message }) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+        <div className={`tooltip tooltip-left lg:tooltip-right z-1000 ${isOpen ? 'tooltip-open' : ''}`}>
+            <div className='tooltip-content z-1000'>
+                <div className='flex items-start gap-1'>
+                    <span>{message}</span>
+                    {isOpen && (
+                        <button
+                            className='iconify mdi--close pointer-events-auto shrink-0 cursor-pointer text-xs'
+                            aria-label='Close tooltip'
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsOpen(false);
+                            }}
+                        />
+                    )}
+                </div>
+            </div>
+            <button
+                className='iconify mdi--alert-circle text-error size-4 cursor-pointer'
+                onClick={() => setIsOpen((open) => !open)}
+                aria-label='Error'
+            />
         </div>
     );
 };

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -72,22 +72,28 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
 
     const isError = validationState.type === 'error';
     const isValid = validationState.type === 'valid';
+    const isValidating = validationState.type === 'validating';
 
     return (
         <div className='form-control'>
             <div className='label'>
                 <span className='label-text'>Advanced query</span>
             </div>
-            <input
-                className={`input input-bordered w-full ${isError ? 'input-error' : ''} ${isValid ? 'input-success' : ''}`}
-                placeholder={'Advanced query: A123T & ins_123:TA'}
-                value={inputValue ?? ''}
-                onInput={(event: InputEvent<HTMLInputElement>) => {
-                    userEditedRef.current = true;
-                    const newValue = event.currentTarget.value;
-                    setInputValue(newValue === '' ? undefined : newValue);
-                }}
-            />
+            <label
+                className={`input input-bordered flex w-full items-center gap-2 ${isError ? 'input-error' : ''} ${isValid ? 'input-success' : ''}`}
+            >
+                <input
+                    className='grow'
+                    placeholder={'Advanced query: A123T & ins_123:TA'}
+                    value={inputValue ?? ''}
+                    onInput={(event: InputEvent<HTMLInputElement>) => {
+                        userEditedRef.current = true;
+                        const newValue = event.currentTarget.value;
+                        setInputValue(newValue === '' ? undefined : newValue);
+                    }}
+                />
+                {isValidating && <span className='loading loading-spinner loading-xs' aria-label='Validating' />}
+            </label>
             {isError && (
                 <div>
                     <span className='label-text-alt text-error'>{validationState.message}</span>

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -27,7 +27,7 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
     const userEditedRef = useRef(false);
 
     const { mutate: validateQuery } = useMutation({
-        mutationFn: (query: string) => parseQuery(lapisUrl, { queries: [query] }),
+        mutationFn: (query: string) => parseQuery(lapisUrl, { queries: [query], doFullValidation: true }),
         onSuccess: (results, query) => {
             const result = results[0];
             if (result.type === 'success') {
@@ -37,8 +37,8 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                 setValidationState({ type: 'error', message: result.error });
             }
         },
-        onError: () => {
-            logger.error(`Failed to validate advanced query`);
+        onError: (error) => {
+            logger.error(`Failed to validate advanced query: ${error.message}`);
             setValidationState({ type: 'error', message: 'Validation is not possible right now.' });
         },
     });

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { type InputEvent, type FC, useEffect, useRef, useState } from 'react';
 
 import { getClientLogger } from '../../clientLogger.ts';
@@ -25,6 +26,23 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
     const [validationState, setValidationState] = useState<ValidationState>({ type: 'idle' });
     const userEditedRef = useRef(false);
 
+    const { mutate: validateQuery } = useMutation({
+        mutationFn: (query: string) => parseQuery(lapisUrl, [query]),
+        onSuccess: (results, query) => {
+            const result = results[0];
+            if (result.type === 'success') {
+                setValidationState({ type: 'valid' });
+                onInput?.(query);
+            } else {
+                setValidationState({ type: 'error', message: result.error });
+            }
+        },
+        onError: () => {
+            logger.error(`Failed to validate advanced query`);
+            setValidationState({ type: 'error', message: 'Validation is not possible right now.' });
+        },
+    });
+
     useEffect(() => {
         userEditedRef.current = false;
         setInputValue(value);
@@ -43,24 +61,10 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
 
         setValidationState({ type: 'validating' });
 
-        const timeout = setTimeout(async () => {
-            try {
-                const results = await parseQuery(lapisUrl, [inputValue]);
-                const result = results[0];
-                if (result.type === 'success') {
-                    setValidationState({ type: 'valid' });
-                    onInput?.(inputValue);
-                } else {
-                    setValidationState({ type: 'error', message: result.error });
-                }
-            } catch {
-                logger.error(`Failed to validate advanced query`);
-                setValidationState({ type: 'error', message: 'Validation is not possible right now.' });
-            }
-        }, DEBOUNCE_MS);
+        const timeout = setTimeout(() => validateQuery(inputValue), DEBOUNCE_MS);
 
         return () => clearTimeout(timeout);
-    }, [inputValue, lapisUrl, onInput]);
+    }, [inputValue, lapisUrl, onInput, validateQuery]);
 
     if (!enabled) {
         return null;
@@ -85,7 +89,7 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                 }}
             />
             {isError && (
-                <div className='label'>
+                <div>
                     <span className='label-text-alt text-error'>{validationState.message}</span>
                 </div>
             )}

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -1,39 +1,95 @@
-import { type InputEvent, type FC, useEffect, useState } from 'react';
+import { type InputEvent, type FC, useEffect, useRef, useState } from 'react';
+
+import { getClientLogger } from '../../clientLogger.ts';
+import { parseQuery } from '../../lapis/parseQuery.ts';
+
+const logger = getClientLogger('AdvancedQueryFilter');
+
+const DEBOUNCE_MS = 500;
+
+type ValidationState =
+    | { type: 'idle' }
+    | { type: 'validating' }
+    | { type: 'valid' }
+    | { type: 'error'; message: string };
 
 type AdvancedQueryFilterProps = {
     value?: string;
     onInput?: (newValue: string | undefined) => void;
     enabled: boolean;
+    lapisUrl: string;
 };
 
-export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput, enabled }) => {
+export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput, enabled, lapisUrl }) => {
     const [inputValue, setInputValue] = useState(value);
+    const [validationState, setValidationState] = useState<ValidationState>({ type: 'idle' });
+    const userEditedRef = useRef(false);
 
     useEffect(() => {
+        userEditedRef.current = false;
         setInputValue(value);
     }, [value]);
+
+    useEffect(() => {
+        if (!userEditedRef.current) {
+            return;
+        }
+
+        if (inputValue === undefined || inputValue === '') {
+            setValidationState({ type: 'idle' });
+            onInput?.(undefined);
+            return;
+        }
+
+        setValidationState({ type: 'validating' });
+
+        const timeout = setTimeout(async () => {
+            try {
+                const results = await parseQuery(lapisUrl, [inputValue]);
+                const result = results[0];
+                if (result.type === 'success') {
+                    setValidationState({ type: 'valid' });
+                    onInput?.(inputValue);
+                } else {
+                    setValidationState({ type: 'error', message: result.error });
+                }
+            } catch {
+                logger.error(`Failed to validate advanced query`);
+                setValidationState({ type: 'error', message: 'Validation is not possible right now.' });
+            }
+        }, DEBOUNCE_MS);
+
+        return () => clearTimeout(timeout);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [inputValue, lapisUrl]);
 
     if (!enabled) {
         return null;
     }
 
+    const isError = validationState.type === 'error';
+    const isValid = validationState.type === 'valid';
+
     return (
-        <label className='form-control'>
+        <div className='form-control'>
             <div className='label'>
                 <span className='label-text'>Advanced query</span>
             </div>
             <input
-                className='input input-bordered w-full'
+                className={`input input-bordered w-full ${isError ? 'input-error' : ''} ${isValid ? 'input-success' : ''}`}
                 placeholder={'Advanced query: A123T & ins_123:TA'}
-                value={inputValue}
+                value={inputValue ?? ''}
                 onInput={(event: InputEvent<HTMLInputElement>) => {
+                    userEditedRef.current = true;
                     const newValue = event.currentTarget.value;
                     setInputValue(newValue === '' ? undefined : newValue);
                 }}
-                onBlur={() => {
-                    onInput?.(inputValue);
-                }}
-            ></input>
-        </label>
+            />
+            {isError && (
+                <div className='label'>
+                    <span className='label-text-alt text-error'>{validationState.message}</span>
+                </div>
+            )}
+        </div>
     );
 };

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { type InputEvent, type FC, useEffect, useRef, useState } from 'react';
+import { type FC, type InputEvent, useEffect, useRef, useState } from 'react';
 
 import { getClientLogger } from '../../clientLogger.ts';
 import { parseQuery } from '../../lapis/parseQuery.ts';
@@ -79,9 +79,7 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
             <div className='label'>
                 <span className='label-text'>Advanced query</span>
             </div>
-            <label
-                className={`input input-bordered flex w-full items-center gap-2 ${isError ? 'input-error' : ''} ${isValid ? 'input-success' : ''}`}
-            >
+            <label className={`input input-bordered flex w-full items-center gap-2 ${isError ? 'input-error' : ''}`}>
                 <input
                     className='grow'
                     placeholder={'Advanced query: A123T & ins_123:TA'}
@@ -92,7 +90,8 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                         setInputValue(newValue === '' ? undefined : newValue);
                     }}
                 />
-                {isValidating && <span className='loading loading-spinner loading-xs' aria-label='Validating' />}
+                {isValidating && <span className='loading loading-spinner loading-xs' title='Validating' />}
+                {isValid && <div className='iconify mdi--check text-success size-4' title='Advanced query is valid' />}
             </label>
             {isError && (
                 <div>

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -93,10 +93,9 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                 {isValidating && <span className='loading loading-spinner loading-xs' title='Validating' />}
                 {isValid && <div className='iconify mdi--check text-success size-4' title='Advanced query is valid' />}
                 {isError && (
-                    <div
-                        className='iconify mdi--alert-circle text-error size-4 cursor-pointer'
-                        title={`Invalid advanced query: ${validationState.message}`}
-                    />
+                    <div className='tooltip tooltip-left lg:tooltip-top' data-tip={validationState.message}>
+                        <div className='iconify mdi--alert-circle text-error size-4' aria-label='Error' />
+                    </div>
                 )}
             </label>
         </div>

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -49,12 +49,14 @@ export function BaselineSelector({
     setDatasetFilter,
     lapisFilter,
     enableAdvancedQueryFilter,
+    lapisUrl,
 }: {
     datasetFilter: DatasetFilter;
     setDatasetFilter: (datasetFilter: DatasetFilter) => void;
     lapisFilter: LapisFilter;
     baselineFilterConfigs?: BaselineFilterConfig[];
     enableAdvancedQueryFilter: boolean;
+    lapisUrl: string;
 }) {
     return (
         <div className={`flex flex-col gap-2`}>
@@ -174,6 +176,7 @@ export function BaselineSelector({
                                 }}
                                 value={datasetFilter.advancedQuery ?? ''}
                                 enabled={enableAdvancedQueryFilter}
+                                lapisUrl={lapisUrl}
                             />
                         );
                     }

--- a/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareSideBySidePageStateSelector.tsx
@@ -15,12 +15,14 @@ export function CompareSideBySidePageStateSelector({
     draftPageState,
     setDraftPageState,
     enableAdvancedQueryFilter,
+    lapisUrl,
 }: {
     view: BaseView<CompareSideBySideData, OrganismConstants, CompareSideBySideStateHandler>;
     filterId: number;
     draftPageState: CompareSideBySideData;
     setDraftPageState: Dispatch<SetStateAction<CompareSideBySideData>>;
     enableAdvancedQueryFilter: boolean;
+    lapisUrl: string;
 }) {
     const variantFilterConfig = useMemo(
         () => makeVariantFilterConfig(view.organismConstants),
@@ -66,6 +68,7 @@ export function CompareSideBySidePageStateSelector({
                             });
                         }}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </Inset>
             </div>
@@ -87,6 +90,7 @@ export function CompareSideBySidePageStateSelector({
                         variantFilter={filterOfCurrentId.variantFilter}
                         lapisFilter={currentLapisFilter}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </Inset>
             </div>

--- a/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsPageStateSelector.tsx
@@ -15,11 +15,13 @@ export function CompareVariantsPageStateSelector({
     pageState,
     setPageState,
     enableAdvancedQueryFilter,
+    lapisUrl,
 }: {
     view: GenericCompareVariantsView<OrganismConstants>;
     pageState: CompareVariantsData;
     setPageState: Dispatch<SetStateAction<CompareVariantsData>>;
     enableAdvancedQueryFilter: boolean;
+    lapisUrl: string;
 }) {
     const [draftPageState, setDraftPageState] = useState(pageState);
     useEffect(() => setDraftPageState(pageState), [pageState]);
@@ -50,6 +52,7 @@ export function CompareVariantsPageStateSelector({
                             }));
                         }}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </Inset>
             </div>
@@ -67,6 +70,7 @@ export function CompareVariantsPageStateSelector({
                         }}
                         lapisFilter={currentLapisFilter}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </Inset>
             </div>

--- a/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/CompareVariantsToBaselineStateSelector.tsx
@@ -15,11 +15,13 @@ export function CompareVariantsToBaselineStateSelector({
     pageState,
     setPageState,
     enableAdvancedQueryFilter,
+    lapisUrl,
 }: {
     view: GenericCompareToBaselineView<OrganismConstants>;
     pageState: CompareToBaselineData;
     setPageState: Dispatch<SetStateAction<CompareToBaselineData>>;
     enableAdvancedQueryFilter: boolean;
+    lapisUrl: string;
 }) {
     const [draftPageState, setDraftPageState] = useState(pageState);
     useEffect(() => setDraftPageState(pageState), [pageState]);
@@ -54,6 +56,7 @@ export function CompareVariantsToBaselineStateSelector({
                                 }));
                             }}
                             enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                            lapisUrl={lapisUrl}
                         />
                     </div>
                 </Inset>
@@ -72,6 +75,7 @@ export function CompareVariantsToBaselineStateSelector({
                         variantFilter={draftPageState.baselineFilter}
                         lapisFilter={currentLapisFilter}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </Inset>
             </div>
@@ -90,6 +94,7 @@ export function CompareVariantsToBaselineStateSelector({
                         }}
                         lapisFilter={currentLapisFilter}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </Inset>
             </div>

--- a/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SequencingEffortsPageStateSelector.tsx
@@ -14,11 +14,13 @@ export function SequencingEffortsPageStateSelector({
     pageState,
     setPageState,
     enableAdvancedQueryFilter,
+    lapisUrl,
 }: {
     view: GenericSequencingEffortsView<OrganismConstants>;
     pageState: DatasetAndVariantData;
     setPageState: Dispatch<SetStateAction<DatasetAndVariantData>>;
     enableAdvancedQueryFilter: boolean;
+    lapisUrl: string;
 }) {
     const [draftPageState, setDraftPageState] = useState(pageState);
     useEffect(() => setDraftPageState(pageState), [pageState]);
@@ -43,6 +45,7 @@ export function SequencingEffortsPageStateSelector({
                             }));
                         }}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                     {view.organismConstants.lineageFilters.map((lineageFilterConfig) => (
                         <LineageFilterInput

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.browser.spec.tsx
@@ -6,8 +6,11 @@ import { render, renderHook } from 'vitest-browser-react';
 import { SingleVariantPageStateSelector } from './SingleVariantPageStateSelector.tsx';
 import { DUMMY_LAPIS_URL, testOrganismsConfig } from '../../../routeMocker.ts';
 import { it } from '../../../test-extend';
+import { withQueryProvider } from '../../backendApi/withQueryProvider.tsx';
 import type { CovidVariantData } from '../../views/covid.ts';
 import { Routing } from '../../views/routing.ts';
+
+const SingleVariantPageStateSelectorWithProvider = withQueryProvider(SingleVariantPageStateSelector);
 
 describe('SingleVariantPageStateSelector', () => {
     it('should remember the covid collection id', async ({ routeMockers }) => {
@@ -33,7 +36,7 @@ describe('SingleVariantPageStateSelector', () => {
 
         const { getByRole } = render(
             <gs-app lapis={DUMMY_LAPIS_URL}>
-                <SingleVariantPageStateSelector
+                <SingleVariantPageStateSelectorWithProvider
                     view={new Routing(testOrganismsConfig).getOrganismView('covid.singleVariantView')}
                     pageState={result.current[0]}
                     setPageState={result.current[1]}

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.browser.spec.tsx
@@ -38,6 +38,7 @@ describe('SingleVariantPageStateSelector', () => {
                     pageState={result.current[0]}
                     setPageState={result.current[1]}
                     enableAdvancedQueryFilter={true}
+                    lapisUrl={DUMMY_LAPIS_URL}
                 />
             </gs-app>,
         );

--- a/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/SingleVariantPageStateSelector.tsx
@@ -14,11 +14,13 @@ export function SingleVariantPageStateSelector({
     pageState,
     setPageState,
     enableAdvancedQueryFilter,
+    lapisUrl,
 }: {
     view: GenericSingleVariantView<OrganismConstants>;
     pageState: DatasetAndVariantData;
     setPageState: Dispatch<SetStateAction<DatasetAndVariantData>>;
     enableAdvancedQueryFilter: boolean;
+    lapisUrl: string;
 }) {
     const variantFilterConfig = useMemo(
         () => makeVariantFilterConfig(view.organismConstants),
@@ -50,6 +52,7 @@ export function SingleVariantPageStateSelector({
                             }));
                         }}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </Inset>
             </div>
@@ -68,6 +71,7 @@ export function SingleVariantPageStateSelector({
                         variantFilter={draftPageState.variantFilter}
                         lapisFilter={currentLapisFilter}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </Inset>
             </div>

--- a/website/src/components/pageStateSelectors/VariantSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantSelector.tsx
@@ -35,12 +35,14 @@ export function VariantSelector({
     variantFilter,
     lapisFilter,
     enableAdvancedQueryFilter,
+    lapisUrl,
 }: {
     variantFilterConfig: VariantFilterConfig;
     onVariantFilterChange: (variantFilter: VariantFilter) => void;
     variantFilter: VariantFilter;
     lapisFilter: LapisFilter;
     enableAdvancedQueryFilter: boolean;
+    lapisUrl: string;
 }) {
     const [isInVariantQueryMode, setIsInVariantQueryMode] = useState(
         variantFilterConfig.variantQueryConfig.enabled && variantFilter.variantQuery !== undefined,
@@ -113,6 +115,7 @@ export function VariantSelector({
                         }}
                         value={variantFilter.advancedQuery ?? ''}
                         enabled={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                 </div>
             )}

--- a/website/src/components/pageStateSelectors/VariantsSelector.tsx
+++ b/website/src/components/pageStateSelectors/VariantsSelector.tsx
@@ -9,12 +9,14 @@ export function VariantsSelector({
     setVariantFilters,
     lapisFilter,
     enableAdvancedQueryFilter,
+    lapisUrl,
 }: {
     variantFilters: Map<Id, VariantFilter>;
     variantFilterConfigs: Map<Id, VariantFilterConfig>;
     setVariantFilters: (variantFilters: Map<Id, VariantFilter>) => void;
     lapisFilter: LapisFilter;
     enableAdvancedQueryFilter: boolean;
+    lapisUrl: string;
 }) {
     const removeVariant = (id: Id) => {
         setVariantFilters(new Map(Array.from(variantFilters).filter(([key]) => key !== id)));
@@ -46,6 +48,7 @@ export function VariantsSelector({
                         onVariantFilterChange={(variantFilter) => updateVariantFilter(id, variantFilter)}
                         lapisFilter={lapisFilter}
                         enableAdvancedQueryFilter={enableAdvancedQueryFilter}
+                        lapisUrl={lapisUrl}
                     />
                     <button className='text-sm hover:text-gray-500' onClick={() => removeVariant(id)}>
                         Remove

--- a/website/src/components/views/analyzeSingleVariant/CovidSingleVariantReactPage.tsx
+++ b/website/src/components/views/analyzeSingleVariant/CovidSingleVariantReactPage.tsx
@@ -56,6 +56,7 @@ export const CovidSingleVariantReactPage: FC<CovidSingleVariantReactPageProps> =
                         pageState={pageState}
                         setPageState={setPageState}
                         enableAdvancedQueryFilter={isStaging}
+                        lapisUrl={organismsConfig.covid.lapis.url}
                     />
                     <hr className='my-4 border-gray-200' />
                     <div className='mt-4'>

--- a/website/src/components/views/analyzeSingleVariant/GenericAnalyseSingleVariantReactPage.tsx
+++ b/website/src/components/views/analyzeSingleVariant/GenericAnalyseSingleVariantReactPage.tsx
@@ -63,6 +63,7 @@ export const GenericAnalyseSingleVariantReactPage: FC<GenericAnalyseSingleVarian
                     pageState={pageState}
                     setPageState={setPageState}
                     enableAdvancedQueryFilter={isStaging}
+                    lapisUrl={organismsConfig[organism].lapis.url}
                 />
             }
             dataDisplay={

--- a/website/src/components/views/compareSideBySide/GenericCompareSideBySideReactPage.tsx
+++ b/website/src/components/views/compareSideBySide/GenericCompareSideBySideReactPage.tsx
@@ -69,6 +69,7 @@ export const GenericCompareSideBySideReactPage: FC<GenericCompareSideBySideReact
                                     draftPageState={draftPageState}
                                     setDraftPageState={setDraftPageState}
                                     enableAdvancedQueryFilter={isStaging}
+                                    lapisUrl={organismsConfig[organism].lapis.url}
                                 />
                             </div>
                         ))}

--- a/website/src/components/views/compareToBaseline/GenericCompareToBaselineReactPage.tsx
+++ b/website/src/components/views/compareToBaseline/GenericCompareToBaselineReactPage.tsx
@@ -50,6 +50,7 @@ export const GenericCompareToBaselineReactPage: FC<GenericCompareToBaselineReact
                     pageState={pageState}
                     setPageState={setPageState}
                     enableAdvancedQueryFilter={isStaging}
+                    lapisUrl={organismsConfig[organism].lapis.url}
                 />
             }
             dataDisplay={<GenericCompareToBaselineDataDisplay view={view} pageState={pageState} />}

--- a/website/src/components/views/compareVariants/GenericCompareVariantsReactPage.tsx
+++ b/website/src/components/views/compareVariants/GenericCompareVariantsReactPage.tsx
@@ -50,6 +50,7 @@ export const GenericCompareVariantsReactPage: FC<GenericCompareVariantsReactPage
                     pageState={pageState}
                     setPageState={setPageState}
                     enableAdvancedQueryFilter={isStaging}
+                    lapisUrl={organismsConfig[organism].lapis.url}
                 />
             }
             dataDisplay={<GenericCompareVariantsDataDisplay view={view} pageState={pageState} />}

--- a/website/src/components/views/sequencingEfforts/GenericSequencingEffortsReactPage.tsx
+++ b/website/src/components/views/sequencingEfforts/GenericSequencingEffortsReactPage.tsx
@@ -48,6 +48,7 @@ export const GenericSequencingEffortsReactPage: FC<GenericSequencingEffortsReact
                     pageState={pageState}
                     setPageState={setPageState}
                     enableAdvancedQueryFilter={isStaging}
+                    lapisUrl={organismsConfig[organism].lapis.url}
                 />
             }
             dataDisplay={

--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -189,10 +189,7 @@ async function fetchCollectionModeData(
     }
 
     // Parse all variant queries through LAPIS
-    const parseResults = await parseQuery(
-        config.lapisBaseUrl,
-        variantData.map((vd) => vd.queryString),
-    );
+    const parseResults = await parseQuery(config.lapisBaseUrl, { queries: variantData.map((vd) => vd.queryString) });
 
     // Process results and validate
     const queries: {

--- a/website/src/lapis/parseQuery.spec.ts
+++ b/website/src/lapis/parseQuery.spec.ts
@@ -28,7 +28,7 @@ describe('parseQuery', () => {
             },
         );
 
-        const result = await parseQuery(DUMMY_LAPIS_URL, queries);
+        const result = await parseQuery(DUMMY_LAPIS_URL, { queries });
 
         expect(result).toHaveLength(1);
         expect(result[0]).toEqual({
@@ -39,6 +39,19 @@ describe('parseQuery', () => {
                 value: 'USA',
             },
         });
+    });
+
+    test('should pass the doFullValidation parameter', async () => {
+        const queries = [''];
+
+        lapisRouteMocker.mockPostQueryParse(
+            { queries, doFullValidation: true },
+            { data: [{ type: 'success', filter: { type: 'True' } }] },
+        );
+
+        const result = await parseQuery(DUMMY_LAPIS_URL, { queries, doFullValidation: true });
+
+        expect(result).toHaveLength(1);
     });
 
     test('should handle failed query parsing', async () => {
@@ -56,7 +69,7 @@ describe('parseQuery', () => {
             },
         );
 
-        const result = await parseQuery(DUMMY_LAPIS_URL, queries);
+        const result = await parseQuery(DUMMY_LAPIS_URL, { queries });
 
         expect(result).toHaveLength(1);
         expect(result[0]).toEqual({
@@ -70,7 +83,9 @@ describe('parseQuery', () => {
 
         lapisRouteMocker.mockPostQueryParse({ queries }, { data: [] }, 500);
 
-        await expect(parseQuery(DUMMY_LAPIS_URL, queries)).rejects.toThrow(/Failed to make parse queries API request/);
+        await expect(parseQuery(DUMMY_LAPIS_URL, { queries })).rejects.toThrow(
+            /Failed to make parse queries API request/,
+        );
     });
 
     test('should throw when LAPIS returns unexpected data', async () => {
@@ -79,6 +94,6 @@ describe('parseQuery', () => {
         // @ts-expect-error -- intentionally passing wrong data
         lapisRouteMocker.mockPostQueryParse({ queries }, { data: 'something unexpected' });
 
-        await expect(parseQuery(DUMMY_LAPIS_URL, queries)).rejects.toThrow(/Failed to parse API response/);
+        await expect(parseQuery(DUMMY_LAPIS_URL, { queries })).rejects.toThrow(/Failed to parse API response/);
     });
 });

--- a/website/src/lapis/parseQuery.ts
+++ b/website/src/lapis/parseQuery.ts
@@ -27,18 +27,23 @@ const queryParseResponseSchema = z.object({
     data: z.array(parsedQueryResultSchema),
 });
 
+export type ParseQueryRequest = {
+    queries: string[];
+    doFullValidation?: boolean;
+};
+
 /**
  * Parses a list of advanced query strings into SILO filter expressions.
  * Returns partial results: successfully parsed queries will have a "filter" field,
  * while failed queries will have an "error" field with the error message.
  *
  * @param lapisUrl The base API URL
- * @param queries Array of advanced query strings to parse
+ * @param request
  * @returns Array of parsed query results (success or failure for each query)
  */
-export async function parseQuery(lapisUrl: string, queries: string[]): Promise<ParsedQueryResult[]> {
+export async function parseQuery(lapisUrl: string, request: ParseQueryRequest): Promise<ParsedQueryResult[]> {
     const url = `${lapisUrl}/query/parse`;
-    const body = { queries };
+    const body = request;
 
     let response;
     try {

--- a/website/tests/api/parseQuery.spec.ts
+++ b/website/tests/api/parseQuery.spec.ts
@@ -8,7 +8,7 @@ test.describe('parseQuery integration', () => {
     test('should parse a simple query against real LAPIS', async () => {
         const queries = ["country = 'Switzerland'"];
 
-        const result = await parseQuery(LAPIS_URL, queries);
+        const result = await parseQuery(LAPIS_URL, { queries });
 
         expect(result).toHaveLength(1);
         expect(result[0].type).toBe('success');
@@ -17,10 +17,22 @@ test.describe('parseQuery integration', () => {
         }
     });
 
+    test('should recognize genome out of bounds when doing full validation', async () => {
+        const queries = ['1234567890'];
+
+        const result = await parseQuery(LAPIS_URL, { queries, doFullValidation: true });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe('failure');
+        if (result[0].type === 'failure') {
+            expect(result[0].error).toBe('TODO - insert correct error message');
+        }
+    });
+
     test('should handle invalid query syntax', async () => {
         const queries = ['this is invalid syntax !!!!'];
 
-        const result = await parseQuery(LAPIS_URL, queries);
+        const result = await parseQuery(LAPIS_URL, { queries });
 
         expect(result).toHaveLength(1);
         expect(result[0].type).toBe('failure');
@@ -37,7 +49,7 @@ test.describe('parseQuery integration', () => {
             "pangoLineage = 'BA.1*'", // valid
         ];
 
-        const result = await parseQuery(LAPIS_URL, queries);
+        const result = await parseQuery(LAPIS_URL, { queries });
 
         // Should get 3 results total (HTTP 200 with partial results)
         expect(result).toHaveLength(3);
@@ -66,7 +78,7 @@ test.describe('parseQuery integration', () => {
             "(country = 'Switzerland' | country = 'Germany') & ((age >= 30 & age <= 50) | pangoLineage = 'BA.1*')",
         ];
 
-        const result = await parseQuery(LAPIS_URL, queries);
+        const result = await parseQuery(LAPIS_URL, { queries });
 
         expect(result).toHaveLength(1);
         expect(result[0].type).toBe('success');

--- a/website/tests/api/parseQuery.spec.ts
+++ b/website/tests/api/parseQuery.spec.ts
@@ -25,9 +25,8 @@ test.describe('parseQuery integration', () => {
         expect(result).toHaveLength(1);
         expect(result[0].type).toBe('failure');
         if (result[0].type === 'failure') {
-            expect(result[0].error).toBe(
-                'Error from SILO: HasNucleotideMutation position is out of bounds 1234567890 > 29903',
-            );
+            expect(result[0].error).toMatch(/out of bounds/i);
+            expect(result[0].error).toMatch(/1234567890/);
         }
     });
 

--- a/website/tests/api/parseQuery.spec.ts
+++ b/website/tests/api/parseQuery.spec.ts
@@ -25,7 +25,9 @@ test.describe('parseQuery integration', () => {
         expect(result).toHaveLength(1);
         expect(result[0].type).toBe('failure');
         if (result[0].type === 'failure') {
-            expect(result[0].error).toBe('TODO - insert correct error message');
+            expect(result[0].error).toBe(
+                'Error from SILO: HasNucleotideMutation position is out of bounds 1234567890 > 29903',
+            );
         }
     });
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

resolves #1156

### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Adds LAPIS backed validation to the advanced query input field: after a 500 ms debounce, send the query string to LAPIS. Only when valid, sync it to the surrounding page state (thus the other components should only get valid queries so that they don't error). When there is an error, you can hover the error icon to get the error message (we simply show what we get from LAPIS - that might need to be improved, too).

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

when valid:

<img width="450" height="124" alt="grafik" src="https://github.com/user-attachments/assets/60db139e-95d2-4b6a-953e-0812b0f7413e" />

when not valid (clicking the error icon makes the tooltip sticky):

<img width="607" height="464" alt="grafik" src="https://github.com/user-attachments/assets/6c3b4101-dbe3-4b39-97ae-6f7d2adea587" />


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
