### PR TITLE
feat(website): make error tooltip direction configurable in AdvancedQueryFilter

### DIFF
--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -29,7 +29,13 @@ type AdvancedQueryFilterProps = {
     errorTooltipClass?: string;
 };
 
-export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput, enabled, lapisUrl, errorTooltipClass }) => {
+export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({
+    value,
+    onInput,
+    enabled,
+    lapisUrl,
+    errorTooltipClass,
+}) => {
     const [inputValue, setInputValue] = useState(value);
     const [validationState, setValidationState] = useState<ValidationState>({ type: 'idle' });
     const userEditedRef = useRef(false);

--- a/website/src/components/genspectrum/AdvancedQueryFilter.tsx
+++ b/website/src/components/genspectrum/AdvancedQueryFilter.tsx
@@ -19,9 +19,17 @@ type AdvancedQueryFilterProps = {
     onInput?: (newValue: string | undefined) => void;
     enabled: boolean;
     lapisUrl: string;
+    /**
+     * Tailwind classes controlling the direction of the validation error tooltip.
+     * Defaults to `'tooltip-left lg:tooltip-right'`.
+     *
+     * Common values: `tooltip-left`, `tooltip-right`, `tooltip-top`, `tooltip-bottom`.
+     * Responsive variants are also valid, e.g. `'tooltip-left lg:tooltip-right'`.
+     */
+    errorTooltipClass?: string;
 };
 
-export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput, enabled, lapisUrl }) => {
+export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInput, enabled, lapisUrl, errorTooltipClass }) => {
     const [inputValue, setInputValue] = useState(value);
     const [validationState, setValidationState] = useState<ValidationState>({ type: 'idle' });
     const userEditedRef = useRef(false);
@@ -94,17 +102,20 @@ export const AdvancedQueryFilter: FC<AdvancedQueryFilterProps> = ({ value, onInp
                 />
                 {isValidating && <span className='loading loading-spinner loading-xs' title='Validating' />}
                 {isValid && <div className='iconify mdi--check text-success size-4' title='Advanced query is valid' />}
-                {isError && <ErrorIconWithTooltip message={validationState.message} />}
+                {isError && <ErrorIconWithTooltip message={validationState.message} tooltipClass={errorTooltipClass} />}
             </label>
         </div>
     );
 };
 
-const ErrorIconWithTooltip: FC<{ message: string }> = ({ message }) => {
+const ErrorIconWithTooltip: FC<{ message: string; tooltipClass?: string }> = ({
+    message,
+    tooltipClass = 'tooltip-left lg:tooltip-right',
+}) => {
     const [isOpen, setIsOpen] = useState(false);
 
     return (
-        <div className={`tooltip tooltip-left lg:tooltip-right z-1000 ${isOpen ? 'tooltip-open' : ''}`}>
+        <div className={`tooltip ${tooltipClass} z-1000 ${isOpen ? 'tooltip-open' : ''}`}>
             <div className='tooltip-content z-1000'>
                 <div className='flex items-start gap-1'>
                     <span>{message}</span>


### PR DESCRIPTION
## Summary

- Adds an optional `errorTooltipClass` prop to `AdvancedQueryFilter` that is forwarded to the internal `ErrorIconWithTooltip` component, allowing callers to control which direction the validation error tooltip opens.
- Defaults to `'tooltip-left lg:tooltip-right'` (the original hardcoded value), so all existing usages are unchanged.

## Design note

We considered using an explicit union type (`'left' | 'right' | 'top' | 'bottom'`) with a lookup map to avoid Tailwind purging dynamic class names. However, that approach would have made it impossible for callers to pass responsive variants like `tooltip-left lg:tooltip-right` without introducing extra complexity. Accepting a plain class string keeps full flexibility — callers are responsible for using complete Tailwind class names so the compiler can detect them.

## Screenshot

With `tooltip-top`

<img width="437" height="155" alt="image" src="https://github.com/user-attachments/assets/0f0ad042-7d30-42a5-9069-9378b15a3aa7" />

## Test plan

- [x] Existing pages with `AdvancedQueryFilter` show the tooltip in the same position as before (left on small screens, right on large screens)
- [x] A caller passing e.g. `errorTooltipClass="tooltip-top"` sees the tooltip pinned top at all breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)