### PR TITLE
feat(website): allow restricting which fields are allowed to be referenced in the AdvancedQueryFilter

### DIFF
--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -105,21 +105,88 @@ describe('AdvancedQueryFilter', () => {
         await expect.element(getByTitle('Validating')).toBeVisible();
     });
 
-    // TODO: allowedFields - shows error when query references a disallowed metadata field
-    //   - mock a successful parse returning e.g. { type: 'StringEquals', column: 'host', value: 'Human' }
-    //   - render with allowedFields={['nextcladePangoLineage']}
-    //   - assert error icon is shown and message contains the disallowed field name and the allowed list
-    //   - assert onInput was NOT called
+    it('allowedFields - shows error when query references a disallowed metadata field', async ({ routeMockers }) => {
+        const onInput = vi.fn();
 
-    // TODO: allowedFields - does not show error when all referenced fields are in the allowed list
-    //   - mock a successful parse returning a Lineage filter on 'nextcladePangoLineage'
-    //   - render with allowedFields={['nextcladePangoLineage']}
-    //   - assert checkmark is shown and onInput was called with the query
+        routeMockers.lapis.mockPostQueryParse(
+            { queries: ['host:Human'], doFullValidation: true },
+            { data: [{ type: 'success', filter: { type: 'StringEquals', column: 'host', value: 'Human' } }] },
+        );
 
-    // TODO: allowedFields - mutation-only query passes even with a restrictive allowedFields list
-    //   - mock a successful parse returning e.g. { type: 'NucleotideEquals', position: 123, symbol: 'A' }
-    //   - render with allowedFields={['nextcladePangoLineage']}
-    //   - assert checkmark is shown (no metadata columns referenced, so nothing to block)
+        const { getByRole, getByLabelText, getByText } = render(
+            <AdvancedQueryFilterWithProvider
+                onInput={onInput}
+                enabled
+                lapisUrl={DUMMY_LAPIS_URL}
+                allowedFields={['nextcladePangoLineage']}
+            />,
+        );
+
+        await userEvent.type(getByRole('textbox'), 'host:Human');
+
+        await expect.element(getByLabelText('Error')).toBeVisible();
+        await expect.element(getByText(/"host"/)).toBeVisible();
+        await expect.element(getByText(/nextcladePangoLineage/)).toBeVisible();
+        expect(onInput).not.toHaveBeenCalled();
+    });
+
+    it('allowedFields - does not show error when all referenced fields are in the allowed list', async ({
+        routeMockers,
+    }) => {
+        const onInput = vi.fn();
+
+        routeMockers.lapis.mockPostQueryParse(
+            { queries: ['BA.1*'], doFullValidation: true },
+            {
+                data: [
+                    {
+                        type: 'success',
+                        filter: {
+                            type: 'Lineage',
+                            column: 'nextcladePangoLineage',
+                            value: 'BA.1',
+                            includeSublineages: true,
+                        },
+                    },
+                ],
+            },
+        );
+
+        const { getByRole, getByTitle } = render(
+            <AdvancedQueryFilterWithProvider
+                onInput={onInput}
+                enabled
+                lapisUrl={DUMMY_LAPIS_URL}
+                allowedFields={['nextcladePangoLineage']}
+            />,
+        );
+
+        await userEvent.type(getByRole('textbox'), 'BA.1*');
+
+        await expect.element(getByTitle('Advanced query is valid')).toBeVisible();
+        await expect.poll(() => onInput).toHaveBeenCalledWith('BA.1*');
+    });
+
+    it('allowedFields - mutation-only query passes even with a restrictive allowedFields list', async ({
+        routeMockers,
+    }) => {
+        routeMockers.lapis.mockPostQueryParse(
+            { queries: ['A123T'], doFullValidation: true },
+            { data: [{ type: 'success', filter: { type: 'NucleotideEquals', position: 123, symbol: 'A' } }] },
+        );
+
+        const { getByRole, getByTitle } = render(
+            <AdvancedQueryFilterWithProvider
+                enabled
+                lapisUrl={DUMMY_LAPIS_URL}
+                allowedFields={['nextcladePangoLineage']}
+            />,
+        );
+
+        await userEvent.type(getByRole('textbox'), 'A123T');
+
+        await expect.element(getByTitle('Advanced query is valid')).toBeVisible();
+    });
 
     it('shows error icon with network error tooltip when LAPIS is unreachable', async ({ routeMockers }) => {
         routeMockers.lapis.mockLapisDown();

--- a/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.browser.spec.tsx
@@ -105,6 +105,22 @@ describe('AdvancedQueryFilter', () => {
         await expect.element(getByTitle('Validating')).toBeVisible();
     });
 
+    // TODO: allowedFields - shows error when query references a disallowed metadata field
+    //   - mock a successful parse returning e.g. { type: 'StringEquals', column: 'host', value: 'Human' }
+    //   - render with allowedFields={['nextcladePangoLineage']}
+    //   - assert error icon is shown and message contains the disallowed field name and the allowed list
+    //   - assert onInput was NOT called
+
+    // TODO: allowedFields - does not show error when all referenced fields are in the allowed list
+    //   - mock a successful parse returning a Lineage filter on 'nextcladePangoLineage'
+    //   - render with allowedFields={['nextcladePangoLineage']}
+    //   - assert checkmark is shown and onInput was called with the query
+
+    // TODO: allowedFields - mutation-only query passes even with a restrictive allowedFields list
+    //   - mock a successful parse returning e.g. { type: 'NucleotideEquals', position: 123, symbol: 'A' }
+    //   - render with allowedFields={['nextcladePangoLineage']}
+    //   - assert checkmark is shown (no metadata columns referenced, so nothing to block)
+
     it('shows error icon with network error tooltip when LAPIS is unreachable', async ({ routeMockers }) => {
         routeMockers.lapis.mockLapisDown();
 

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -49,7 +49,7 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({
             const result = results[0];
             if (result.type === 'success') {
                 if (allowedFields !== undefined) {
-                    const usedFields = extractMetadataFields(result.filter);
+                    const usedFields = [...new Set(extractMetadataFields(result.filter))];
                     const disallowed = usedFields.filter((col) => !allowedFields.includes(col));
                     if (disallowed.length > 0) {
                         const listed = disallowed.map((col) => `"${col}"`).join(', ');

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -37,7 +37,7 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({
     enabled,
     lapisUrl,
     errorTooltipClass,
-    allowedFields
+    allowedFields,
 }) => {
     const [inputValue, setInputValue] = useState(value);
     const [validationState, setValidationState] = useState<ValidationState>({ type: 'idle' });

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -3,6 +3,7 @@ import { type FC, type InputEvent, useEffect, useRef, useState } from 'react';
 
 import { getClientLogger } from '../../clientLogger.ts';
 import { parseQuery } from '../../lapis/parseQuery.ts';
+import { extractMetadataFields } from '../../lapis/siloFilterExpression.ts';
 
 const logger = getClientLogger('AdvancedQueryFilter');
 
@@ -27,6 +28,7 @@ type AdvancedQueryFilterProps = {
      * Responsive variants are also valid, e.g. `'tooltip-left lg:tooltip-right'`.
      */
     errorTooltipClass?: string;
+    allowedFields?: string[];
 };
 
 export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({
@@ -35,6 +37,7 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({
     enabled,
     lapisUrl,
     errorTooltipClass,
+    allowedFields
 }) => {
     const [inputValue, setInputValue] = useState(value);
     const [validationState, setValidationState] = useState<ValidationState>({ type: 'idle' });
@@ -45,6 +48,18 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({
         onSuccess: (results, query) => {
             const result = results[0];
             if (result.type === 'success') {
+                if (allowedFields !== undefined) {
+                    const usedFields = extractMetadataFields(result.filter);
+                    const disallowed = usedFields.filter((col) => !allowedFields.includes(col));
+                    if (disallowed.length > 0) {
+                        const listed = disallowed.map((col) => `"${col}"`).join(', ');
+                        setValidationState({
+                            type: 'error',
+                            message: `Field ${listed} is not allowed. Allowed fields: ${allowedFields.join(', ')}.`,
+                        });
+                        return;
+                    }
+                }
                 setValidationState({ type: 'valid' });
                 onInput?.(query);
             } else {

--- a/website/src/components/pageStateSelectors/BaselineSelector.tsx
+++ b/website/src/components/pageStateSelectors/BaselineSelector.tsx
@@ -34,6 +34,10 @@ export type NumberRangeFilterConfig = {
     sliderStep?: number;
 };
 
+export type AdvancedQueryFilterConfig = {
+    allowedFields?: string[];
+};
+
 export type BaselineFilterConfig =
     | ({
           type: 'date';
@@ -41,7 +45,7 @@ export type BaselineFilterConfig =
     | ({ type: 'text' } & TextInputConfig)
     | ({ type: 'location' } & LocationFilterConfig)
     | ({ type: 'number' } & NumberRangeFilterConfig)
-    | { type: 'advancedQuery' };
+    | ({ type: 'advancedQuery' } & AdvancedQueryFilterConfig);
 
 export function BaselineSelector({
     baselineFilterConfigs,
@@ -177,6 +181,7 @@ export function BaselineSelector({
                                 value={datasetFilter.advancedQuery ?? ''}
                                 enabled={enableAdvancedQueryFilter}
                                 lapisUrl={lapisUrl}
+                                allowedFields={config.allowedFields}
                             />
                         );
                     }

--- a/website/src/lapis/siloFilterExpression.spec.ts
+++ b/website/src/lapis/siloFilterExpression.spec.ts
@@ -255,7 +255,7 @@ describe('extractMetadataFields', () => {
     });
 
     test('returns no columns for mutation-only expressions', () => {
-        const expr: Parameters<typeof extractMetadataFields>[0] = {
+        const expr: SiloFilterExpression = {
             type: 'And',
             children: [
                 { type: 'NucleotideEquals', position: 123, symbol: 'A' },

--- a/website/src/lapis/siloFilterExpression.spec.ts
+++ b/website/src/lapis/siloFilterExpression.spec.ts
@@ -229,6 +229,7 @@ describe('siloFilterExpressionSchema', () => {
 
         expect(result.success).toBe(false);
     });
+});
 
 describe('extractMetadataFields', () => {
     test('extracts column names from nested And/Or expressions', () => {

--- a/website/src/lapis/siloFilterExpression.spec.ts
+++ b/website/src/lapis/siloFilterExpression.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { SiloFilterExpression, extractMetadataFields, siloFilterExpressionSchema } from './siloFilterExpression.ts';
+import { type SiloFilterExpression, extractMetadataFields, siloFilterExpressionSchema } from './siloFilterExpression.ts';
 
 describe('siloFilterExpressionSchema', () => {
     test('should parse StringEquals', () => {

--- a/website/src/lapis/siloFilterExpression.spec.ts
+++ b/website/src/lapis/siloFilterExpression.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest';
 
-import { type SiloFilterExpression, extractMetadataFields, siloFilterExpressionSchema } from './siloFilterExpression.ts';
+import {
+    type SiloFilterExpression,
+    extractMetadataFields,
+    siloFilterExpressionSchema,
+} from './siloFilterExpression.ts';
 
 describe('siloFilterExpressionSchema', () => {
     test('should parse StringEquals', () => {

--- a/website/src/lapis/siloFilterExpression.spec.ts
+++ b/website/src/lapis/siloFilterExpression.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { siloFilterExpressionSchema } from './siloFilterExpression.ts';
+import { SiloFilterExpression, extractMetadataFields, siloFilterExpressionSchema } from './siloFilterExpression.ts';
 
 describe('siloFilterExpressionSchema', () => {
     test('should parse StringEquals', () => {
@@ -230,6 +230,39 @@ describe('siloFilterExpressionSchema', () => {
         expect(result.success).toBe(false);
     });
 
+describe('extractMetadataFields', () => {
+    test('extracts column names from nested And/Or expressions', () => {
+        const expr: SiloFilterExpression = {
+            type: 'And',
+            children: [
+                { type: 'Lineage', column: 'nextcladePangoLineage', value: 'BA.1', includeSublineages: true },
+                {
+                    type: 'Or',
+                    children: [
+                        { type: 'StringEquals', column: 'country', value: 'Germany' },
+                        { type: 'DateBetween', column: 'date', from: '2024-01-01', to: null },
+                    ],
+                },
+            ],
+        };
+
+        expect(extractMetadataFields(expr)).toEqual(['nextcladePangoLineage', 'country', 'date']);
+    });
+
+    test('returns no columns for mutation-only expressions', () => {
+        const expr: Parameters<typeof extractMetadataFields>[0] = {
+            type: 'And',
+            children: [
+                { type: 'NucleotideEquals', position: 123, symbol: 'A' },
+                { type: 'HasAminoAcidMutation', sequenceName: 'S', position: 501 },
+            ],
+        };
+
+        expect(extractMetadataFields(expr)).toEqual([]);
+    });
+});
+
+describe('siloFilterExpressionSchema (parse)', () => {
     test('should accept nullable values', () => {
         const data = {
             type: 'StringEquals',

--- a/website/src/lapis/siloFilterExpression.ts
+++ b/website/src/lapis/siloFilterExpression.ts
@@ -166,6 +166,35 @@ const nOfSchema: z.ZodType<{
     }),
 );
 
+/**
+ * Given an expression, returns a list of all the metadata fields that are referenced
+ * in the expression.
+ */
+export function extractMetadataFields(expr: SiloFilterExpression): string[] {
+    switch (expr.type) {
+        case 'StringEquals':
+        case 'BooleanEquals':
+        case 'Lineage':
+        case 'DateBetween':
+        case 'IntEquals':
+        case 'IntBetween':
+        case 'FloatEquals':
+        case 'FloatBetween':
+        case 'StringSearch':
+        case 'PhyloDescendantOf':
+            return [expr.column];
+        case 'And':
+        case 'Or':
+        case 'N-Of':
+            return expr.children.flatMap(extractMetadataFields);
+        case 'Not':
+        case 'Maybe':
+            return extractMetadataFields(expr.child);
+        default:
+            return [];
+    }
+}
+
 // Combined union for all SiloFilterExpression types.
 // This schema was initially LLM generated from the LAPIS code.
 export const siloFilterExpressionSchema = z.union([


### PR DESCRIPTION
resolves #1157, #1194

## Summary

Adds an optional `allowedFields` config to the `advancedQuery` baseline filter. When set, the parsed LAPIS expression is walked client-side after successful validation, and any metadata column not in the allowed list causes an error with an informative message. Mutation-only queries (e.g. `A123T`) always pass regardless of `allowedFields`, since they reference sequence positions rather than metadata columns.

- New `AdvancedQueryFilterConfig` type exported from `BaselineSelector.tsx` with optional `allowedFields?: string[]`
- `AdvancedQueryFilter` component accepts and enforces `allowedFields` in its `onSuccess` handler via `extractMetadataFields`
- New `extractMetadataFields` utility in `siloFilterExpression.ts` recursively collects all `column` values from a `SiloFilterExpression` tree
- Three browser spec tests covering: disallowed field → error, allowed field → checkmark + callback, mutation-only → checkmark

The feature is fully opt-in: omitting `allowedFields` preserves existing behaviour (any field is allowed).

## Test plan

- [x] `extractMetadataFields` unit tests in `siloFilterExpression.spec.ts`
- [x] Browser spec tests for the three `allowedFields` scenarios in `AdvancedQueryFilter.browser.spec.tsx`
- [x] Manually tested by temporarily setting `allowedFields: ['host']` on the COVID baseline config — queries on `host` passed, queries on other metadata fields showed the error, mutation queries passed

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.