### PR TITLE
fix(website): hide Subscriptions link in user menu on prod

### DIFF
--- a/website/src/components/auth/UserDropdown.astro
+++ b/website/src/components/auth/UserDropdown.astro
@@ -1,11 +1,14 @@
 ---
 import type { Session } from '@auth/core/types';
 
+import { isStaging } from '../../config';
+
 interface Props {
     session: Session;
 }
 
 const { session } = Astro.props;
+const showSubscriptions = isStaging();
 ---
 
 <div class='dropdown dropdown-end dropdown-hover'>
@@ -13,9 +16,13 @@ const { session } = Astro.props;
     <ul tabindex='0' class='menu dropdown-content rounded-box bg-base-100 z-1 w-52 border-2 p-2 shadow-2xl'>
         <li class='menu-title text-black'><a>{session.user?.name}</a></li>
         <li class='divider m-1 h-0.5'></li>
-        <li>
-            <a href='/subscriptions'>Subscriptions</a>
-        </li>
+        {
+            showSubscriptions && (
+                <li>
+                    <a href='/subscriptions'>Subscriptions</a>
+                </li>
+            )
+        }
         <li>
             <a href='/logout'>Logout</a>
         </li>

--- a/website/src/layouts/base/header/HamburgerMenu.astro
+++ b/website/src/layouts/base/header/HamburgerMenu.astro
@@ -5,6 +5,7 @@ import HamburgerMenuItem from './HamburgerMenuItem.astro';
 import HamburgerMenuSection from './HamburgerMenuSection.astro';
 import { getPathogenMegaMenuSections } from './getPathogenMegaMenuSections';
 import { LoginButton } from '../../../components/auth/LoginButton';
+import { isStaging } from '../../../config';
 import { Page } from '../../../types/pages';
 
 type Props = {
@@ -17,6 +18,7 @@ const pathogenMegaMenuSections = Object.values(getPathogenMegaMenuSections());
 
 const session = await getSession(Astro.request);
 const showLoggedInState = !forceLoggedOutState && session?.user !== undefined;
+const showSubscriptions = isStaging();
 ---
 
 <nav>
@@ -43,10 +45,7 @@ const showLoggedInState = !forceLoggedOutState && session?.user !== undefined;
                 <HamburgerMenuSection
                     navigationEntries={[
                         { label: session.user?.name ?? 'My Account' },
-                        {
-                            label: 'Subscriptions',
-                            href: '/subscriptions',
-                        },
+                        ...(showSubscriptions ? [{ label: 'Subscriptions', href: '/subscriptions' }] : []),
                         { label: 'Logout', href: '/logout' },
                     ]}
                 >


### PR DESCRIPTION
## Summary
- Hides the **Subscriptions** link in the user dropdown and hamburger menu when running on `dashboards-prod`
- Uses the existing `isStaging()` helper from `config.ts` — the link remains visible on staging and in local dev