### PR TITLE
feat(website): sync user with backend on login, use internal user ID

### DIFF
--- a/website/src/auth.ts
+++ b/website/src/auth.ts
@@ -1,9 +1,9 @@
 import { betterAuth } from 'better-auth';
 
-import { getGitHubClientId, getGitHubClientSecret, getTrustedOrigins } from './config';
+import { getBackendHost, getTrustedOrigins, getGitHubClientId, getGitHubClientSecret } from './config';
 import { getInstanceLogger } from './logger';
 
-const logger = getInstanceLogger('auth');
+const logger = getInstanceLogger('Auth');
 
 export const auth = betterAuth({
     logger: {
@@ -38,8 +38,9 @@ export const auth = betterAuth({
     },
     user: {
         additionalFields: {
-            githubId: {
-                type: 'string',
+            gsUserId: {
+                type: 'number',
+                required: true,
                 input: false,
             },
         },
@@ -48,11 +49,31 @@ export const auth = betterAuth({
         github: {
             clientId: getGitHubClientId(),
             clientSecret: getGitHubClientSecret(),
-            // store the GitHub user ID (i.e. 45882389) in the 'user' object,
-            // which is easy to access from context later on.
-            // the 'id' property cannot be overwritten.
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- profile.id is typed as string but GitHub returns a number at runtime; String() ensures it's always stored as a string for consistent ownership checks
-            mapProfileToUser: (profile) => ({ githubId: String(profile.id) }),
+            mapProfileToUser: async (profile) => {
+                try {
+                    const response = await fetch(`${getBackendHost()}/users/sync`, {
+                        method: 'POST',
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- profile.id is typed as string but GitHub returns a number at runtime
+                            githubId: String(profile.id),
+                            name: profile.name || profile.login || '',
+                            email: profile.email ?? null,
+                        }),
+                    });
+
+                    if (response.ok) {
+                        const user = (await response.json()) as { id: number };
+                        return { gsUserId: String(user.id) };
+                    }
+
+                    throw new Error(`Failed to sync user with backend: HTTP ${response.status}`);
+                } catch (error) {
+                    logger.error(`Failed to sync user with backend: ${error}`);
+                    throw error;
+                }
+            },
         },
     },
     // enable account cookie (we're running stateless, no DB for account info)

--- a/website/src/auth.ts
+++ b/website/src/auth.ts
@@ -58,6 +58,7 @@ export const auth = betterAuth({
                         body: JSON.stringify({
                             // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- profile.id is typed as string but GitHub returns a number at runtime
                             githubId: String(profile.id),
+                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- profile.name is typed as string but GitHub can return null at runtime
                             name: (profile.name as string | null | undefined) ?? profile.login ?? '',
                             email: profile.email ?? null,
                         }),

--- a/website/src/auth.ts
+++ b/website/src/auth.ts
@@ -58,7 +58,7 @@ export const auth = betterAuth({
                         body: JSON.stringify({
                             // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- profile.id is typed as string but GitHub returns a number at runtime
                             githubId: String(profile.id),
-                            name: profile.name ?? profile.login ?? '',
+                            name: (profile.name as string | null | undefined) ?? profile.login ?? '',
                             email: profile.email ?? null,
                         }),
                     });

--- a/website/src/auth.ts
+++ b/website/src/auth.ts
@@ -65,7 +65,7 @@ export const auth = betterAuth({
 
                     if (response.ok) {
                         const user = (await response.json()) as { id: number };
-                        return { gsUserId: String(user.id) };
+                        return { gsUserId: user.id };
                     }
 
                     throw new Error(`Failed to sync user with backend: HTTP ${response.status}`);

--- a/website/src/auth.ts
+++ b/website/src/auth.ts
@@ -58,7 +58,7 @@ export const auth = betterAuth({
                         body: JSON.stringify({
                             // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- profile.id is typed as string but GitHub returns a number at runtime
                             githubId: String(profile.id),
-                            name: profile.name || profile.login || '',
+                            name: profile.name ?? profile.login ?? '',
                             email: profile.email ?? null,
                         }),
                     });

--- a/website/src/backendApi/backendProxy.ts
+++ b/website/src/backendApi/backendProxy.ts
@@ -15,7 +15,7 @@ const API_PATHNAME_LENGTH = '/api'.length;
  * in here, instead of in the backend.
  */
 export async function proxyToBackend(context: APIContext): Promise<Response> {
-    const userId = context.locals.user?.githubId;
+    const userId = context.locals.gsUserId;
 
     if (userId === undefined) {
         return getUnauthorizedResponse(context.request.url);
@@ -31,7 +31,7 @@ export async function proxyToBackendNoAuth(context: APIContext): Promise<Respons
     return proxyRequest(context.request, undefined);
 }
 
-async function proxyRequest(request: Request, userId: string | undefined): Promise<Response> {
+async function proxyRequest(request: Request, userId: number | undefined): Promise<Response> {
     const backendUrl = getBackendUrl(request, userId);
 
     try {
@@ -47,7 +47,7 @@ async function proxyRequest(request: Request, userId: string | undefined): Promi
     }
 }
 
-function getBackendUrl(request: Request, userId: string | undefined) {
+function getBackendUrl(request: Request, userId: number | undefined) {
     const backendEndpoint = new URL(request.url).pathname.slice(API_PATHNAME_LENGTH);
     const backendUrl = new URL(backendEndpoint, getBackendHost());
 
@@ -56,7 +56,7 @@ function getBackendUrl(request: Request, userId: string | undefined) {
     });
 
     if (userId !== undefined) {
-        backendUrl.searchParams.set('userId', userId);
+        backendUrl.searchParams.set('userId', String(userId));
     }
 
     return backendUrl;

--- a/website/src/backendApi/backendService.spec.ts
+++ b/website/src/backendApi/backendService.spec.ts
@@ -175,7 +175,7 @@ describe('backendService', () => {
     const aCollection: Collection = {
         id: 1,
         name: 'Test collection',
-        ownedBy: 'user123',
+        ownedBy: 123,
         organism: 'covid',
         description: 'A test collection',
         variants: [],

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -4,6 +4,7 @@ import { z, type ZodSchema } from 'zod';
 import { UserFacingError } from '../components/ErrorReportInstruction.tsx';
 import { collectionSchema, type CollectionRequest, type CollectionUpdate } from '../types/Collection.ts';
 import { type ProblemDetail, problemDetailSchema } from '../types/ProblemDetail.ts';
+import { publicUserSchema } from '../types/PublicUser.ts';
 import {
     type SubscriptionPutRequest,
     type SubscriptionRequest,
@@ -164,6 +165,10 @@ export class BackendService extends ApiService {
             url,
             schema: z.literal('').refine((_input): _input is never => true),
         });
+    }
+
+    public async getUser({ id }: { id: number }) {
+        return this.get({ url: `/users/${id}`, schema: publicUserSchema });
     }
 
     public async getCollections({ organism }: { organism?: string } = {}) {

--- a/website/src/components/collections/detail/CollectionDetail.tsx
+++ b/website/src/components/collections/detail/CollectionDetail.tsx
@@ -27,11 +27,13 @@ function CollectionDetailInner({
     collection,
     lapisConfig,
     isOwner,
+    ownerName,
 }: {
     organism: Organism;
     collection: Collection;
     lapisConfig: LapisConfig;
     isOwner: boolean;
+    ownerName: string;
 }) {
     const organismName = organismConfig[organism].label;
     const dateFrom30 = dayjs().subtract(30, 'day').format('YYYY-MM-DD');
@@ -56,7 +58,7 @@ function CollectionDetailInner({
                 </div>
                 {collection.description !== null && <p className='mt-1 text-gray-500'>{collection.description}</p>}
                 <p className='mt-1 text-sm text-gray-500'>
-                    {organismName} collection owned by {collection.ownedBy}
+                    {organismName} collection owned by {ownerName}
                 </p>
             </div>
 

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -12,7 +12,7 @@ const mockCollections = [
     {
         id: 1,
         name: 'My first collection',
-        ownedBy: 'user1',
+        ownedBy: 1,
         organism: ORGANISM,
         description: 'A test collection',
         variants: [
@@ -48,7 +48,7 @@ const mockCollections = [
     {
         id: 2,
         name: 'Another collection',
-        ownedBy: 'user1',
+        ownedBy: 1,
         organism: ORGANISM,
         description: null,
         variants: [],

--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -8,8 +8,9 @@ declare namespace App {
     type AuthUser = NonNullable<Awaited<ReturnType<(typeof import('./auth').auth)['api']['getSession']>>>['user'];
 
     interface Locals {
-        user: AuthUser | null; // we use our own user type, see not above
-        session: import('better-auth').Session | null;
+        user: AuthUser | undefined;
+        session: import('better-auth').Session | undefined;
+        gsUserId: number | undefined;
     }
 }
 

--- a/website/src/layouts/base/header/HamburgerMenu.astro
+++ b/website/src/layouts/base/header/HamburgerMenu.astro
@@ -14,7 +14,7 @@ const { forceLoggedOutState } = Astro.props;
 
 const pathogenMegaMenuSections = Object.values(getPathogenMegaMenuSections());
 
-const showLoggedInState = !forceLoggedOutState && Astro.locals.user !== null;
+const showLoggedInState = !forceLoggedOutState && Astro.locals.user !== undefined;
 const showSubscriptions = isStaging();
 ---
 

--- a/website/src/middleware/authMiddleware.ts
+++ b/website/src/middleware/authMiddleware.ts
@@ -10,9 +10,11 @@ export const authMiddleware = defineMiddleware(async (context, next) => {
     if (session) {
         context.locals.user = session.user;
         context.locals.session = session.session;
+        context.locals.gsUserId = session.user.gsUserId;
     } else {
-        context.locals.user = null;
-        context.locals.session = null;
+        context.locals.user = undefined;
+        context.locals.session = undefined;
+        context.locals.gsUserId = undefined;
     }
 
     return next();

--- a/website/src/middleware/authMiddleware.ts
+++ b/website/src/middleware/authMiddleware.ts
@@ -10,7 +10,8 @@ export const authMiddleware = defineMiddleware(async (context, next) => {
     if (session) {
         context.locals.user = session.user;
         context.locals.session = session.session;
-        context.locals.gsUserId = session.user.gsUserId;
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- better-auth serialises all session fields as strings in the JWE cookie regardless of the declared field type
+        context.locals.gsUserId = Number(session.user.gsUserId);
     } else {
         context.locals.user = undefined;
         context.locals.session = undefined;

--- a/website/src/pages/api/users/[id].ts
+++ b/website/src/pages/api/users/[id].ts
@@ -1,0 +1,3 @@
+import { proxyToBackendNoAuth } from '../../../backendApi/backendProxy.ts';
+
+export const GET = proxyToBackendNoAuth;

--- a/website/src/pages/collections/[organism]/[id]/edit.astro
+++ b/website/src/pages/collections/[organism]/[id]/edit.astro
@@ -24,7 +24,7 @@ if (id === undefined) {
 }
 
 const orgConfig = organismConfig[parsedOrganism.data];
-const currentUserId = Astro.locals.user?.githubId;
+const currentUserId = Astro.locals.gsUserId;
 const config = getDashboardsConfig();
 
 let collection;

--- a/website/src/pages/collections/[organism]/[id]/index.astro
+++ b/website/src/pages/collections/[organism]/[id]/index.astro
@@ -26,8 +26,6 @@ if (id === undefined) {
 const orgConfig = organismConfig[parsedOrganism.data];
 const lapisConfig = getOrganismConfig(parsedOrganism.data).lapis;
 
-const currentUserId = Astro.locals.user?.githubId;
-
 let collection: Collection | undefined;
 
 try {
@@ -39,11 +37,29 @@ try {
     logger.error(`Failed to fetch collection ${id}: ${getErrorLogMessage(error)}`);
 }
 
-const collectionTitle = collection !== undefined ? `#${id} ${collection.name}` : `Collection #${id}`;
-
-if (collection !== undefined && collection.organism !== parsedOrganism.data) {
+if (collection === undefined) {
     return Astro.redirect('/404');
 }
+
+// It's possible a collection with the ID exists, but the organism in the path is different.
+// In that case, we want to treat this as 'not found'.
+if (collection.organism !== parsedOrganism.data) {
+    return Astro.redirect('/404');
+}
+
+const collectionTitle = `#${id} ${collection.name}`;
+
+let ownerName = String(collection.ownedBy);
+try {
+    const owner = await new BackendService(getBackendHost()).getUser({ id: collection.ownedBy });
+    ownerName = owner.name;
+} catch (error) {
+    logger.warn(`Failed to fetch owner for collection ${id}: ${getErrorLogMessage(error)}`);
+}
+
+const currentUserId = Astro.locals.gsUserId;
+const userIsLoggedIn = currentUserId !== undefined;
+const userIsOwner = userIsLoggedIn && currentUserId === collection.ownedBy;
 ---
 
 <ContaineredPageLayout
@@ -61,7 +77,8 @@ if (collection !== undefined && collection.organism !== parsedOrganism.data) {
                 organism={parsedOrganism.data}
                 collection={collection}
                 lapisConfig={lapisConfig}
-                isOwner={currentUserId !== undefined && currentUserId === collection.ownedBy}
+                isOwner={userIsOwner}
+                ownerName={ownerName}
                 client:load
             />
         ) : (

--- a/website/src/pages/collections/[organism]/create.astro
+++ b/website/src/pages/collections/[organism]/create.astro
@@ -28,7 +28,7 @@ const config = getDashboardsConfig();
     ]}
 >
     {
-        Astro.locals.user !== null ? (
+        Astro.locals.user !== undefined ? (
             <CollectionCreate client:only='react' organism={parsedOrganism.data} config={config} />
         ) : (
             <NotLoggedIn />

--- a/website/src/pages/collections/[organism]/index.astro
+++ b/website/src/pages/collections/[organism]/index.astro
@@ -19,7 +19,7 @@ if (!parsedOrganism.success) {
 }
 
 const orgConfig = organismConfig[parsedOrganism.data];
-const isLoggedIn = Astro.locals.user !== null;
+const isLoggedIn = Astro.locals.user !== undefined;
 ---
 
 <ContaineredPageLayout

--- a/website/src/pages/subscriptions/create.astro
+++ b/website/src/pages/subscriptions/create.astro
@@ -22,5 +22,5 @@ const config = getDashboardsConfig();
         },
     ]}
 >
-    {Astro.locals.user !== null ? <SubscriptionsCreate config={config} client:only='react' /> : <NotLoggedIn />}
+    {Astro.locals.user !== undefined ? <SubscriptionsCreate config={config} client:only='react' /> : <NotLoggedIn />}
 </SubscriptionPageLayout>

--- a/website/src/pages/subscriptions/index.astro
+++ b/website/src/pages/subscriptions/index.astro
@@ -18,5 +18,5 @@ const breadcrumbs = [
 ---
 
 <SubscriptionPageLayout title='Subscriptions overview' breadcrumbs={breadcrumbs}>
-    {Astro.locals.user !== null ? <Subscriptions client:load organismsFromUrl={organisms} /> : <NotLoggedIn />}
+    {Astro.locals.user !== undefined ? <Subscriptions client:load organismsFromUrl={organisms} /> : <NotLoggedIn />}
 </SubscriptionPageLayout>

--- a/website/src/types/Collection.ts
+++ b/website/src/types/Collection.ts
@@ -33,7 +33,7 @@ const variantSchema = z.discriminatedUnion('type', [queryVariantSchema, filterOb
 export const collectionSchema = z.object({
     id: z.number(),
     name: z.string(),
-    ownedBy: z.string(),
+    ownedBy: z.number(),
     organism: z.string(),
     description: z.string().nullable(),
     variants: z.array(variantSchema),

--- a/website/src/types/PublicUser.ts
+++ b/website/src/types/PublicUser.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const publicUserSchema = z.object({
+    id: z.number(),
+    name: z.string(),
+});
+
+export type PublicUser = z.infer<typeof publicUserSchema>;

--- a/website/tests/collections/collectionDetail.spec.ts
+++ b/website/tests/collections/collectionDetail.spec.ts
@@ -1,9 +1,8 @@
 import { expect } from '@playwright/test';
 
 import { test } from '../e2e.fixture.ts';
+import { E2E_GITHUB_ID } from '../helpers/auth.ts';
 import { createCollection, deleteCollection, syncUser } from '../helpers/backendClient.ts';
-
-const GITHUB_ID = 'e2e-test';
 const ORGANISM = 'covid';
 const ORGANISM_LABEL = 'SARS-CoV-2';
 
@@ -28,28 +27,23 @@ const TEST_COLLECTION = {
 };
 
 let collectionId: number | undefined;
-let userId: number | undefined;
+let userId: number;
 
 function getCollectionId(): number {
     if (collectionId === undefined) throw new Error('collectionId was not set in beforeAll');
     return collectionId;
 }
 
-function getUserId(): number {
-    if (userId === undefined) throw new Error('userId was not set in beforeAll');
-    return userId;
-}
-
 test.beforeAll(async ({ request }) => {
-    userId = await syncUser(request, GITHUB_ID);
-    collectionId = await createCollection(request, getUserId(), TEST_COLLECTION);
+    userId = await syncUser(request, E2E_GITHUB_ID);
+    collectionId = await createCollection(request, userId, TEST_COLLECTION);
 });
 
 test.afterAll(async ({ request }) => {
     if (collectionId === undefined) {
         return;
     }
-    await deleteCollection(request, collectionId, getUserId());
+    await deleteCollection(request, collectionId, userId);
 });
 
 test.describe('Collection detail page', () => {

--- a/website/tests/collections/collectionForm.spec.ts
+++ b/website/tests/collections/collectionForm.spec.ts
@@ -27,28 +27,23 @@ const SEED_COLLECTION = {
 };
 
 let collectionId: number | undefined;
-let userId: number | undefined;
+let userId: number;
 
 function getCollectionId(): number {
     if (collectionId === undefined) throw new Error('collectionId was not set in beforeAll');
     return collectionId;
 }
 
-function getUserId(): number {
-    if (userId === undefined) throw new Error('userId was not set in beforeAll');
-    return userId;
-}
-
 test.beforeAll(async ({ request }) => {
     userId = await syncUser(request, E2E_GITHUB_ID);
-    collectionId = await createCollection(request, getUserId(), SEED_COLLECTION);
+    collectionId = await createCollection(request, userId, SEED_COLLECTION);
 });
 
 test.afterAll(async ({ request }) => {
     if (collectionId === undefined) {
         return;
     }
-    await deleteCollection(request, collectionId, getUserId());
+    await deleteCollection(request, collectionId, userId);
 });
 
 test.describe('New collection page', () => {
@@ -105,7 +100,7 @@ test.describe('New collection page', () => {
         const url = authenticatedCollectionFormPage.page.url();
         const id = /\/collections\/\w+\/(\d+)$/.exec(url)?.[1];
         if (id !== undefined) {
-            await deleteCollection(request, Number(id), getUserId());
+            await deleteCollection(request, Number(id), userId);
         }
     });
 });

--- a/website/tests/e2e.fixture.ts
+++ b/website/tests/e2e.fixture.ts
@@ -8,7 +8,9 @@ import { SequencingEffortsPage } from './SequencingEffortsPage.ts';
 import { SingleVariantPage } from './SingleVariantPage.ts';
 import { CollectionDetailPage } from './collections/CollectionDetailPage.ts';
 import { CollectionFormPage } from './collections/CollectionFormPage.ts';
-import { setupAuthCookie } from './helpers/auth.ts';
+import { E2E_GITHUB_ID, setupAuthCookie } from './helpers/auth.ts';
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080';
 
 type E2EFixture = {
     compareVariantsPage: CompareVariantsPage;
@@ -48,8 +50,12 @@ export const test = base.extend<E2EFixture>({
     collectionFormPage: async ({ page }, use) => {
         await use(new CollectionFormPage(page));
     },
-    authenticatedPage: async ({ page }, use) => {
-        await setupAuthCookie(page, 'e2e-test');
+    authenticatedPage: async ({ page, request }, use) => {
+        const syncResponse = await request.post(`${BACKEND_URL}/users/sync`, {
+            data: { githubId: E2E_GITHUB_ID, name: 'e2e-test', email: null },
+        });
+        const { id: gsUserId } = (await syncResponse.json()) as { id: number };
+        await setupAuthCookie(page, 'e2e-test', gsUserId);
         await use(page);
     },
     authenticatedCollectionFormPage: async ({ authenticatedPage }, use) => {

--- a/website/tests/helpers/auth.ts
+++ b/website/tests/helpers/auth.ts
@@ -77,6 +77,7 @@ export async function setupAuthCookie(page: Page, name: string): Promise<void> {
                 createdAt: now.toISOString(),
                 updatedAt: now.toISOString(),
                 githubId: E2E_GITHUB_ID,
+                gsUserId: '1',
             },
             updatedAt: now.getTime(),
             version: '1',

--- a/website/tests/helpers/auth.ts
+++ b/website/tests/helpers/auth.ts
@@ -40,7 +40,7 @@ export async function createAuthCookies(
     ];
 }
 
-export async function setupAuthCookie(page: Page, name: string): Promise<void> {
+export async function setupAuthCookie(page: Page, name: string, gsUserId: number): Promise<void> {
     const now = new Date();
     const expiresAt = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
     const userId = crypto.randomUUID();
@@ -76,8 +76,7 @@ export async function setupAuthCookie(page: Page, name: string): Promise<void> {
                 image: null,
                 createdAt: now.toISOString(),
                 updatedAt: now.toISOString(),
-                githubId: E2E_GITHUB_ID,
-                gsUserId: '1',
+                gsUserId,
             },
             updatedAt: now.getTime(),
             version: '1',


### PR DESCRIPTION
resolves #1190

## Summary

- On GitHub login, `mapProfileToUser` calls `POST /users/sync` to upsert the user in the backend and stores the returned internal ID as `gsUserId` in the better-auth session (stateless JWE cookie)
- If the sync fails, login is aborted (no silent fallback)
- Replaces the use of the GitHub ID for ownership checks — collections and subscriptions now use the internal numeric user ID throughout
- Owner name is resolved via `GET /users/{id}` and displayed on the collection detail page

## Changes

**Auth & middleware**
- `auth.ts`: `mapProfileToUser` syncs user with backend, stores `gsUserId` (number); throws on failure to abort login
- `authMiddleware.ts`: reads `gsUserId` from session into `Astro.locals`
- `backendProxy.ts`: forwards `gsUserId` as `userId` query param

**Types & API**
- `types/Collection.ts`: `ownedBy` changed from `string` to `number` to match backend `Long`
- `types/PublicUser.ts`: new Zod schema for `GET /users/{id}` response
- `backendService.ts`: adds `getUser()` to resolve owner names server-side
- `pages/api/users/[id].ts`: new proxy route for public user lookup

**Collection pages**
- Detail page: fetches and displays owner name (falls back to numeric ID on error); `ownerName` is always a `string`
- Edit page: uses `gsUserId` for ownership check

**Tests**
- Unit/browser specs: fix `ownedBy` from string to number in fixtures
- E2E tests: sync E2E user via `POST /users/sync` in `beforeAll` to obtain internal ID for collection ownership

## Notes

This branch depends on the backend changes in `feat/user-table` (users table, `POST /users/sync`, `GET /users/{id}` endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)