### PR TITLE
chore(vscode): use workspace TypeScript to fix .ts import extension errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "website/node_modules/typescript/lib"
+}


### PR DESCRIPTION
## Summary

- Adds `.vscode/settings.json` pointing `typescript.tsdk` at `website/node_modules/typescript/lib`
- VS Code was using its bundled TypeScript, which doesn't honour `allowImportingTsExtensions` (set in the Astro base tsconfig) — causing false-positive `ts(5097)` errors on every `.ts` import path
