### PR TITLE
feat(backend): add system user auto-creation from application YAML

### DIFF
--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
@@ -4,7 +4,7 @@ import org.genspectrum.dashboardsbackend.controller.BadRequestException
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "dashboards")
-data class DashboardsConfig(val organisms: Map<String, OrganismConfig>) {
+data class DashboardsConfig(val organisms: Map<String, OrganismConfig>, val systemUser: SystemUserConfig? = null) {
     fun getOrganismConfig(organism: String) = organisms[organism]
         ?: throw IllegalArgumentException("No configuration found for organism $organism")
 
@@ -35,3 +35,10 @@ data class LapisConfig(
 )
 
 data class ExternalNavigationLink(val url: String, val label: String, val menuIcon: String, val description: String)
+
+data class SystemUserConfig(
+    val githubId: String,
+    val name: String,
+    val email: String? = null,
+    val apiKey: String? = null,
+)

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
@@ -41,4 +41,8 @@ data class SystemUserConfig(
     val name: String,
     val email: String? = null,
     val apiKey: String? = null,
-)
+) {
+    init {
+        require(apiKey == null || apiKey.length >= 32) { "systemUser.apiKey must be at least 32 characters" }
+    }
+}

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/DashboardsConfig.kt
@@ -45,4 +45,7 @@ data class SystemUserConfig(
     init {
         require(apiKey == null || apiKey.length >= 32) { "systemUser.apiKey must be at least 32 characters" }
     }
+
+    override fun toString() =
+        "SystemUserConfig(githubId=$githubId, name=$name, email=$email, apiKey=${if (apiKey != null) "***" else "null"})"
 }

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializer.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializer.kt
@@ -21,7 +21,7 @@ class SystemUserInitializer(
         val user = userModel.syncUser(
             UserSyncRequest(githubId = config.githubId, name = config.name, email = config.email),
         )
-        log.info { "System user ready: id=${user.id}, githubId=${config.githubId}, name=${config.name}" }
+        log.info { "System user ready: id=${user.id}, $config" }
         config.apiKey?.let {
             apiKeyModel.upsertApiKey(userId = user.id, rawKey = it)
             log.info { "System user API key upserted for userId=${user.id}" }

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializer.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializer.kt
@@ -1,0 +1,30 @@
+package org.genspectrum.dashboardsbackend.config
+
+import mu.KotlinLogging
+import org.genspectrum.dashboardsbackend.api.UserSyncRequest
+import org.genspectrum.dashboardsbackend.model.apikey.ApiKeyModel
+import org.genspectrum.dashboardsbackend.model.user.UserModel
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class SystemUserInitializer(
+    private val dashboardsConfig: DashboardsConfig,
+    private val userModel: UserModel,
+    private val apiKeyModel: ApiKeyModel,
+) : ApplicationRunner {
+    override fun run(args: ApplicationArguments) {
+        val config = dashboardsConfig.systemUser ?: return
+        val user = userModel.syncUser(
+            UserSyncRequest(githubId = config.githubId, name = config.name, email = config.email),
+        )
+        log.info { "System user ready: id=${user.id}, githubId=${config.githubId}, name=${config.name}" }
+        config.apiKey?.let {
+            apiKeyModel.upsertApiKey(userId = user.id, rawKey = it)
+            log.info { "System user API key upserted for userId=${user.id}" }
+        }
+    }
+}

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/apikey/ApiKeyModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/apikey/ApiKeyModel.kt
@@ -47,6 +47,28 @@ class ApiKeyModel {
         return GeneratedApiKey(key = rawKey, createdAt = now)
     }
 
+    /**
+     * Upsert a given API key. This is only used by the init function where the user can pass
+     * in an API key for a system user.
+     */
+    fun upsertApiKey(userId: Long, rawKey: String) {
+        val hash = sha256(rawKey)
+        val now = now()
+        val existing = ApiKeyEntity.findByUserId(userId)
+        if (existing == null) {
+            ApiKeyEntity.new {
+                this.userId = userId
+                this.keyHash = hash
+                this.createdAt = now
+                this.lastUsedAt = null
+            }
+        } else if (existing.keyHash != hash) {
+            existing.keyHash = hash
+            existing.createdAt = now
+            existing.lastUsedAt = null
+        }
+    }
+
     fun revokeApiKey(userId: Long) {
         val entity = ApiKeyEntity.findByUserId(userId)
             ?: throw NotFoundException("No API key found for user $userId")

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializerTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializerTest.kt
@@ -38,7 +38,7 @@ class SystemUserInitializerTest(
     )
 
     @Test
-    fun `WHEN systemUser config with apiKey THEN key validates and user exists`() {
+    fun `GIVEN systemUser config with apiKey WHEN initializer runs THEN key validates and user exists`() {
         val githubId = "system-user-with-key-${System.nanoTime()}"
         val rawKey = uniqueKey()
 
@@ -49,7 +49,7 @@ class SystemUserInitializerTest(
     }
 
     @Test
-    fun `WHEN systemUser config without apiKey THEN user is created but no key exists`() {
+    fun `GIVEN systemUser config without apiKey WHEN initializer runs THEN user is created but no key exists`() {
         val githubId = "system-user-no-key-${System.nanoTime()}"
 
         initializerWith(SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = null)).run(noArgs)
@@ -60,7 +60,7 @@ class SystemUserInitializerTest(
     }
 
     @Test
-    fun `WHEN run twice with same config THEN idempotent - no errors and key still valid`() {
+    fun `GIVEN systemUser config with apiKey WHEN initializer runs twice THEN is idempotent and key still valid`() {
         val githubId = "system-user-idempotent-${System.nanoTime()}"
         val rawKey = uniqueKey()
         val config = SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = rawKey)
@@ -74,7 +74,7 @@ class SystemUserInitializerTest(
     }
 
     @Test
-    fun `WHEN apiKey changes THEN old key is rejected and new key validates`() {
+    fun `GIVEN systemUser config with apiKey WHEN apiKey changes THEN old key is rejected and new key validates`() {
         val githubId = "system-user-rotation-${System.nanoTime()}"
         val oldKey = uniqueKey()
         val newKey = uniqueKey()
@@ -88,7 +88,7 @@ class SystemUserInitializerTest(
     }
 
     @Test
-    fun `WHEN run twice with same key THEN lastUsedAt is not reset`() {
+    fun `GIVEN systemUser config with apiKey WHEN initializer runs twice THEN lastUsedAt is not reset`() {
         val githubId = "system-user-no-reset-${System.nanoTime()}"
         val rawKey = uniqueKey()
         val config = SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = rawKey)

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializerTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializerTest.kt
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -27,6 +28,8 @@ class SystemUserInitializerTest(
 ) {
     private val noArgs: ApplicationArguments = DefaultApplicationArguments()
 
+    private fun uniqueKey() = UUID.randomUUID().toString()
+
     private fun initializerWith(config: SystemUserConfig?) = SystemUserInitializer(
         dashboardsConfig = DashboardsConfig(organisms = emptyMap(), systemUser = config),
         userModel = userModel,
@@ -36,7 +39,7 @@ class SystemUserInitializerTest(
     @Test
     fun `WHEN systemUser config with apiKey THEN key validates and user exists`() {
         val githubId = "system-user-with-key-${System.nanoTime()}"
-        val rawKey = "a".repeat(64)
+        val rawKey = uniqueKey()
 
         initializerWith(SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = rawKey)).run(noArgs)
 
@@ -47,7 +50,7 @@ class SystemUserInitializerTest(
     @Test
     fun `WHEN run twice with same config THEN idempotent - no errors and key still valid`() {
         val githubId = "system-user-idempotent-${System.nanoTime()}"
-        val rawKey = "b".repeat(64)
+        val rawKey = uniqueKey()
         val config = SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = rawKey)
         val initializer = initializerWith(config)
 
@@ -61,8 +64,8 @@ class SystemUserInitializerTest(
     @Test
     fun `WHEN apiKey changes THEN old key is rejected and new key validates`() {
         val githubId = "system-user-rotation-${System.nanoTime()}"
-        val oldKey = "c".repeat(64)
-        val newKey = "d".repeat(64)
+        val oldKey = uniqueKey()
+        val newKey = uniqueKey()
 
         initializerWith(SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = oldKey)).run(noArgs)
         initializerWith(SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = newKey)).run(noArgs)
@@ -75,7 +78,7 @@ class SystemUserInitializerTest(
     @Test
     fun `WHEN run twice with same key THEN lastUsedAt is not reset`() {
         val githubId = "system-user-no-reset-${System.nanoTime()}"
-        val rawKey = "e".repeat(64)
+        val rawKey = uniqueKey()
         val config = SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = rawKey)
         val initializer = initializerWith(config)
 

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializerTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializerTest.kt
@@ -1,0 +1,92 @@
+package org.genspectrum.dashboardsbackend.config
+
+import org.genspectrum.dashboardsbackend.controller.ApiKeyClient
+import org.genspectrum.dashboardsbackend.controller.UsersClient
+import org.genspectrum.dashboardsbackend.model.apikey.ApiKeyModel
+import org.genspectrum.dashboardsbackend.model.user.UserModel
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.DefaultApplicationArguments
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(ApiKeyClient::class, UsersClient::class)
+class SystemUserInitializerTest(
+    @param:Autowired private val userModel: UserModel,
+    @param:Autowired private val apiKeyModel: ApiKeyModel,
+    @param:Autowired private val apiKeyClient: ApiKeyClient,
+    @param:Autowired private val usersClient: UsersClient,
+) {
+    private val noArgs: ApplicationArguments = DefaultApplicationArguments()
+
+    private fun initializerWith(config: SystemUserConfig?) = SystemUserInitializer(
+        dashboardsConfig = DashboardsConfig(organisms = emptyMap(), systemUser = config),
+        userModel = userModel,
+        apiKeyModel = apiKeyModel,
+    )
+
+    @Test
+    fun `WHEN systemUser config with apiKey THEN key validates and user exists`() {
+        val githubId = "system-user-with-key-${System.nanoTime()}"
+        val rawKey = "a".repeat(64)
+
+        initializerWith(SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = rawKey)).run(noArgs)
+
+        val userId = apiKeyClient.validateApiKey(rawKey).userId
+        usersClient.getUserRaw(userId).andExpect(status().isOk)
+    }
+
+    @Test
+    fun `WHEN run twice with same config THEN idempotent - no errors and key still valid`() {
+        val githubId = "system-user-idempotent-${System.nanoTime()}"
+        val rawKey = "b".repeat(64)
+        val config = SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = rawKey)
+        val initializer = initializerWith(config)
+
+        initializer.run(noArgs)
+        initializer.run(noArgs)
+
+        val response = apiKeyClient.validateApiKey(rawKey)
+        assertThat(response.userId, notNullValue())
+    }
+
+    @Test
+    fun `WHEN apiKey changes THEN old key is rejected and new key validates`() {
+        val githubId = "system-user-rotation-${System.nanoTime()}"
+        val oldKey = "c".repeat(64)
+        val newKey = "d".repeat(64)
+
+        initializerWith(SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = oldKey)).run(noArgs)
+        initializerWith(SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = newKey)).run(noArgs)
+
+        apiKeyClient.validateApiKeyRaw(oldKey).andExpect(status().isNotFound)
+        val response = apiKeyClient.validateApiKey(newKey)
+        assertThat(response.userId, notNullValue())
+    }
+
+    @Test
+    fun `WHEN run twice with same key THEN lastUsedAt is not reset`() {
+        val githubId = "system-user-no-reset-${System.nanoTime()}"
+        val rawKey = "e".repeat(64)
+        val config = SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = rawKey)
+        val initializer = initializerWith(config)
+
+        initializer.run(noArgs)
+        val userId = apiKeyClient.validateApiKey(rawKey).userId
+        val lastUsedAfterValidation = apiKeyClient.getApiKey(userId).lastUsedAt
+        assertThat(lastUsedAfterValidation, notNullValue())
+
+        initializer.run(noArgs)
+
+        val lastUsedAfterRerun = apiKeyClient.getApiKey(userId).lastUsedAt
+        assertThat(lastUsedAfterRerun, equalTo(lastUsedAfterValidation))
+    }
+}

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializerTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializerTest.kt
@@ -1,5 +1,6 @@
 package org.genspectrum.dashboardsbackend.config
 
+import org.genspectrum.dashboardsbackend.api.UserSyncRequest
 import org.genspectrum.dashboardsbackend.controller.ApiKeyClient
 import org.genspectrum.dashboardsbackend.controller.UsersClient
 import org.genspectrum.dashboardsbackend.model.apikey.ApiKeyModel
@@ -45,6 +46,17 @@ class SystemUserInitializerTest(
 
         val userId = apiKeyClient.validateApiKey(rawKey).userId
         usersClient.getUserRaw(userId).andExpect(status().isOk)
+    }
+
+    @Test
+    fun `WHEN systemUser config without apiKey THEN user is created but no key exists`() {
+        val githubId = "system-user-no-key-${System.nanoTime()}"
+
+        initializerWith(SystemUserConfig(githubId = githubId, name = "Bot", email = null, apiKey = null)).run(noArgs)
+
+        val userId = usersClient.syncUser(UserSyncRequest(githubId = githubId, name = "Bot", email = null)).id
+        usersClient.getUserRaw(userId).andExpect(status().isOk)
+        apiKeyClient.getApiKeyRaw(userId).andExpect(status().isNotFound)
     }
 
     @Test


### PR DESCRIPTION
For our staging environment, we want to initialize a system user with a known API key, that we can use right away from our collection seeding scripts.

This feature allows us to configure that system user in the `applications.yaml`:

```yaml
dashboards:
  systemUser:
    githubId: "218605180"
    name: "Genspectrum Bot"
    email: null
    apiKey: "${SYSTEM_USER_API_KEY}"
  organisms:
    ...
```

And then set the env var (`SYSTEM_USER_API_KEY`).

In our deployment scripts we can then have a shared secret between the backend and the seeder container.

## Summary

- Adds `SystemUserConfig` data class and optional `systemUser` field to `DashboardsConfig`
- Adds `upsertApiKey(userId, rawKey)` to `ApiKeyModel` — inserts on first run, rotates on key change, no-ops if hash is unchanged
- New `SystemUserInitializer` `ApplicationRunner` creates/updates the configured bot account and upserts its API key at startup

## Test plan

- [x] 4 integration tests in `SystemUserInitializerTest` cover: key creation + user existence, idempotency, key rotation (old key rejected / new key validates), `lastUsedAt` not reset on same-key re-run
- [x] Add a `systemUser` block to a local YAML profile, start the backend, verify user appears at `GET /users/{id}` and key validates at `POST /internal/api-keys/validate`
- [x] Restart with identical config → same user, same key, no errors
- [x] Restart with changed `apiKey` → old key rejected, new key validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)