### PR TITLE
chore(website): bump astro to 5.18.1

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,7 +13,7 @@
                 "@auth/core": "^0.37.4",
                 "@genspectrum/dashboard-components": "^1.17.0",
                 "@tanstack/react-query": "^5.99.2",
-                "astro": "^5.17.2",
+                "astro": "^5.18.1",
                 "auth-astro": "^4.2.0",
                 "axios": "^1.15.1",
                 "cookie": "^1.1.1",
@@ -126,7 +126,8 @@
             "version": "2.13.1",
             "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
             "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@astrojs/internal-helpers": {
             "version": "0.7.5",
@@ -177,12 +178,12 @@
             }
         },
         "node_modules/@astrojs/markdown-remark": {
-            "version": "6.3.10",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.10.tgz",
-            "integrity": "sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==",
+            "version": "6.3.11",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+            "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/internal-helpers": "0.7.5",
+                "@astrojs/internal-helpers": "0.7.6",
                 "@astrojs/prism": "3.3.0",
                 "github-slugger": "^2.0.0",
                 "hast-util-from-html": "^2.0.3",
@@ -196,14 +197,20 @@
                 "remark-parse": "^11.0.0",
                 "remark-rehype": "^11.1.2",
                 "remark-smartypants": "^3.0.2",
-                "shiki": "^3.19.0",
-                "smol-toml": "^1.5.2",
+                "shiki": "^3.21.0",
+                "smol-toml": "^1.6.0",
                 "unified": "^11.0.5",
                 "unist-util-remove-position": "^5.0.0",
                 "unist-util-visit": "^5.0.0",
                 "unist-util-visit-parents": "^6.0.2",
                 "vfile": "^6.0.3"
             }
+        },
+        "node_modules/@astrojs/markdown-remark/node_modules/@astrojs/internal-helpers": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+            "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+            "license": "MIT"
         },
         "node_modules/@astrojs/node": {
             "version": "9.5.3",
@@ -285,6 +292,7 @@
             "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.4.tgz",
             "integrity": "sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "@panva/hkdf": "^1.2.1",
                 "jose": "^5.9.6",
@@ -340,6 +348,7 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -2544,60 +2553,60 @@
             "license": "MIT"
         },
         "node_modules/@shikijs/core": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.21.0.tgz",
-            "integrity": "sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA==",
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+            "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.21.0",
+                "@shikijs/types": "3.23.0",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4",
                 "hast-util-to-html": "^9.0.5"
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.21.0.tgz",
-            "integrity": "sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ==",
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+            "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.21.0",
+                "@shikijs/types": "3.23.0",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "oniguruma-to-es": "^4.3.4"
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.21.0.tgz",
-            "integrity": "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==",
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+            "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.21.0",
+                "@shikijs/types": "3.23.0",
                 "@shikijs/vscode-textmate": "^10.0.2"
             }
         },
         "node_modules/@shikijs/langs": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.21.0.tgz",
-            "integrity": "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==",
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+            "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.21.0"
+                "@shikijs/types": "3.23.0"
             }
         },
         "node_modules/@shikijs/themes": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.21.0.tgz",
-            "integrity": "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==",
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+            "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.21.0"
+                "@shikijs/types": "3.23.0"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.21.0.tgz",
-            "integrity": "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==",
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+            "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
             "license": "MIT",
             "dependencies": {
                 "@shikijs/vscode-textmate": "^10.0.2",
@@ -3070,6 +3079,7 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -3297,6 +3307,7 @@
             "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.12.0"
             }
@@ -3307,6 +3318,7 @@
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -3317,6 +3329,7 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -3421,6 +3434,7 @@
             "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.59.0",
                 "@typescript-eslint/types": "8.59.0",
@@ -3662,6 +3676,7 @@
             "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/user-event": "^14.6.1",
@@ -3916,6 +3931,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4237,14 +4253,15 @@
             }
         },
         "node_modules/astro": {
-            "version": "5.17.2",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.2.tgz",
-            "integrity": "sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA==",
+            "version": "5.18.1",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.1.tgz",
+            "integrity": "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@astrojs/compiler": "^2.13.0",
-                "@astrojs/internal-helpers": "0.7.5",
-                "@astrojs/markdown-remark": "6.3.10",
+                "@astrojs/internal-helpers": "0.7.6",
+                "@astrojs/markdown-remark": "6.3.11",
                 "@astrojs/telemetry": "3.3.0",
                 "@capsizecss/unpack": "^4.0.0",
                 "@oslojs/encoding": "^1.1.0",
@@ -4265,7 +4282,7 @@
                 "dlv": "^1.1.3",
                 "dset": "^3.1.4",
                 "es-module-lexer": "^1.7.0",
-                "esbuild": "^0.27.0",
+                "esbuild": "^0.27.3",
                 "estree-walker": "^3.0.3",
                 "flattie": "^1.1.1",
                 "fontace": "~0.4.0",
@@ -4361,6 +4378,12 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+            "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+            "license": "MIT"
         },
         "node_modules/astro/node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.3",
@@ -5165,6 +5188,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001737",
                 "electron-to-chromium": "^1.5.211",
@@ -5356,6 +5380,7 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
             "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
             },
@@ -5941,9 +5966,9 @@
             }
         },
         "node_modules/decode-named-character-reference": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-            "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
             "license": "MIT",
             "dependencies": {
                 "character-entities": "^2.0.0"
@@ -6580,6 +6605,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -9271,9 +9297,9 @@
             }
         },
         "node_modules/mdast-util-from-markdown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-            "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+            "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -10521,19 +10547,19 @@
             }
         },
         "node_modules/oniguruma-parser": {
-            "version": "0.12.1",
-            "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
-            "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+            "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
             "license": "MIT"
         },
         "node_modules/oniguruma-to-es": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
-            "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+            "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
             "license": "MIT",
             "dependencies": {
-                "oniguruma-parser": "^0.12.1",
-                "regex": "^6.0.1",
+                "oniguruma-parser": "^0.12.2",
+                "regex": "^6.1.0",
                 "regex-recursion": "^6.0.2"
             }
         },
@@ -10998,6 +11024,7 @@
             "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
             "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -11028,6 +11055,7 @@
             "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -11044,6 +11072,7 @@
             "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@astrojs/compiler": "^2.9.1",
                 "prettier": "^3.0.0",
@@ -11203,6 +11232,7 @@
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -11285,6 +11315,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
             "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11294,6 +11325,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
             "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -11737,6 +11769,7 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.9.tgz",
             "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.6"
             },
@@ -12104,17 +12137,17 @@
             }
         },
         "node_modules/shiki": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.21.0.tgz",
-            "integrity": "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==",
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+            "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "3.21.0",
-                "@shikijs/engine-javascript": "3.21.0",
-                "@shikijs/engine-oniguruma": "3.21.0",
-                "@shikijs/langs": "3.21.0",
-                "@shikijs/themes": "3.21.0",
-                "@shikijs/types": "3.21.0",
+                "@shikijs/core": "3.23.0",
+                "@shikijs/engine-javascript": "3.23.0",
+                "@shikijs/engine-oniguruma": "3.23.0",
+                "@shikijs/langs": "3.23.0",
+                "@shikijs/themes": "3.23.0",
+                "@shikijs/types": "3.23.0",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
             }
@@ -12256,9 +12289,9 @@
             }
         },
         "node_modules/smol-toml": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-            "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">= 18"
@@ -12664,7 +12697,8 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.3.tgz",
             "integrity": "sha512-fA/NX5gMf0ooCLISgB0wScaWgaj6rjTN2SVAwleURjiya7ITNkV+VMmoHtKkldP6CIZoYCZyxb8zP/e2TWoEtQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tapable": {
             "version": "2.3.2",
@@ -13048,6 +13082,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -13413,6 +13448,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -13544,6 +13580,7 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -14055,6 +14092,7 @@
             "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
             "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@colors/colors": "^1.6.0",
                 "@dabh/diagnostics": "^2.0.8",
@@ -14232,6 +14270,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -14392,6 +14431,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/website/package.json
+++ b/website/package.json
@@ -29,7 +29,7 @@
         "@auth/core": "^0.37.4",
         "@genspectrum/dashboard-components": "^1.17.0",
         "@tanstack/react-query": "^5.99.2",
-        "astro": "^5.17.2",
+        "astro": "^5.18.1",
         "auth-astro": "^4.2.0",
         "axios": "^1.15.1",
         "cookie": "^1.1.1",


### PR DESCRIPTION
## Summary
- Bumps `astro` from `5.17.2` to `5.18.1` (latest 5.x)
- Changelog: https://github.com/withastro/astro/releases/tag/astro%405.18.0
- Notable fix: https://github.com/withastro/astro/pull/15594 — HTTPS wasn't correctly recognized

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
I had this Problem (Claude's words):

**The problem**

Logging in via GitHub OAuth on staging fails with "Cross-site POST form submissions are
forbidden". Auth.js generates this error when it detects a CSRF/origin mismatch.

**Root cause**

Auth.js doesn't know it's running behind nginx and being served over HTTPS. It thinks its own URL
 is http://staging.genspectrum.org, which causes two issues:
1. It sets cookies without the __Host-/__Secure- prefixes (insecure cookies)
2. When the browser submits the sign-in form with callbackUrl=https://..., Auth.js sees a
protocol mismatch and rejects it as cross-site

**What we tried**

AUTH_TRUST_HOST=true — the Auth.js-recommended fix for reverse proxy setups. It picks up
X-Forwarded-Host correctly (callback URL changes from http://localhost to
http://staging.genspectrum.org) but ignores X-Forwarded-Proto, so the scheme stays http://
regardless.

...

Turns out, it is actually an Astro bug. This release fixes it.
