### PR TITLE
fix(website): make border color of user dropdown less aggressive

### DIFF
--- a/website/src/components/auth/UserDropdown.astro
+++ b/website/src/components/auth/UserDropdown.astro
@@ -10,7 +10,10 @@ const { session } = Astro.props;
 
 <div class='dropdown dropdown-end dropdown-hover'>
     <span role='button' tabindex='0' class='iconify mdi--account text-4xl'></span>
-    <ul tabindex='0' class='menu dropdown-content rounded-box bg-base-100 z-1 w-52 border-2 p-2 shadow-2xl'>
+    <ul
+        tabindex='0'
+        class='menu dropdown-content rounded-box bg-base-100 border-neutral-content z-1 w-52 border-2 p-2 shadow-2xl'
+    >
         <li class='menu-title text-black'><a>{session.user?.name}</a></li>
         <li class='divider m-1 h-0.5'></li>
         <li>


### PR DESCRIPTION


### Summary

<!--
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

I suspect that this changed in a Tailwind major upgrade or similar. This adds an explicit border color with `border-neutral-content`

### Screenshot

<!--
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

Before:

<img width="230" height="238" alt="grafik" src="https://github.com/user-attachments/assets/ad4a40e8-d086-4bae-b4fd-aa8e65341a7c" />


After:

<img width="230" height="238" alt="grafik" src="https://github.com/user-attachments/assets/5a4d4d0a-0f98-4eac-a6e9-0b9fd7f19d92" />


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
