### PR TITLE
feat(backend): add pagination to GET /collections

### DIFF
--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/api/Collection.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/api/Collection.kt
@@ -84,3 +84,10 @@ data class CollectionUpdate(
     val description: String? = null,
     val variants: List<VariantUpdate>? = null,
 )
+
+data class PaginatedResponse<T>(
+    val data: List<T>,
+    val totalCount: Long,
+    val page: Int,
+    val pageSize: Int,
+)

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsController.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import org.genspectrum.dashboardsbackend.api.Collection
 import org.genspectrum.dashboardsbackend.api.CollectionRequest
 import org.genspectrum.dashboardsbackend.api.CollectionUpdate
+import org.genspectrum.dashboardsbackend.api.PaginatedResponse
 import org.genspectrum.dashboardsbackend.model.collection.CollectionModel
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -23,14 +24,20 @@ class CollectionsController(private val collectionModel: CollectionModel) {
     @GetMapping("/collections", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(
         summary = "Get collections",
-        description = "Returns collections filtered by optional userId and/or organism parameters.",
+        description = "Returns collections filtered by optional userId and/or organism parameters, with pagination.",
     )
     fun getCollections(
         @RequestParam(required = false) userId: Long?,
         @RequestParam(required = false) organism: String?,
-    ): List<Collection> = collectionModel.getCollections(
+        @Parameter(description = "1-based page number", example = "1")
+        @RequestParam(required = false, defaultValue = "1") page: Int,
+        @Parameter(description = "Number of collections per page", example = "100")
+        @RequestParam(required = false, defaultValue = "100") pageSize: Int,
+    ): PaginatedResponse<Collection> = collectionModel.getCollections(
         userId = userId,
         organism = organism,
+        page = page,
+        pageSize = pageSize,
     )
 
     @GetMapping("/collections/{id}", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
@@ -4,6 +4,7 @@ import org.genspectrum.dashboardsbackend.api.Collection
 import org.genspectrum.dashboardsbackend.api.CollectionRequest
 import org.genspectrum.dashboardsbackend.api.CollectionUpdate
 import org.genspectrum.dashboardsbackend.api.FilterObject
+import org.genspectrum.dashboardsbackend.api.PaginatedResponse
 import org.genspectrum.dashboardsbackend.api.VariantRequest
 import org.genspectrum.dashboardsbackend.api.VariantUpdate
 import org.genspectrum.dashboardsbackend.config.DashboardsConfig
@@ -12,8 +13,9 @@ import org.genspectrum.dashboardsbackend.controller.ForbiddenException
 import org.genspectrum.dashboardsbackend.controller.NotFoundException
 import org.genspectrum.dashboardsbackend.model.user.UserEntity
 import org.genspectrum.dashboardsbackend.util.now
-import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.notInList
@@ -25,7 +27,12 @@ import kotlin.time.Instant
 @Service
 @Transactional
 class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
-    fun getCollections(userId: Long?, organism: String?): List<Collection> {
+    fun getCollections(
+        userId: Long?,
+        organism: String?,
+        page: Int,
+        pageSize: Int,
+    ): PaginatedResponse<Collection> {
         if (userId != null) {
             UserEntity.findById(userId) ?: throw NotFoundException("User $userId not found")
         }
@@ -33,32 +40,29 @@ class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
             dashboardsConfig.validateIsValidOrganism(organism)
             dashboardsConfig.validateCollectionsEnabled(organism)
         }
-        val query = if (userId == null && organism == null) {
-            CollectionEntity.all()
-        } else {
-            CollectionEntity.find {
-                var conditions: Op<Boolean> = Op.TRUE
-                if (userId != null) {
-                    conditions = conditions and (CollectionTable.ownedBy eq userId)
-                }
-                if (organism != null) {
-                    conditions = conditions and (CollectionTable.organism eq organism)
-                }
-                conditions
-            }
+        val baseQuery = CollectionTable.selectAll()
+        if (userId != null) {
+            baseQuery.andWhere { CollectionTable.ownedBy eq userId }
+        }
+        if (organism != null) {
+            baseQuery.andWhere { CollectionTable.organism eq organism }
         }
 
-        // Materialize the collections first to avoid re-running the query
-        val collectionEntities = query.toList()
+        val totalCount = baseQuery.count()
+        val offset = ((page - 1) * pageSize).toLong()
+        val collectionEntities = CollectionEntity.wrapRows(
+            baseQuery.orderBy(CollectionTable.id to SortOrder.ASC).limit(pageSize, offset),
+        ).toList()
+
         if (collectionEntities.isEmpty()) {
-            return emptyList()
+            return PaginatedResponse(data = emptyList(), totalCount = totalCount, page = page, pageSize = pageSize)
         }
-        // Batch-load all variants
+        // Batch-load all variants for this page
         val allCollectionIds = collectionEntities.map { it.id }
         val variantsByCollectionId = VariantEntity
             .find { VariantTable.collectionId inList allCollectionIds }
             .groupBy { it.collectionId }
-        return collectionEntities.map { collectionEntity ->
+        val data = collectionEntities.map { collectionEntity ->
             val variants = variantsByCollectionId[collectionEntity.id].orEmpty().map { it.toVariant() }
             Collection(
                 id = collectionEntity.id.value,
@@ -71,6 +75,7 @@ class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
                 updatedAt = collectionEntity.updatedAt,
             )
         }
+        return PaginatedResponse(data = data, totalCount = totalCount, page = page, pageSize = pageSize)
     }
 
     fun getCollection(id: Long): Collection {

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsClient.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsClient.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import org.genspectrum.dashboardsbackend.api.Collection
 import org.genspectrum.dashboardsbackend.api.CollectionRequest
 import org.genspectrum.dashboardsbackend.api.CollectionUpdate
+import org.genspectrum.dashboardsbackend.api.PaginatedResponse
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
@@ -27,11 +28,18 @@ class CollectionsClient(private val mockMvc: MockMvc, private val objectMapper: 
             .andExpect(status().isCreated),
     )
 
-    fun getCollectionsRaw(userId: Long? = null, organism: String? = null): ResultActions {
+    fun getCollectionsRaw(
+        userId: Long? = null,
+        organism: String? = null,
+        page: Int? = null,
+        pageSize: Int? = null,
+    ): ResultActions {
         val params = buildString {
             val queryParams = mutableListOf<String>()
             if (userId != null) queryParams.add("userId=$userId")
             if (organism != null) queryParams.add("organism=$organism")
+            if (page != null) queryParams.add("page=$page")
+            if (pageSize != null) queryParams.add("pageSize=$pageSize")
             if (queryParams.isNotEmpty()) {
                 append("?")
                 append(queryParams.joinToString("&"))
@@ -40,8 +48,13 @@ class CollectionsClient(private val mockMvc: MockMvc, private val objectMapper: 
         return mockMvc.perform(get("/collections$params"))
     }
 
-    fun getCollections(userId: Long? = null, organism: String? = null): List<Collection> = deserializeJsonResponse(
-        getCollectionsRaw(userId, organism)
+    fun getCollections(
+        userId: Long? = null,
+        organism: String? = null,
+        page: Int? = null,
+        pageSize: Int? = null,
+    ): PaginatedResponse<Collection> = deserializeJsonResponse(
+        getCollectionsRaw(userId, organism, page, pageSize)
             .andExpect(status().isOk),
     )
 

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
@@ -7,6 +7,7 @@ import org.genspectrum.dashboardsbackend.dummyCollectionRequest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThanOrEqualTo
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
@@ -44,8 +45,8 @@ class CollectionsGetTest(
             userB,
         )
 
-        val collectionsForUserA = collectionsClient.getCollections(userId = userA)
-        val collectionsForUserB = collectionsClient.getCollections(userId = userB)
+        val collectionsForUserA = collectionsClient.getCollections(userId = userA).data
+        val collectionsForUserB = collectionsClient.getCollections(userId = userB).data
 
         assertThat(collectionsForUserA, hasItem(collectionA))
         assertThat(collectionsForUserA, not(hasItem(collectionB)))
@@ -72,7 +73,7 @@ class CollectionsGetTest(
             userB,
         )
 
-        val allCollections = collectionsClient.getCollections()
+        val allCollections = collectionsClient.getCollections().data
 
         assertThat(allCollections, hasItem(covidCollectionA))
         assertThat(allCollections, hasItem(mpoxCollectionA))
@@ -87,7 +88,7 @@ class CollectionsGetTest(
         val collectionA = collectionsClient.postCollection(dummyCollectionRequest.copy(name = "User A"), userA)
         val collectionB = collectionsClient.postCollection(dummyCollectionRequest.copy(name = "User B"), userB)
 
-        val collectionsForUserA = collectionsClient.getCollections(userId = userA)
+        val collectionsForUserA = collectionsClient.getCollections(userId = userA).data
 
         assertThat(collectionsForUserA, hasItem(collectionA))
         assertThat(collectionsForUserA, not(hasItem(collectionB)))
@@ -100,18 +101,19 @@ class CollectionsGetTest(
 
         collectionsClient.getCollectionsRaw(userId = userId)
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$[0].id").value(createdCollection.id))
-            .andExpect(jsonPath("$[0].variants[0].type").value("query"))
-            .andExpect(jsonPath("$[0].variants[1].type").value("filterObject"))
+            .andExpect(jsonPath("$.data[0].id").value(createdCollection.id))
+            .andExpect(jsonPath("$.data[0].variants[0].type").value("query"))
+            .andExpect(jsonPath("$.data[0].variants[1].type").value("filterObject"))
     }
 
     @Test
     fun `GIVEN user has no collections WHEN getting collections for user THEN returns empty array`() {
         val nonexistentUserId = usersClient.createUser()
 
-        val collections = collectionsClient.getCollections(userId = nonexistentUserId)
+        val response = collectionsClient.getCollections(userId = nonexistentUserId)
 
-        assertThat(collections, empty())
+        assertThat(response.data, empty())
+        assertThat(response.totalCount, equalTo(0L))
     }
 
     @Test
@@ -127,7 +129,7 @@ class CollectionsGetTest(
             userId,
         )
 
-        val covidCollections = collectionsClient.getCollections(organism = KnownTestOrganisms.Covid.name)
+        val covidCollections = collectionsClient.getCollections(organism = KnownTestOrganisms.Covid.name).data
 
         assertThat(covidCollections, hasItem(covidCollection))
         assertThat(covidCollections, not(hasItem(mpoxCollection)))
@@ -135,9 +137,10 @@ class CollectionsGetTest(
 
     @Test
     fun `GIVEN no collections for organism WHEN getting collections for organism THEN returns empty array`() {
-        val collections = collectionsClient.getCollections(organism = KnownTestOrganisms.WestNile.name)
+        val response = collectionsClient.getCollections(organism = KnownTestOrganisms.WestNile.name)
 
-        assertThat(collections, empty())
+        assertThat(response.data, empty())
+        assertThat(response.totalCount, equalTo(0L))
     }
 
     @Test
@@ -161,7 +164,7 @@ class CollectionsGetTest(
         val filteredCollections = collectionsClient.getCollections(
             userId = userA,
             organism = KnownTestOrganisms.Covid.name,
-        )
+        ).data
 
         assertThat(filteredCollections, hasItem(covidCollectionA))
         assertThat(filteredCollections, not(hasItem(mpoxCollectionA)))
@@ -176,9 +179,10 @@ class CollectionsGetTest(
             userA,
         )
 
-        val collections = collectionsClient.getCollections(userId = userA, organism = KnownTestOrganisms.Mpox.name)
+        val response = collectionsClient.getCollections(userId = userA, organism = KnownTestOrganisms.Mpox.name)
 
-        assertThat(collections, empty())
+        assertThat(response.data, empty())
+        assertThat(response.totalCount, equalTo(0L))
     }
 
     @Test
@@ -186,7 +190,7 @@ class CollectionsGetTest(
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
 
-        val collections = collectionsClient.getCollections(userId = userId)
+        val collections = collectionsClient.getCollections(userId = userId).data
         val retrievedCollection = collections.first { it.id == createdCollection.id }
 
         assertThat(retrievedCollection.variants, hasSize(2))
@@ -212,7 +216,7 @@ class CollectionsGetTest(
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
 
-        val collections = collectionsClient.getCollections(userId = userId)
+        val collections = collectionsClient.getCollections(userId = userId).data
         val retrievedCollection = collections.first { it.id == createdCollection.id }
 
         val queryVariants = retrievedCollection.variants.filterIsInstance<Variant.QueryVariant>()
@@ -281,5 +285,78 @@ class CollectionsGetTest(
         collectionsClient.getCollectionsRaw(userId = 999999999L)
             .andExpect(status().isNotFound)
             .andExpect(jsonPath("$.detail").value("User 999999999 not found"))
+    }
+
+    @Test
+    fun `GIVEN N collections WHEN getting page 1 with small pageSize THEN returns first page and correct totalCount`() {
+        val userId = usersClient.createUser()
+        val created = (1..5).map { i ->
+            collectionsClient.postCollection(dummyCollectionRequest.copy(name = "Collection $i"), userId)
+        }
+
+        val response = collectionsClient.getCollections(userId = userId, page = 1, pageSize = 3)
+
+        assertThat(response.totalCount, equalTo(5L))
+        assertThat(response.page, equalTo(1))
+        assertThat(response.pageSize, equalTo(3))
+        assertThat(response.data, hasSize(3))
+        assertThat(response.data[0].id, equalTo(created[0].id))
+        assertThat(response.data[1].id, equalTo(created[1].id))
+        assertThat(response.data[2].id, equalTo(created[2].id))
+    }
+
+    @Test
+    fun `GIVEN N collections WHEN getting page 2 THEN returns correct offset items`() {
+        val userId = usersClient.createUser()
+        val created = (1..5).map { i ->
+            collectionsClient.postCollection(dummyCollectionRequest.copy(name = "Collection $i"), userId)
+        }
+
+        val response = collectionsClient.getCollections(userId = userId, page = 2, pageSize = 3)
+
+        assertThat(response.totalCount, equalTo(5L))
+        assertThat(response.page, equalTo(2))
+        assertThat(response.data, hasSize(2))
+        assertThat(response.data[0].id, equalTo(created[3].id))
+        assertThat(response.data[1].id, equalTo(created[4].id))
+    }
+
+    @Test
+    fun `GIVEN collections across organisms WHEN paginating with organism filter THEN totalCount reflects filtered count`() {
+        val userId = usersClient.createUser()
+        repeat(3) { i ->
+            collectionsClient.postCollection(
+                dummyCollectionRequest.copy(name = "Covid $i", organism = KnownTestOrganisms.Covid.name),
+                userId,
+            )
+        }
+        repeat(2) { i ->
+            collectionsClient.postCollection(
+                dummyCollectionRequest.copy(name = "Mpox $i", organism = KnownTestOrganisms.Mpox.name),
+                userId,
+            )
+        }
+
+        val response = collectionsClient.getCollections(
+            userId = userId,
+            organism = KnownTestOrganisms.Covid.name,
+            page = 1,
+            pageSize = 100,
+        )
+
+        assertThat(response.totalCount, equalTo(3L))
+        assertThat(response.data, hasSize(3))
+    }
+
+    @Test
+    fun `GIVEN collections WHEN getting all with defaults THEN response has pagination metadata`() {
+        val userId = usersClient.createUser()
+        collectionsClient.postCollection(dummyCollectionRequest, userId)
+
+        val response = collectionsClient.getCollections(userId = userId)
+
+        assertThat(response.page, equalTo(1))
+        assertThat(response.pageSize, equalTo(100))
+        assertThat(response.totalCount, greaterThanOrEqualTo(1L))
     }
 }


### PR DESCRIPTION
## Summary

- Adds `page` (1-based, default 1) and `pageSize` (default 100) query params to `GET /collections`
- Changes the response from `List<Collection>` to `PaginatedResponse<Collection>` — a `{ data, totalCount, page, pageSize }` envelope
- Adds `PaginatedResponse<T>` data class to `api/Collection.kt`
- Updates `CollectionsController`, `CollectionModel`, `CollectionsClient` (test helper), and all existing tests to use `.data` on the response
- Adds 4 new pagination-specific tests

## Current state — does not compile

The implementation is blocked on the correct Exposed 1.3.0 API for **offset/limit pagination** on a `Query`. Specifically:

1. **`limit(n, offset)`** — In Exposed 1.x, `SizedIterable.limit()` and `Query.limit()` only accept a single `count: Int` argument. The old `limit(n, offset)` two-argument form no longer exists. A separate `.offset(n)` method may exist on `Query`/`AbstractQuery`, but hasn't been verified.

2. **`selectAll()` / `andWhere {}`** — The raw query DSL entry point and the method to add WHERE clauses incrementally need the correct import paths for Exposed 1.3.0. `selectAll` resolved via `import org.jetbrains.exposed.v1.jdbc.selectAll`, but `andWhere` is still unresolved.

### What needs to be figured out

The right Exposed 1.x pattern for: "build a query with optional WHERE conditions, get the total count, then fetch one page with LIMIT + OFFSET". Likely something like:

```kotlin
// Option A — build condition upfront, use where { }, chain offset()
var cond: Op<Boolean> = Op.TRUE
if (userId != null) cond = cond and (CollectionTable.ownedBy eq userId)
if (organism != null) cond = cond and (CollectionTable.organism eq organism)
val query = CollectionTable.selectAll().where { cond }
val totalCount = query.count()
val paged = CollectionEntity.wrapRows(query.orderBy(...).limit(pageSize).offset(offset))

// Option B — go back to EntityClass.find { } and figure out offset
CollectionEntity.find { cond }.orderBy(...).limit(pageSize).offset(offset)
```

## Test plan
- [ ] Resolve compile error (correct Exposed 1.x pagination API)
- [ ] Run `./gradlew test --tests "*.CollectionsGetTest"` — all existing + 4 new tests pass
- [ ] Manually verify `GET /collections?page=2&pageSize=10` returns correct slice and `totalCount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)