### PR TITLE
fix(config): remove lineage fields that are not of type lineage in Loculus

### DIFF
--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -19,8 +19,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/h5n1"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "clade"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -33,9 +31,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/h1n1pdm"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "cladeHA"
-          - "cladeNA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -48,9 +43,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/h3n2"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "cladeHA"
-          - "cladeNA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -64,9 +56,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/influenza-a"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "subtypeHA"
-          - "subtypeNA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -80,8 +69,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/influenza-b"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "lineageHA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -94,9 +81,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.genspectrum.org/b-victoria"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "cladeHA"
-          - "cladeNA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -109,9 +93,6 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/mpox"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "lineage"
-          - "clade"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -124,8 +105,6 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/west-nile"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "lineage"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -280,8 +259,6 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/measles"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "genotype"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -16,8 +16,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h5n1"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "clade"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -30,9 +28,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h1n1pdm"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "cladeHA"
-          - "cladeNA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -45,9 +40,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/h3n2"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "cladeHA"
-          - "cladeNA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -61,9 +53,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/influenza-a"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "subtypeHA"
-          - "subtypeNA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -77,8 +66,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/influenza-b"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "lineageHA"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -91,9 +78,6 @@ dashboards:
       lapis:
         url: "https://api.loculus.staging.genspectrum.org/b-victoria"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "cladeHA"
-          - "cladeNA"
         locationFields:
           - "country"
           - "division"
@@ -111,9 +95,6 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/mpox"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "lineage"
-          - "clade"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -126,8 +107,6 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/west-nile"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "lineage"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"
@@ -282,8 +261,6 @@ dashboards:
       lapis:
         url: "https://lapis.pathoplexus.org/measles"
         mainDateField: "sampleCollectionDateRangeLower"
-        lineageFields:
-          - "genotype"
         additionalFilters:
           versionStatus: "LATEST_VERSION"
           isRevocation: "false"


### PR DESCRIPTION
closes https://github.com/GenSpectrum/dashboards/issues/1169

## Summary

- Fields like `cladeHA`, `cladeNA`, `clade`, `subtypeHA`/`subtypeNA`, `lineageHA`, `lineage`, and `genotype` are not of type lineage in Loculus, so they cannot meaningfully be used as lineage filters in collections
- Remove `lineageFields` for `h5n1`, `h1n1pdm`, `h3n2`, `influenzaA`, `influenzaB`, `victoria`, `mpox`, `westNile`, and `measles` from both staging and prod configs
- Fields that are genuine lineage types (`rsvA`, `rsvB`, `cchf`, `denv1–4`) are unchanged

There _might_ be another way, but this is the quickest way for us at the moment, as we also do not really care about Influenza collections for now.

related PR: https://github.com/GenSpectrum/dashboards/pull/1122