### PR TITLE
docs(website): document ESLint naming-convention exception for HTTP headers

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -48,6 +48,15 @@ Check `package.json` for more details on available commands.
 
 Format with prettier. Use eslint to check code style issues.
 
+### ESLint Naming Convention Exceptions
+
+HTTP header names (e.g. `Content-Type`, `Authorization`) must keep their original casing and cannot be camelCased. Suppress the `@typescript-eslint/naming-convention` error with an inline disable comment:
+
+```typescript
+// eslint-disable-next-line @typescript-eslint/naming-convention
+{ 'Content-Type': 'application/json' }
+```
+
 ### React & Astro
 
 - Use **Astro** for static/server-rendered pages; use **React** for interactive components.


### PR DESCRIPTION
## Summary

- Adds a section to `AGENTS.md` explaining that HTTP header names (e.g. `Content-Type`, `Authorization`) must keep their original casing and cannot be camelCased
- Documents the correct way to suppress the `@typescript-eslint/naming-convention` lint error with an inline disable comment

## Test plan

- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)