### PR TITLE
feat(website): replace plain textarea in VariantEditor with validated AdvancedQueryFilter

### DIFF
--- a/website/src/components/collections/form/CollectionForm.tsx
+++ b/website/src/components/collections/form/CollectionForm.tsx
@@ -115,6 +115,7 @@ export function CollectionForm({
                                 onRemove={removeVariant}
                                 canRemove={variants.length > 1}
                                 lineageFields={lineageFields}
+                                lapisUrl={lapisUrl}
                             />
                         ))}
                         <button type='button' className='btn btn-sm w-full' onClick={addVariant}>

--- a/website/src/components/collections/form/VariantEditor.browser.spec.tsx
+++ b/website/src/components/collections/form/VariantEditor.browser.spec.tsx
@@ -4,7 +4,10 @@ import { render } from 'vitest-browser-react';
 import { VariantEditor } from './VariantEditor.tsx';
 import { DUMMY_LAPIS_URL } from '../../../../routeMocker.ts';
 import { it } from '../../../../test-extend.ts';
+import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
 import type { VariantUpdate } from '../../../types/Collection.ts';
+
+const VariantEditorWithProvider = withQueryProvider(VariantEditor);
 
 const FILTER_VARIANT: VariantUpdate = { type: 'filterObject', name: 'JN.1*', filterObject: {} };
 const QUERY_VARIANT: VariantUpdate = {
@@ -18,7 +21,7 @@ describe('VariantEditor', () => {
         lapis.mockLapisDown();
 
         const { getByText } = render(
-            <VariantEditor
+            <VariantEditorWithProvider
                 index={0}
                 variant={FILTER_VARIANT}
                 onChange={vi.fn()}
@@ -37,7 +40,7 @@ describe('VariantEditor', () => {
         lapis.mockLapisDown();
 
         const { getByRole } = render(
-            <VariantEditor
+            <VariantEditorWithProvider
                 index={0}
                 variant={FILTER_VARIANT}
                 onChange={vi.fn()}
@@ -53,7 +56,7 @@ describe('VariantEditor', () => {
 
     itVitest('"Use advanced query" checkbox is checked for query variant', async () => {
         const { getByRole } = render(
-            <VariantEditor
+            <VariantEditorWithProvider
                 index={0}
                 variant={QUERY_VARIANT}
                 onChange={vi.fn()}
@@ -73,7 +76,7 @@ describe('VariantEditor', () => {
         const onChange = vi.fn();
 
         const { getByRole } = render(
-            <VariantEditor
+            <VariantEditorWithProvider
                 index={0}
                 variant={FILTER_VARIANT}
                 onChange={onChange}
@@ -93,7 +96,7 @@ describe('VariantEditor', () => {
         lapis.mockLapisDown();
 
         const { getByRole } = render(
-            <VariantEditor
+            <VariantEditorWithProvider
                 index={0}
                 variant={FILTER_VARIANT}
                 onChange={vi.fn()}
@@ -113,7 +116,7 @@ describe('VariantEditor', () => {
         const onRemove = vi.fn();
 
         const { getByRole } = render(
-            <VariantEditor
+            <VariantEditorWithProvider
                 index={2}
                 variant={FILTER_VARIANT}
                 onChange={vi.fn()}
@@ -133,7 +136,7 @@ describe('VariantEditor', () => {
         const onChange = vi.fn();
 
         const { getByPlaceholder } = render(
-            <VariantEditor
+            <VariantEditorWithProvider
                 index={0}
                 variant={QUERY_VARIANT}
                 onChange={onChange}

--- a/website/src/components/collections/form/VariantEditor.browser.spec.tsx
+++ b/website/src/components/collections/form/VariantEditor.browser.spec.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it as itVitest, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { VariantEditor } from './VariantEditor.tsx';
+import { DUMMY_LAPIS_URL } from '../../../../routeMocker.ts';
 import { it } from '../../../../test-extend.ts';
 import type { VariantUpdate } from '../../../types/Collection.ts';
 
@@ -24,6 +25,7 @@ describe('VariantEditor', () => {
                 onRemove={vi.fn()}
                 canRemove={false}
                 lineageFields={[]}
+                lapisUrl={DUMMY_LAPIS_URL}
             />,
         );
 
@@ -42,6 +44,7 @@ describe('VariantEditor', () => {
                 onRemove={vi.fn()}
                 canRemove={false}
                 lineageFields={[]}
+                lapisUrl={DUMMY_LAPIS_URL}
             />,
         );
 
@@ -57,6 +60,7 @@ describe('VariantEditor', () => {
                 onRemove={vi.fn()}
                 canRemove={false}
                 lineageFields={[]}
+                lapisUrl={DUMMY_LAPIS_URL}
             />,
         );
 
@@ -76,6 +80,7 @@ describe('VariantEditor', () => {
                 onRemove={vi.fn()}
                 canRemove={false}
                 lineageFields={[]}
+                lapisUrl={DUMMY_LAPIS_URL}
             />,
         );
 
@@ -95,6 +100,7 @@ describe('VariantEditor', () => {
                 onRemove={vi.fn()}
                 canRemove={true}
                 lineageFields={[]}
+                lapisUrl={DUMMY_LAPIS_URL}
             />,
         );
 
@@ -114,6 +120,7 @@ describe('VariantEditor', () => {
                 onRemove={onRemove}
                 canRemove={true}
                 lineageFields={[]}
+                lapisUrl={DUMMY_LAPIS_URL}
             />,
         );
 
@@ -133,6 +140,7 @@ describe('VariantEditor', () => {
                 onRemove={vi.fn()}
                 canRemove={false}
                 lineageFields={[]}
+                lapisUrl={DUMMY_LAPIS_URL}
             />,
         );
 

--- a/website/src/components/collections/form/VariantEditor.tsx
+++ b/website/src/components/collections/form/VariantEditor.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useRef } from 'react';
 
 import type { FilterObject, VariantUpdate } from '../../../types/Collection.ts';
+import { AdvancedQueryFilter } from '../../genspectrum/AdvancedQueryFilter.tsx';
 import { GsLineageFilter } from '../../genspectrum/GsLineageFilter.tsx';
 import { GsMutationFilter } from '../../genspectrum/GsMutationFilter.tsx';
 
@@ -11,6 +12,7 @@ type Props = {
     onRemove: (index: number) => void;
     canRemove?: boolean;
     lineageFields: string[];
+    lapisUrl: string;
 };
 
 // Memoized to prevent re-rendering all variant cards when only one changes in the parent list.
@@ -21,6 +23,7 @@ export const VariantEditor = memo(function VariantEditor({
     onRemove,
     canRemove = true,
     lineageFields,
+    lapisUrl,
 }: Props) {
     const variantRef = useRef(variant);
     variantRef.current = variant;
@@ -75,7 +78,13 @@ export const VariantEditor = memo(function VariantEditor({
 
             <div className='col-span-2 flex flex-col gap-4'>
                 {variant.type === 'query' ? (
-                    <QueryVariantFields variant={variant} onChange={(v) => onChange(index, v)} />
+                    <AdvancedQueryFilter
+                        enabled
+                        lapisUrl={lapisUrl}
+                        value={variant.countQuery}
+                        allowedFields={lineageFields.length > 0 ? lineageFields : undefined}
+                        onInput={(newValue) => onChange(index, { ...variant, countQuery: newValue ?? '' })}
+                    />
                 ) : (
                     <MutationListVariantFields
                         filterObject={variant.filterObject}
@@ -108,26 +117,6 @@ export const VariantEditor = memo(function VariantEditor({
         </div>
     );
 });
-
-function QueryVariantFields({
-    variant,
-    onChange,
-}: {
-    variant: Extract<VariantUpdate, { type: 'query' }>;
-    onChange: (v: VariantUpdate) => void;
-}) {
-    return (
-        <div className='flex flex-col'>
-            <label className='label'>Query</label>
-            <textarea
-                className='textarea textarea-bordered w-full max-w-xl font-mono text-sm'
-                placeholder='LAPIS filter expression for counting sequences matching this variant.'
-                value={variant.countQuery}
-                onChange={(e) => onChange({ ...variant, countQuery: e.currentTarget.value })}
-            />
-        </div>
-    );
-}
 
 // Memoized because GsMutationFilter is expensive to re-render. Relies on handleFilterObjectChange
 // being stable (via useCallback) in the parent — otherwise memo would have no effect.

--- a/website/src/components/collections/form/VariantEditor.tsx
+++ b/website/src/components/collections/form/VariantEditor.tsx
@@ -84,6 +84,7 @@ export const VariantEditor = memo(function VariantEditor({
                         value={variant.countQuery}
                         allowedFields={lineageFields.length > 0 ? lineageFields : undefined}
                         onInput={(newValue) => onChange(index, { ...variant, countQuery: newValue ?? '' })}
+                        errorTooltipClass='tooltip-top'
                     />
                 ) : (
                     <MutationListVariantFields


### PR DESCRIPTION
depends on #1195

## Summary

- Replaces the plain `<textarea>` in the collection variant editor's advanced query mode with the validated `AdvancedQueryFilter` component
- Restricts users to lineage fields only (using the existing `lineageFields` config, already passed to `VariantEditor`)
- No config changes needed — `lineageFields` doubles as the allowed fields list; when empty, no restriction is applied

## Test plan

- [x] Manually test: open the collection edit UI, enable "Use advanced query instead", type a lineage query (e.g. `BA.1*`) — should show checkmark
- [x] Type a query referencing a disallowed field (e.g. `host:Human`) — should show error with field name and allowed list
- [x] Type a mutation query (e.g. `A123T`) — should pass (no metadata columns referenced)
- [x] Existing `VariantEditor` browser spec tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)