### PR TITLE
feat(website): add staging example data seeder

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,7 @@ jobs:
       env:
         WEBSITE_TAG: ${{ steps.branchTag.outputs.branchTag }}
         BACKEND_TAG: ${{ steps.branchTag.outputs.branchTag }}
+        SEEDER_TAG: ${{ steps.branchTag.outputs.branchTag }}
 
     - name: Run Playwright tests (all browsers)
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/example-data-seeder.yml
+++ b/.github/workflows/example-data-seeder.yml
@@ -1,0 +1,45 @@
+name: Example Data Seeder
+
+on: [push]
+
+env:
+  DOCKER_IMAGE_NAME: ghcr.io/genspectrum/dashboards/example-data-seeder
+
+jobs:
+  dockerImage:
+    name: Build Example Data Seeder Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: dockerMetadata
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./example-data
+          tags: ${{ steps.dockerMetadata.outputs.tags }}
+          cache-from: type=gha,scope=example-data-seeder-${{ github.ref }}
+          cache-to: type=gha,mode=max,scope=example-data-seeder-${{ github.ref }}
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: true

--- a/README.md
+++ b/README.md
@@ -34,11 +34,15 @@ This monorepo contains the following packages:
 - [`backend/`](./backend): 
   The backend for additional features of the dashboard website, currently the notification features.
 
-- [`website/`](./website): 
+- [`website/`](./website):
   The dashboard website: delivery of the (basically static, via Astro) HTML pages with the embedded Dashboard Components
-  (which are included via npm), 
+  (which are included via npm),
   which retrieve data from LAPIS instances directly,
   and some additional client side features accessing the backend.
+
+- [`example-data/`](./example-data):
+  A Node.js seeder script and Dockerfile that populate the backend with example collections (resistance mutation data for 3CLpro, RdRp, and Spike).
+  Activated via the `staging` Docker Compose profile (see below).
 
 
 ## Local setup
@@ -49,3 +53,23 @@ Use Docker Compose to run the dashboards:
 ```bash
 BACKEND_TAG=latest WEBSITE_TAG=latest docker compose up
 ```
+
+### Seeding example data
+
+The `example-data-seeder` service seeds the backend with example collections.
+It only starts when the `staging` Docker Compose profile is active:
+
+```bash
+BACKEND_TAG=latest WEBSITE_TAG=latest docker compose --profile staging up
+```
+
+The seeder is idempotent — running it multiple times will not create duplicate collections.
+Collections are owned by the `example-data-seeder` user and can be inspected via:
+
+```
+GET /collections?userId=example-data-seeder&organism=covid
+```
+
+### Deleting data
+
+`docker compose down` won't delete the postgres volume. Use `... down -v` to also delete the DB volume.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Check the [Docker compose file](docker-compose.yml) for an example on how to run
 
 Use Docker Compose to run the dashboards:
 ```bash
-BACKEND_TAG=latest WEBSITE_TAG=latest docker compose up
+BACKEND_TAG=latest WEBSITE_TAG=latest SEEDER_TAG=latest docker compose up
 ```
 
 ### Seeding example data
@@ -58,7 +58,7 @@ BACKEND_TAG=latest WEBSITE_TAG=latest docker compose up
 The `example-data-seeder` service seeds the backend with example collections.
 
 ```bash
-BACKEND_TAG=latest WEBSITE_TAG=latest docker compose up
+BACKEND_TAG=latest WEBSITE_TAG=latest SEEDER_TAG=latest docker compose up
 ```
 
 The seeder is idempotent — running it multiple times will not create duplicate collections.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ This monorepo contains the following packages:
 
 - [`example-data/`](./example-data):
   A Node.js seeder script and Dockerfile that populate the backend with example collections (resistance mutation data for 3CLpro, RdRp, and Spike).
-  Activated via the `staging` Docker Compose profile (see below).
 
 
 ## Local setup
@@ -57,10 +56,9 @@ BACKEND_TAG=latest WEBSITE_TAG=latest docker compose up
 ### Seeding example data
 
 The `example-data-seeder` service seeds the backend with example collections.
-It only starts when the `staging` Docker Compose profile is active:
 
 ```bash
-BACKEND_TAG=latest WEBSITE_TAG=latest docker compose --profile staging up
+BACKEND_TAG=latest WEBSITE_TAG=latest docker compose up
 ```
 
 The seeder is idempotent — running it multiple times will not create duplicate collections.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,7 @@ services:
       - database-data:/var/lib/postgresql/data
 
   example-data-seeder:
-    build:
-      context: ./example-data
+    image: ghcr.io/genspectrum/dashboards/example-data-seeder:${SEEDER_TAG}
     depends_on:
       - backend
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
   example-data-seeder:
     build:
       context: ./example-data
-    profiles:
-      - staging
     depends_on:
       - backend
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,20 @@ services:
       POSTGRES_DB: dashboards-backend-db
     ports:
       - "127.0.0.1:9022:5432"
+    volumes:
+      - database-data:/var/lib/postgresql/data
+
+  example-data-seeder:
+    build:
+      context: ./example-data
+    profiles:
+      - staging
+    depends_on:
+      - backend
+    environment:
+      BACKEND_URL: http://backend:8080
+      SEED_USER_ID: example-data-seeder
+    restart: "no"
+
+volumes:
+  database-data:

--- a/example-data/Dockerfile
+++ b/example-data/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:25-alpine
 WORKDIR /app
-COPY seed.js .
-CMD ["node", "seed.js"]
+COPY seed.mjs .
+CMD ["node", "seed.mjs"]

--- a/example-data/Dockerfile
+++ b/example-data/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25-alpine
+FROM node:24-alpine
 WORKDIR /app
 COPY seed.mjs .
 CMD ["node", "seed.mjs"]

--- a/example-data/Dockerfile
+++ b/example-data/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY seed.js .
+CMD ["node", "seed.js"]

--- a/example-data/README.md
+++ b/example-data/README.md
@@ -4,29 +4,31 @@ Seeds the backend with example collections (resistance mutation data for 3CLpro,
 
 The script is idempotent — re-running it will skip collections that already exist.
 
-## Via Docker Compose (staging)
+## Via Docker Compose
+
+The seeder runs automatically as part of Docker Compose:
 
 ```bash
-BACKEND_TAG=latest WEBSITE_TAG=latest docker compose --profile staging up
+BACKEND_TAG=latest WEBSITE_TAG=latest docker compose up
 ```
 
 ## Running locally by hand
 
-Requires Node 18+. No `npm install` needed.
+Requires a current version of NodeJS. No `npm install` needed.
 
 ```bash
 # Local backend running on :8080
-node seed.js
+node seed.mjs
 
 # Local backend on a different port
-node seed.js --url http://localhost:9021
+node seed.mjs --url http://localhost:9021
 
 # Staging via session token
 # Grab __Secure-authjs.session-token from browser DevTools → Application → Cookies
-node seed.js --url https://staging.genspectrum.org --session-token eyJhbG...
+node seed.mjs --url https://staging.genspectrum.org --session-token eyJhbG...
 
 # Prod
-node seed.js --url https://genspectrum.org --session-token eyJhbG...
+node seed.mjs --url https://genspectrum.org --session-token eyJhbG...
 ```
 
-Run `node seed.js --help` for all options.
+Run `node seed.mjs --help` for all options.

--- a/example-data/README.md
+++ b/example-data/README.md
@@ -1,0 +1,32 @@
+# example-data
+
+Seeds the backend with example collections (resistance mutation data for 3CLpro, RdRp, and Spike mAb).
+
+The script is idempotent — re-running it will skip collections that already exist.
+
+## Via Docker Compose (staging)
+
+```bash
+BACKEND_TAG=latest WEBSITE_TAG=latest docker compose --profile staging up
+```
+
+## Running locally by hand
+
+Requires Node 18+. No `npm install` needed.
+
+```bash
+# Local backend running on :8080
+node seed.js
+
+# Local backend on a different port
+node seed.js --url http://localhost:9021
+
+# Staging via session token
+# Grab __Secure-authjs.session-token from browser DevTools → Application → Cookies
+node seed.js --url https://staging.genspectrum.org --session-token eyJhbG...
+
+# Prod
+node seed.js --url https://genspectrum.org --session-token eyJhbG...
+```
+
+Run `node seed.js --help` for all options.

--- a/example-data/README.md
+++ b/example-data/README.md
@@ -9,7 +9,7 @@ The script is idempotent — re-running it will skip collections that already ex
 The seeder runs automatically as part of Docker Compose:
 
 ```bash
-BACKEND_TAG=latest WEBSITE_TAG=latest docker compose up
+BACKEND_TAG=latest WEBSITE_TAG=latest SEEDER_TAG=latest docker compose up
 ```
 
 ## Running locally by hand
@@ -22,13 +22,6 @@ node seed.mjs
 
 # Local backend on a different port
 node seed.mjs --url http://localhost:9021
-
-# Staging via session token
-# Grab __Secure-authjs.session-token from browser DevTools → Application → Cookies
-node seed.mjs --url https://staging.genspectrum.org --session-token eyJhbG...
-
-# Prod
-node seed.mjs --url https://genspectrum.org --session-token eyJhbG...
 ```
 
 Run `node seed.mjs --help` for all options.

--- a/example-data/seed.js
+++ b/example-data/seed.js
@@ -1,13 +1,82 @@
 #!/usr/bin/env node
 // Seeds example collections into the backend.
-// Only runs when DASHBOARDS_ENVIRONMENT=dashboards-staging.
 // Idempotent: skips any collection whose name already exists for the seed user.
+//
+// Run with --help for usage.
 
-const BACKEND_URL = process.env.BACKEND_URL ?? 'http://backend:8080';
-const SEED_USER_ID = process.env.SEED_USER_ID ?? 'example-data-seeder';
+import { parseArgs } from 'node:util';
+
+const HELP = `\
+Usage: node seed.js [options]
+
+Options:
+  -u, --url <url>              Backend base URL (default: $BACKEND_URL or http://localhost:8080)
+      --user-id <id>           User ID for direct backend access (default: $SEED_USER_ID or example-data-seeder)
+  -t, --session-token <token>  Session token for staging/prod (uses website proxy, injects user from session)
+      --wait                   Retry until backend is ready (auto-enabled when no TTY)
+  -h, --help                   Show this help
+
+Examples:
+  # Local backend running on :8080
+  node seed.js
+
+  # Local backend on a different port
+  node seed.js --url http://localhost:9021
+
+  # Staging via session token (grab __Secure-authjs.session-token from browser DevTools → Application → Cookies)
+  node seed.js --url https://staging.genspectrum.org --session-token eyJhbG...
+
+  # Prod
+  node seed.js --url https://genspectrum.org --session-token eyJhbG...
+`;
+
+let parsedArgs;
+try {
+    parsedArgs = parseArgs({
+        options: {
+            url:            { type: 'string',  short: 'u' },
+            'user-id':      { type: 'string' },
+            'session-token':{ type: 'string',  short: 't' },
+            wait:           { type: 'boolean' },
+            help:           { type: 'boolean', short: 'h' },
+        },
+    });
+} catch (err) {
+    console.error(`Error: ${err.message}\n`);
+    console.error(HELP);
+    process.exit(1);
+}
+
+const { values } = parsedArgs;
+
+if (values.help) {
+    console.log(HELP);
+    process.exit(0);
+}
+
+const BACKEND_URL   = values.url            ?? process.env.BACKEND_URL   ?? 'http://localhost:8080';
+const SEED_USER_ID  = values['user-id']     ?? process.env.SEED_USER_ID  ?? 'example-data-seeder';
+const SESSION_TOKEN = values['session-token'] ?? null;
+// Auto-enable wait when there's no TTY (e.g. running inside Docker).
+const WAIT          = values.wait ?? !process.stdout.isTTY;
 
 const RETRY_ATTEMPTS = 30;
 const RETRY_DELAY_MS = 2000;
+
+// When a session token is provided we go through the website proxy at /api/collections,
+// which resolves the user from the session. The cookie name differs by scheme.
+const USE_SESSION_AUTH = SESSION_TOKEN !== null;
+const COLLECTIONS_BASE = USE_SESSION_AUTH
+    ? `${BACKEND_URL}/api/collections`
+    : `${BACKEND_URL}/collections`;
+
+function authHeaders() {
+    if (!USE_SESSION_AUTH) return {};
+    const cookieName = BACKEND_URL.startsWith('https://')
+        ? '__Secure-authjs.session-token'
+        : 'authjs.session-token';
+    return { Cookie: `${cookieName}=${SESSION_TOKEN}` };
+}
 
 // Converts a genomic mutation code to a mature protein name with the given offset.
 // e.g. matureName("ORF1a:T3284I", "3CLpro", -3263) => "3CLpro:T21I"
@@ -133,10 +202,11 @@ async function sleep(ms) {
 async function waitForBackend() {
     for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
         try {
-            const response = await fetch(`${BACKEND_URL}/collections?userId=${SEED_USER_ID}&organism=covid`);
-            if (response.ok || response.status === 404) {
-                return;
-            }
+            const response = await fetch(
+                `${BACKEND_URL}/collections?userId=${SEED_USER_ID}&organism=covid`,
+                { headers: authHeaders() },
+            );
+            if (response.ok || response.status === 404) return;
         } catch {
             // backend not ready yet
         }
@@ -148,9 +218,10 @@ async function waitForBackend() {
 }
 
 async function fetchExistingCollections(organism) {
-    const response = await fetch(
-        `${BACKEND_URL}/collections?userId=${encodeURIComponent(SEED_USER_ID)}&organism=${encodeURIComponent(organism)}`,
-    );
+    const url = USE_SESSION_AUTH
+        ? `${COLLECTIONS_BASE}?organism=${encodeURIComponent(organism)}`
+        : `${COLLECTIONS_BASE}?userId=${encodeURIComponent(SEED_USER_ID)}&organism=${encodeURIComponent(organism)}`;
+    const response = await fetch(url, { headers: authHeaders() });
     if (!response.ok) {
         throw new Error(`GET /collections failed: ${response.status} ${await response.text()}`);
     }
@@ -158,14 +229,14 @@ async function fetchExistingCollections(organism) {
 }
 
 async function createCollection(collection) {
-    const response = await fetch(
-        `${BACKEND_URL}/collections?userId=${encodeURIComponent(SEED_USER_ID)}`,
-        {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(collection),
-        },
-    );
+    const url = USE_SESSION_AUTH
+        ? COLLECTIONS_BASE
+        : `${COLLECTIONS_BASE}?userId=${encodeURIComponent(SEED_USER_ID)}`;
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify(collection),
+    });
     if (response.status !== 201) {
         throw new Error(`POST /collections failed: ${response.status} ${await response.text()}`);
     }
@@ -176,9 +247,15 @@ async function createCollection(collection) {
 // --- Main ---
 
 async function main() {
-    console.log(`Seeding example data against ${BACKEND_URL} as user '${SEED_USER_ID}'...`);
+    if (USE_SESSION_AUTH) {
+        console.log(`Seeding example data against ${BACKEND_URL} using session token...`);
+    } else {
+        console.log(`Seeding example data against ${BACKEND_URL} as user '${SEED_USER_ID}'...`);
+    }
 
-    await waitForBackend();
+    if (WAIT) {
+        await waitForBackend();
+    }
 
     // Group collections by organism to minimise GET requests
     const byOrganism = {};
@@ -212,9 +289,3 @@ main().catch((err) => {
     console.error(err);
     process.exit(1);
 });
-
-
-// TODO - it would be nice if we could run this as a utility script by hand,
-// can we add a readme on how we can do that? Also it should be possible to manually provide
-// an auth token, and run it agains the live staging environment, or even prod.
-// Maybe we can also have a proper commandline interface, but it's nice that so far we don't have dependencies.

--- a/example-data/seed.js
+++ b/example-data/seed.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+// Seeds example collections into the backend.
+// Only runs when DASHBOARDS_ENVIRONMENT=dashboards-staging.
+// Idempotent: skips any collection whose name already exists for the seed user.
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://backend:8080';
+const SEED_USER_ID = process.env.SEED_USER_ID ?? 'example-data-seeder';
+
+const RETRY_ATTEMPTS = 30;
+const RETRY_DELAY_MS = 2000;
+
+// Converts a genomic mutation code to a mature protein name with the given offset.
+// e.g. matureName("ORF1a:T3284I", "3CLpro", -3263) => "3CLpro:T21I"
+function matureName(mutation, setName, offset) {
+    const mutationPart = mutation.slice(mutation.indexOf(':') + 1);
+    const originalBase = mutationPart[0];
+    const newBase = mutationPart[mutationPart.length - 1];
+    const position = parseInt(mutationPart.match(/\d+/)[0], 10);
+    return `${setName}:${originalBase}${position + offset}${newBase}`;
+}
+
+function buildVariants(mutations, setName, offset) {
+    return mutations.map((mutation) => ({
+        type: 'filterObject',
+        name: matureName(mutation, setName, offset),
+        filterObject: { aminoAcidMutations: [mutation] },
+    }));
+}
+
+// --- Collection definitions ---
+
+const CLPRO_MUTATIONS = [
+    'ORF1a:T3284I', 'ORF1a:T3288A', 'ORF1a:T3288N', 'ORF1a:T3308I', 'ORF1a:D3311Y',
+    'ORF1a:M3312I', 'ORF1a:M3312L', 'ORF1a:M3312T', 'ORF1a:M3312-', 'ORF1a:L3313F',
+    'ORF1a:G3401S', 'ORF1a:F3403L', 'ORF1a:F3403S', 'ORF1a:N3405D', 'ORF1a:N3405L',
+    'ORF1a:N3405S', 'ORF1a:G3406S', 'ORF1a:S3407A', 'ORF1a:S3407E', 'ORF1a:S3407L',
+    'ORF1a:S3407P', 'ORF1a:C3423F', 'ORF1a:M3428R', 'ORF1a:M3428T', 'ORF1a:E3429A',
+    'ORF1a:E3429G', 'ORF1a:E3429K', 'ORF1a:E3429Q', 'ORF1a:E3429V', 'ORF1a:L3430F',
+    'ORF1a:P3431-', 'ORF1a:T3432I', 'ORF1a:H3435L', 'ORF1a:H3435N', 'ORF1a:H3435Q',
+    'ORF1a:H3435Y', 'ORF1a:A3436T', 'ORF1a:A3436V', 'ORF1a:V3449A', 'ORF1a:R3451G',
+    'ORF1a:R3451S', 'ORF1a:Q3452I', 'ORF1a:Q3452K', 'ORF1a:T3453I', 'ORF1a:A3454T',
+    'ORF1a:A3454V', 'ORF1a:Q3455A', 'ORF1a:Q3455C', 'ORF1a:Q3455D', 'ORF1a:Q3455E',
+    'ORF1a:Q3455F', 'ORF1a:Q3455G', 'ORF1a:Q3455H', 'ORF1a:Q3455I', 'ORF1a:Q3455K',
+    'ORF1a:Q3455L', 'ORF1a:Q3455N', 'ORF1a:Q3455P', 'ORF1a:Q3455R', 'ORF1a:Q3455S',
+    'ORF1a:Q3455T', 'ORF1a:Q3455V', 'ORF1a:Q3455W', 'ORF1a:Q3455Y', 'ORF1a:A3456P',
+    'ORF1a:A3457S', 'ORF1a:P3515L', 'ORF1a:V3560A', 'ORF1a:S3564P', 'ORF1a:T3567I',
+    'ORF1a:F3568L',
+];
+
+const RDRP_MUTATIONS = [
+    'ORF1b:V157A', 'ORF1b:V157L', 'ORF1b:N189S', 'ORF1b:R276C', 'ORF1b:A367V',
+    'ORF1b:A440V', 'ORF1b:F471L', 'ORF1b:D475Y', 'ORF1b:A517V', 'ORF1b:V548L',
+    'ORF1b:G662S', 'ORF1b:S750A', 'ORF1b:V783I', 'ORF1b:E787G', 'ORF1b:C790F',
+    'ORF1b:C790R', 'ORF1b:E793A', 'ORF1b:E793D', 'ORF1b:M915R',
+];
+
+const SPIKE_MUTATIONS = [
+    'S:P337H', 'S:P337L', 'S:P337R', 'S:P337S', 'S:P337T',
+    'S:E340A', 'S:E340D', 'S:E340G', 'S:E340K', 'S:E340Q', 'S:E340V',
+    'S:T345P',
+    'S:R346G', 'S:R346I', 'S:R346K', 'S:R346S', 'S:R346T',
+    'S:K356Q', 'S:K356T',
+    'S:S371F', 'S:S371L',
+    'S:D405E', 'S:D405N', 'S:E406D',
+    'S:K417E', 'S:K417H', 'S:K417I', 'S:K417M', 'S:K417N', 'S:K417R', 'S:K417S', 'S:K417T',
+    'S:D420A', 'S:D420N',
+    'S:N439K',
+    'S:N440D', 'S:N440E', 'S:N440I', 'S:N440K', 'S:N440R', 'S:N440T', 'S:N440Y',
+    'S:S443Y',
+    'S:K444E', 'S:K444F', 'S:K444I', 'S:K444L', 'S:K444M', 'S:K444N', 'S:K444R', 'S:K444T',
+    'S:V445A', 'S:V445D', 'S:V445F', 'S:V445I', 'S:V445L',
+    'S:G446A', 'S:G446D', 'S:G446I', 'S:G446N', 'S:G446R', 'S:G446S', 'S:G446T', 'S:G446V',
+    'S:G447C', 'S:G447D', 'S:G447F', 'S:G447S', 'S:G447V',
+    'S:N448D', 'S:N448K', 'S:N448T', 'S:N448Y',
+    'S:Y449D',
+    'S:N450D', 'S:N450K',
+    'S:L452M', 'S:L452Q', 'S:L452R', 'S:L452W',
+    'S:Y453F', 'S:Y453H',
+    'S:L455F', 'S:L455M', 'S:L455S', 'S:L455W',
+    'S:F456C', 'S:F456L', 'S:F456V',
+    'S:S459P',
+    'S:N460D', 'S:N460H', 'S:N460I', 'S:N460K', 'S:N460S', 'S:N460T', 'S:N460Y',
+    'S:A475D', 'S:A475V',
+    'S:G476D', 'S:G476R', 'S:G476T',
+    'S:V483A',
+    'S:E484A', 'S:E484D', 'S:E484G', 'S:E484K', 'S:E484P', 'S:E484Q', 'S:E484R', 'S:E484S', 'S:E484T', 'S:E484V',
+    'S:G485D', 'S:G485R',
+    'S:F486D', 'S:F486I', 'S:F486L', 'S:F486N', 'S:F486P', 'S:F486S', 'S:F486T', 'S:F486V',
+    'S:N487D', 'S:N487H', 'S:N487S',
+    'S:Y489H', 'S:Y489W',
+    'S:F490G', 'S:F490I', 'S:F490L', 'S:F490R', 'S:F490S', 'S:F490V', 'S:F490Y',
+    'S:Q493D', 'S:Q493E', 'S:Q493H', 'S:Q493K', 'S:Q493L', 'S:Q493R', 'S:Q493V',
+    'S:S494P', 'S:S494R',
+    'S:G496S',
+    'S:Q498H',
+    'S:P499H', 'S:P499R', 'S:P499S', 'S:P499T',
+    'S:N501T', 'S:N501Y',
+    'S:G504C', 'S:G504D', 'S:G504I', 'S:G504L', 'S:G504N', 'S:G504R', 'S:G504V',
+    'S:P507A',
+    'S:N856K', 'S:N969K', 'S:E990A', 'S:T1009I',
+];
+
+const COLLECTIONS = [
+    {
+        name: '3CLpro resistance mutations',
+        organism: 'covid',
+        description:
+            'SARS-CoV-2 3C-like protease (3CLpro/Mpro) inhibitor resistance mutations as per Stanford Coronavirus Antiviral & Resistance database (last updated 21 August 2024).',
+        variants: buildVariants(CLPRO_MUTATIONS, '3CLpro', -3263),
+    },
+    {
+        name: 'RdRp resistance mutations',
+        organism: 'covid',
+        description:
+            'SARS-CoV-2 RNA-dependent RNA polymerase (RdRp) inhibitor resistance mutations as per Stanford Coronavirus Antiviral & Resistance database (last updated 21 August 2024).',
+        variants: buildVariants(RDRP_MUTATIONS, 'RdRp', 9),
+    },
+    {
+        name: 'Spike mAb resistance mutations',
+        organism: 'covid',
+        description:
+            'SARS-CoV-2 Spike monoclonal antibody (mAb) resistance mutations as per Stanford Coronavirus Antiviral & Resistance database (last updated 21 August 2024).',
+        variants: buildVariants(SPIKE_MUTATIONS, 'Spike', 0),
+    },
+];
+
+// --- API helpers ---
+
+async function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForBackend() {
+    for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+        try {
+            const response = await fetch(`${BACKEND_URL}/collections?userId=${SEED_USER_ID}&organism=covid`);
+            if (response.ok || response.status === 404) {
+                return;
+            }
+        } catch {
+            // backend not ready yet
+        }
+        console.log(`Waiting for backend... (attempt ${attempt}/${RETRY_ATTEMPTS})`);
+        await sleep(RETRY_DELAY_MS);
+    }
+    console.error(`Backend at ${BACKEND_URL} did not become ready after ${RETRY_ATTEMPTS} attempts.`);
+    process.exit(1);
+}
+
+async function fetchExistingCollections(organism) {
+    const response = await fetch(
+        `${BACKEND_URL}/collections?userId=${encodeURIComponent(SEED_USER_ID)}&organism=${encodeURIComponent(organism)}`,
+    );
+    if (!response.ok) {
+        throw new Error(`GET /collections failed: ${response.status} ${await response.text()}`);
+    }
+    return response.json();
+}
+
+async function createCollection(collection) {
+    const response = await fetch(
+        `${BACKEND_URL}/collections?userId=${encodeURIComponent(SEED_USER_ID)}`,
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(collection),
+        },
+    );
+    if (response.status !== 201) {
+        throw new Error(`POST /collections failed: ${response.status} ${await response.text()}`);
+    }
+    const created = await response.json();
+    return created.id;
+}
+
+// --- Main ---
+
+async function main() {
+    console.log(`Seeding example data against ${BACKEND_URL} as user '${SEED_USER_ID}'...`);
+
+    await waitForBackend();
+
+    // Group collections by organism to minimise GET requests
+    const byOrganism = {};
+    for (const collection of COLLECTIONS) {
+        (byOrganism[collection.organism] ??= []).push(collection);
+    }
+
+    let created = 0;
+    let skipped = 0;
+
+    for (const [organism, collections] of Object.entries(byOrganism)) {
+        const existing = await fetchExistingCollections(organism);
+        const existingNames = new Set(existing.map((c) => c.name));
+
+        for (const collection of collections) {
+            if (existingNames.has(collection.name)) {
+                console.log(`  SKIP  ${collection.name}`);
+                skipped++;
+            } else {
+                const id = await createCollection(collection);
+                console.log(`  OK    id=${id}  ${collection.name}`);
+                created++;
+            }
+        }
+    }
+
+    console.log(`\nDone. Created: ${created}, skipped (already exist): ${skipped}.`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});
+
+
+// TODO - it would be nice if we could run this as a utility script by hand,
+// can we add a readme on how we can do that? Also it should be possible to manually provide
+// an auth token, and run it agains the live staging environment, or even prod.
+// Maybe we can also have a proper commandline interface, but it's nice that so far we don't have dependencies.

--- a/example-data/seed.mjs
+++ b/example-data/seed.mjs
@@ -10,11 +10,10 @@ const HELP = `\
 Usage: node seed.mjs [options]
 
 Options:
-  -u, --url <url>              Backend base URL (default: $BACKEND_URL or http://localhost:8080)
-      --user-id <id>           User ID for direct backend access (default: $SEED_USER_ID or example-data-seeder)
-  -t, --session-token <token>  Session token for staging/prod (uses website proxy, injects user from session)
-      --wait                   Retry until backend is ready (auto-enabled when no TTY)
-  -h, --help                   Show this help
+  -u, --url <url>    Backend base URL (default: $BACKEND_URL or http://localhost:8080)
+      --user-id <id> User ID (default: $SEED_USER_ID or example-data-seeder)
+      --wait         Retry until backend is ready (auto-enabled when no TTY)
+  -h, --help         Show this help
 
 Examples:
   # Local backend running on :8080
@@ -22,23 +21,16 @@ Examples:
 
   # Local backend on a different port
   node seed.mjs --url http://localhost:9021
-
-  # Staging via session token (grab __Secure-authjs.session-token from browser DevTools → Application → Cookies)
-  node seed.mjs --url https://staging.genspectrum.org --session-token eyJhbG...
-
-  # Prod
-  node seed.mjs --url https://genspectrum.org --session-token eyJhbG...
 `;
 
 let parsedArgs;
 try {
     parsedArgs = parseArgs({
         options: {
-            url:            { type: 'string',  short: 'u' },
-            'user-id':      { type: 'string' },
-            'session-token':{ type: 'string',  short: 't' },
-            wait:           { type: 'boolean' },
-            help:           { type: 'boolean', short: 'h' },
+            url:       { type: 'string',  short: 'u' },
+            'user-id': { type: 'string' },
+            wait:      { type: 'boolean' },
+            help:      { type: 'boolean', short: 'h' },
         },
     });
 } catch (err) {
@@ -54,29 +46,14 @@ if (values.help) {
     process.exit(0);
 }
 
-const BACKEND_URL   = values.url            ?? process.env.BACKEND_URL   ?? 'http://localhost:8080';
-const SEED_USER_ID  = values['user-id']     ?? process.env.SEED_USER_ID  ?? 'example-data-seeder';
-const SESSION_TOKEN = values['session-token'] ?? null;
+const BACKEND_URL  = values.url        ?? process.env.BACKEND_URL  ?? 'http://localhost:8080';
+const SEED_USER_ID = values['user-id'] ?? process.env.SEED_USER_ID ?? 'example-data-seeder';
 // Auto-enable wait when there's no TTY (e.g. running inside Docker).
-const WAIT          = values.wait ?? !process.stdout.isTTY;
+const WAIT         = values.wait ?? !process.stdout.isTTY;
 
-const RETRY_ATTEMPTS = 30;
-const RETRY_DELAY_MS = 2000;
-
-// When a session token is provided we go through the website proxy at /api/collections,
-// which resolves the user from the session. The cookie name differs by scheme.
-const USE_SESSION_AUTH = SESSION_TOKEN !== null;
-const COLLECTIONS_BASE = USE_SESSION_AUTH
-    ? `${BACKEND_URL}/api/collections`
-    : `${BACKEND_URL}/collections`;
-
-function authHeaders() {
-    if (!USE_SESSION_AUTH) return {};
-    const cookieName = BACKEND_URL.startsWith('https://')
-        ? '__Secure-authjs.session-token'
-        : 'authjs.session-token';
-    return { Cookie: `${cookieName}=${SESSION_TOKEN}` };
-}
+const RETRY_ATTEMPTS   = 30;
+const RETRY_DELAY_MS   = 2000;
+const COLLECTIONS_BASE = `${BACKEND_URL}/collections`;
 
 // Converts a genomic mutation code to a mature protein name with the given offset.
 // e.g. matureName("ORF1a:T3284I", "3CLpro", -3263) => "3CLpro:T21I"
@@ -204,7 +181,6 @@ async function waitForBackend() {
         try {
             const response = await fetch(
                 `${BACKEND_URL}/collections?userId=${SEED_USER_ID}&organism=covid`,
-                { headers: authHeaders() },
             );
             if (response.ok || response.status === 404) return;
         } catch {
@@ -218,10 +194,8 @@ async function waitForBackend() {
 }
 
 async function fetchExistingCollections(organism) {
-    const url = USE_SESSION_AUTH
-        ? `${COLLECTIONS_BASE}?organism=${encodeURIComponent(organism)}`
-        : `${COLLECTIONS_BASE}?userId=${encodeURIComponent(SEED_USER_ID)}&organism=${encodeURIComponent(organism)}`;
-    const response = await fetch(url, { headers: authHeaders() });
+    const url = `${COLLECTIONS_BASE}?userId=${encodeURIComponent(SEED_USER_ID)}&organism=${encodeURIComponent(organism)}`;
+    const response = await fetch(url);
     if (!response.ok) {
         throw new Error(`GET /collections failed: ${response.status} ${await response.text()}`);
     }
@@ -229,12 +203,10 @@ async function fetchExistingCollections(organism) {
 }
 
 async function createCollection(collection) {
-    const url = USE_SESSION_AUTH
-        ? COLLECTIONS_BASE
-        : `${COLLECTIONS_BASE}?userId=${encodeURIComponent(SEED_USER_ID)}`;
+    const url = `${COLLECTIONS_BASE}?userId=${encodeURIComponent(SEED_USER_ID)}`;
     const response = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(collection),
     });
     if (response.status !== 201) {
@@ -247,11 +219,7 @@ async function createCollection(collection) {
 // --- Main ---
 
 async function main() {
-    if (USE_SESSION_AUTH) {
-        console.log(`Seeding example data against ${BACKEND_URL} using session token...`);
-    } else {
-        console.log(`Seeding example data against ${BACKEND_URL} as user '${SEED_USER_ID}'...`);
-    }
+    console.log(`Seeding example data against ${BACKEND_URL} as user '${SEED_USER_ID}'...`);
 
     if (WAIT) {
         await waitForBackend();
@@ -285,7 +253,9 @@ async function main() {
     console.log(`\nDone. Created: ${created}, skipped (already exist): ${skipped}.`);
 }
 
-main().catch((err) => {
+try {
+    await main();
+} catch (err) {
     console.error(err);
     process.exit(1);
-});
+}

--- a/example-data/seed.mjs
+++ b/example-data/seed.mjs
@@ -7,7 +7,7 @@
 import { parseArgs } from 'node:util';
 
 const HELP = `\
-Usage: node seed.js [options]
+Usage: node seed.mjs [options]
 
 Options:
   -u, --url <url>              Backend base URL (default: $BACKEND_URL or http://localhost:8080)
@@ -18,16 +18,16 @@ Options:
 
 Examples:
   # Local backend running on :8080
-  node seed.js
+  node seed.mjs
 
   # Local backend on a different port
-  node seed.js --url http://localhost:9021
+  node seed.mjs --url http://localhost:9021
 
   # Staging via session token (grab __Secure-authjs.session-token from browser DevTools → Application → Cookies)
-  node seed.js --url https://staging.genspectrum.org --session-token eyJhbG...
+  node seed.mjs --url https://staging.genspectrum.org --session-token eyJhbG...
 
   # Prod
-  node seed.js --url https://genspectrum.org --session-token eyJhbG...
+  node seed.mjs --url https://genspectrum.org --session-token eyJhbG...
 `;
 
 let parsedArgs;


### PR DESCRIPTION
## Summary

- Adds `example-data/` with a Node.js seeder script and Dockerfile that create resistance mutation collections (3CLpro, RdRp, Spike mAb) in the backend
- Seeder runs as a Docker Compose service activated via `--profile staging` — does nothing in normal `docker compose up`
- Idempotent: checks existing collections by name before creating, so re-runs are safe
- No npm dependencies — uses Node 22 built-in `fetch` and `util.parseArgs`
- Persists Postgres data in a named Docker volume across restarts

## CLI usage

The script can also be run by hand against any environment:

```bash
# Local backend
node example-data/seed.js

# Staging or prod via session token (grab __Secure-authjs.session-token from browser DevTools → Application → Cookies)
node example-data/seed.js --url https://staging.genspectrum.org --session-token eyJhbG...

node example-data/seed.js --help  # full options
```

## Docker Compose usage

```bash
BACKEND_TAG=latest WEBSITE_TAG=latest docker compose --profile staging up
```

Note: always pass `--profile staging` to both `up` and `down`, otherwise the seeder container is not included in teardown and may leave stale state.

## Test plan

- [x] `node example-data/seed.js --help` — prints usage, exits 0
- [x] Run with `--profile staging` — seeder starts, waits for backend, creates 3 collections, exits 0
- [x] Run again — all 3 collections are skipped (idempotent)
- [x] Run without `--profile staging` — seeder service does not start
- [x] `docker compose --profile staging down` then `up` — Postgres data is preserved
- [x] Verify via `GET /collections?userId=example-data-seeder&organism=covid`
- [x] Try running the script with a session cookie against staging and see if it still works (maybe modified collection names)

Felix 🤝 🤖 [Claude Code](https://claude.com/claude-code)
