### PR TITLE
feat(backend): add variantCount and includeVariants param to collections endpoint

### DIFF
--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/api/Collection.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/api/Collection.kt
@@ -1,5 +1,6 @@
 package org.genspectrum.dashboardsbackend.api
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import kotlin.time.Instant
 
@@ -12,6 +13,7 @@ import kotlin.time.Instant
     "ownedBy": "user123",
     "organism": "covid",
     "description": "A collection of interesting variants",
+    "variantCount": 1,
     "variants": [],
     "createdAt": "2026-01-01T00:00:00Z",
     "updatedAt": "2026-01-02T00:00:00Z"
@@ -24,7 +26,9 @@ data class Collection(
     val ownedBy: Long,
     val organism: String,
     val description: String?,
-    val variants: List<Variant>,
+    val variantCount: Int,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val variants: List<Variant>?,
     val createdAt: Instant,
     val updatedAt: Instant,
 )

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/api/Collection.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/api/Collection.kt
@@ -10,11 +10,10 @@ import kotlin.time.Instant
 {
     "id": 1,
     "name": "My Collection",
-    "ownedBy": "user123",
+    "ownedBy": 123,
     "organism": "covid",
     "description": "A collection of interesting variants",
     "variantCount": 1,
-    "variants": [],
     "createdAt": "2026-01-01T00:00:00Z",
     "updatedAt": "2026-01-02T00:00:00Z"
 }

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsController.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsController.kt
@@ -23,14 +23,17 @@ class CollectionsController(private val collectionModel: CollectionModel) {
     @GetMapping("/collections", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(
         summary = "Get collections",
-        description = "Returns collections filtered by optional userId and/or organism parameters.",
+        description = "Returns collections filtered by optional userId and/or organism parameters. " +
+            "Set includeVariants=true to include the full variant list; by default only variantCount is returned.",
     )
     fun getCollections(
         @RequestParam(required = false) userId: Long?,
         @RequestParam(required = false) organism: String?,
+        @RequestParam(required = false, defaultValue = "false") includeVariants: Boolean,
     ): List<Collection> = collectionModel.getCollections(
         userId = userId,
         organism = organism,
+        includeVariants = includeVariants,
     )
 
     @GetMapping("/collections/{id}", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
@@ -25,7 +25,7 @@ import kotlin.time.Instant
 @Service
 @Transactional
 class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
-    fun getCollections(userId: Long?, organism: String?): List<Collection> {
+    fun getCollections(userId: Long?, organism: String?, includeVariants: Boolean = false): List<Collection> {
         if (userId != null) {
             UserEntity.findById(userId) ?: throw NotFoundException("User $userId not found")
         }
@@ -66,7 +66,8 @@ class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
                 ownedBy = collectionEntity.ownedBy,
                 organism = collectionEntity.organism,
                 description = collectionEntity.description,
-                variants = variants,
+                variantCount = variants.size,
+                variants = if (includeVariants) variants else null,
                 createdAt = collectionEntity.createdAt,
                 updatedAt = collectionEntity.updatedAt,
             )
@@ -100,13 +101,15 @@ class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
             variantEntity
         }
 
+        val variants = variantEntities.map { it.toVariant() }
         return Collection(
             id = collectionEntity.id.value,
             name = collectionEntity.name,
             ownedBy = collectionEntity.ownedBy,
             organism = collectionEntity.organism,
             description = collectionEntity.description,
-            variants = variantEntities.map { it.toVariant() },
+            variantCount = variants.size,
+            variants = variants,
             createdAt = collectionEntity.createdAt,
             updatedAt = collectionEntity.updatedAt,
         )

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
@@ -14,10 +14,12 @@ import org.genspectrum.dashboardsbackend.model.user.UserEntity
 import org.genspectrum.dashboardsbackend.util.now
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.count
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.select
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import kotlin.time.Instant
@@ -53,24 +55,47 @@ class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
         if (collectionEntities.isEmpty()) {
             return emptyList()
         }
-        // Batch-load all variants
         val allCollectionIds = collectionEntities.map { it.id }
-        val variantsByCollectionId = VariantEntity
-            .find { VariantTable.collectionId inList allCollectionIds }
-            .groupBy { it.collectionId }
-        return collectionEntities.map { collectionEntity ->
-            val variants = variantsByCollectionId[collectionEntity.id].orEmpty().map { it.toVariant() }
-            Collection(
-                id = collectionEntity.id.value,
-                name = collectionEntity.name,
-                ownedBy = collectionEntity.ownedBy,
-                organism = collectionEntity.organism,
-                description = collectionEntity.description,
-                variantCount = variants.size,
-                variants = if (includeVariants) variants else null,
-                createdAt = collectionEntity.createdAt,
-                updatedAt = collectionEntity.updatedAt,
-            )
+
+        if (includeVariants) {
+            val variantsByCollectionId = VariantEntity
+                .find { VariantTable.collectionId inList allCollectionIds }
+                .groupBy { it.collectionId }
+            return collectionEntities.map { collectionEntity ->
+                val variants = variantsByCollectionId[collectionEntity.id].orEmpty().map { it.toVariant() }
+                Collection(
+                    id = collectionEntity.id.value,
+                    name = collectionEntity.name,
+                    ownedBy = collectionEntity.ownedBy,
+                    organism = collectionEntity.organism,
+                    description = collectionEntity.description,
+                    variantCount = variants.size,
+                    variants = variants,
+                    createdAt = collectionEntity.createdAt,
+                    updatedAt = collectionEntity.updatedAt,
+                )
+            }
+        } else {
+            val countExpr = VariantTable.id.count()
+            val countByCollectionId = VariantTable
+                .select(VariantTable.collectionId, countExpr)
+                // we're not doing a 'where' to filter only for collections we care about,
+                // because it's faster to just get the whole map and then pick the entries we need.
+                .groupBy(VariantTable.collectionId)
+                .associate { row -> row[VariantTable.collectionId].value to row[countExpr].toInt() }
+            return collectionEntities.map { collectionEntity ->
+                Collection(
+                    id = collectionEntity.id.value,
+                    name = collectionEntity.name,
+                    ownedBy = collectionEntity.ownedBy,
+                    organism = collectionEntity.organism,
+                    description = collectionEntity.description,
+                    variantCount = countByCollectionId[collectionEntity.id.value] ?: 0,
+                    variants = null,
+                    createdAt = collectionEntity.createdAt,
+                    updatedAt = collectionEntity.updatedAt,
+                )
+            }
         }
     }
 

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
@@ -12,14 +12,15 @@ import org.genspectrum.dashboardsbackend.controller.ForbiddenException
 import org.genspectrum.dashboardsbackend.controller.NotFoundException
 import org.genspectrum.dashboardsbackend.model.user.UserEntity
 import org.genspectrum.dashboardsbackend.util.now
+import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.count
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import kotlin.time.Instant
@@ -35,67 +36,73 @@ class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
             dashboardsConfig.validateIsValidOrganism(organism)
             dashboardsConfig.validateCollectionsEnabled(organism)
         }
-        val query = if (userId == null && organism == null) {
-            CollectionEntity.all()
-        } else {
-            CollectionEntity.find {
-                var conditions: Op<Boolean> = Op.TRUE
-                if (userId != null) {
-                    conditions = conditions and (CollectionTable.ownedBy eq userId)
-                }
-                if (organism != null) {
-                    conditions = conditions and (CollectionTable.organism eq organism)
-                }
-                conditions
-            }
+
+        var collectionConditions: Op<Boolean> = Op.TRUE
+        if (userId != null) {
+            collectionConditions = collectionConditions and (CollectionTable.ownedBy eq userId)
+        }
+        if (organism != null) {
+            collectionConditions = collectionConditions and (CollectionTable.organism eq organism)
         }
 
-        // Materialize the collections first to avoid re-running the query
-        val collectionEntities = query.toList()
-        if (collectionEntities.isEmpty()) {
-            return emptyList()
-        }
-        val allCollectionIds = collectionEntities.map { it.id }
+        val join = CollectionTable.join(VariantTable, JoinType.LEFT)
 
-        if (includeVariants) {
-            val variantsByCollectionId = VariantEntity
-                .find { VariantTable.collectionId inList allCollectionIds }
-                .groupBy { it.collectionId }
-            return collectionEntities.map { collectionEntity ->
-                val variants = variantsByCollectionId[collectionEntity.id].orEmpty().map { it.toVariant() }
-                Collection(
-                    id = collectionEntity.id.value,
-                    name = collectionEntity.name,
-                    ownedBy = collectionEntity.ownedBy,
-                    organism = collectionEntity.organism,
-                    description = collectionEntity.description,
-                    variantCount = variants.size,
-                    variants = variants,
-                    createdAt = collectionEntity.createdAt,
-                    updatedAt = collectionEntity.updatedAt,
-                )
-            }
+        return if (includeVariants) {
+            join.selectAll()
+                .where { collectionConditions }
+                .groupBy { it[CollectionTable.id] }
+                .map { (_, rows) ->
+                    val first = rows.first()
+                    val variants = rows.mapNotNull { row ->
+                        row.getOrNull(VariantTable.id)?.let { row.toVariant() }
+                    }
+                    Collection(
+                        id = first[CollectionTable.id].value,
+                        name = first[CollectionTable.name],
+                        ownedBy = first[CollectionTable.ownedBy],
+                        organism = first[CollectionTable.organism],
+                        description = first[CollectionTable.description],
+                        variantCount = variants.size,
+                        variants = variants,
+                        createdAt = first[CollectionTable.createdAt],
+                        updatedAt = first[CollectionTable.updatedAt],
+                    )
+                }
         } else {
             val countExpr = VariantTable.id.count()
-            val countByCollectionId = VariantTable
-                .select(VariantTable.collectionId, countExpr)
-                // we're not doing a 'where' to filter only for collections we care about,
-                // because it's faster to just get the whole map and then pick the entries we need.
-                .groupBy(VariantTable.collectionId)
-                .associate { row -> row[VariantTable.collectionId].value to row[countExpr].toInt() }
-            return collectionEntities.map { collectionEntity ->
-                Collection(
-                    id = collectionEntity.id.value,
-                    name = collectionEntity.name,
-                    ownedBy = collectionEntity.ownedBy,
-                    organism = collectionEntity.organism,
-                    description = collectionEntity.description,
-                    variantCount = countByCollectionId[collectionEntity.id.value] ?: 0,
-                    variants = null,
-                    createdAt = collectionEntity.createdAt,
-                    updatedAt = collectionEntity.updatedAt,
+            join.select(
+                CollectionTable.id,
+                CollectionTable.name,
+                CollectionTable.ownedBy,
+                CollectionTable.organism,
+                CollectionTable.description,
+                CollectionTable.createdAt,
+                CollectionTable.updatedAt,
+                countExpr,
+            )
+                .where { collectionConditions }
+                .groupBy(
+                    CollectionTable.id,
+                    CollectionTable.name,
+                    CollectionTable.ownedBy,
+                    CollectionTable.organism,
+                    CollectionTable.description,
+                    CollectionTable.createdAt,
+                    CollectionTable.updatedAt,
                 )
-            }
+                .map { row ->
+                    Collection(
+                        id = row[CollectionTable.id].value,
+                        name = row[CollectionTable.name],
+                        ownedBy = row[CollectionTable.ownedBy],
+                        organism = row[CollectionTable.organism],
+                        description = row[CollectionTable.description],
+                        variantCount = row[countExpr].toInt(),
+                        variants = null,
+                        createdAt = row[CollectionTable.createdAt],
+                        updatedAt = row[CollectionTable.updatedAt],
+                    )
+                }
         }
     }
 

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionTable.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionTable.kt
@@ -34,14 +34,18 @@ class CollectionEntity(id: EntityID<Long>) : LongEntity(id) {
     // Navigation property to access variants
     val variants by VariantEntity referrersOn VariantTable.collectionId
 
-    fun toCollection() = Collection(
-        id = id.value,
-        name = name,
-        ownedBy = ownedBy,
-        organism = organism,
-        description = description,
-        variants = variants.map { it.toVariant() },
-        createdAt = createdAt,
-        updatedAt = updatedAt,
-    )
+    fun toCollection(): Collection {
+        val variantList = variants.map { it.toVariant() }
+        return Collection(
+            id = id.value,
+            name = name,
+            ownedBy = ownedBy,
+            organism = organism,
+            description = description,
+            variantCount = variantList.size,
+            variants = variantList,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+    }
 }

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/VariantTable.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/VariantTable.kt
@@ -4,6 +4,7 @@ import org.genspectrum.dashboardsbackend.api.FilterObject
 import org.genspectrum.dashboardsbackend.api.Variant
 import org.genspectrum.dashboardsbackend.model.subscription.jacksonSerializableJsonb
 import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 import org.jetbrains.exposed.v1.dao.LongEntity
@@ -109,6 +110,35 @@ class VariantEntity(id: EntityID<Long>) : LongEntity(id) {
             filterObject = filterObject!!,
             createdAt = createdAt,
             updatedAt = updatedAt,
+        )
+    }
+}
+
+/**
+ * Maps a raw ResultRow from a JOIN query to a Variant, as an alternative to [VariantEntity.toVariant]
+ * which requires the DAO layer.
+ **/
+fun ResultRow.toVariant(): Variant {
+    val variantType = VariantType.fromDatabaseValue(this[VariantTable.variantType])
+    return when (variantType) {
+        VariantType.QUERY -> Variant.QueryVariant(
+            id = this[VariantTable.id].value,
+            collectionId = this[VariantTable.collectionId].value,
+            name = this[VariantTable.name],
+            description = this[VariantTable.description],
+            countQuery = this[VariantTable.countQuery]!!,
+            coverageQuery = this[VariantTable.coverageQuery],
+            createdAt = this[VariantTable.createdAt],
+            updatedAt = this[VariantTable.updatedAt],
+        )
+        VariantType.FILTER_OBJECT -> Variant.FilterObjectVariant(
+            id = this[VariantTable.id].value,
+            collectionId = this[VariantTable.collectionId].value,
+            name = this[VariantTable.name],
+            description = this[VariantTable.description],
+            filterObject = this[VariantTable.filterObject]!!,
+            createdAt = this[VariantTable.createdAt],
+            updatedAt = this[VariantTable.updatedAt],
         )
     }
 }

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsClient.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsClient.kt
@@ -27,11 +27,16 @@ class CollectionsClient(private val mockMvc: MockMvc, private val objectMapper: 
             .andExpect(status().isCreated),
     )
 
-    fun getCollectionsRaw(userId: Long? = null, organism: String? = null): ResultActions {
+    fun getCollectionsRaw(
+        userId: Long? = null,
+        organism: String? = null,
+        includeVariants: Boolean = false,
+    ): ResultActions {
         val params = buildString {
             val queryParams = mutableListOf<String>()
             if (userId != null) queryParams.add("userId=$userId")
             if (organism != null) queryParams.add("organism=$organism")
+            if (includeVariants) queryParams.add("includeVariants=true")
             if (queryParams.isNotEmpty()) {
                 append("?")
                 append(queryParams.joinToString("&"))
@@ -40,8 +45,12 @@ class CollectionsClient(private val mockMvc: MockMvc, private val objectMapper: 
         return mockMvc.perform(get("/collections$params"))
     }
 
-    fun getCollections(userId: Long? = null, organism: String? = null): List<Collection> = deserializeJsonResponse(
-        getCollectionsRaw(userId, organism)
+    fun getCollections(
+        userId: Long? = null,
+        organism: String? = null,
+        includeVariants: Boolean = false,
+    ): List<Collection> = deserializeJsonResponse(
+        getCollectionsRaw(userId, organism, includeVariants)
             .andExpect(status().isOk),
     )
 

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
@@ -44,8 +44,8 @@ class CollectionsGetTest(
             userB,
         )
 
-        val collectionsForUserA = collectionsClient.getCollections(userId = userA)
-        val collectionsForUserB = collectionsClient.getCollections(userId = userB)
+        val collectionsForUserA = collectionsClient.getCollections(userId = userA, includeVariants = true)
+        val collectionsForUserB = collectionsClient.getCollections(userId = userB, includeVariants = true)
 
         assertThat(collectionsForUserA, hasItem(collectionA))
         assertThat(collectionsForUserA, not(hasItem(collectionB)))
@@ -72,7 +72,7 @@ class CollectionsGetTest(
             userB,
         )
 
-        val allCollections = collectionsClient.getCollections()
+        val allCollections = collectionsClient.getCollections(includeVariants = true)
 
         assertThat(allCollections, hasItem(covidCollectionA))
         assertThat(allCollections, hasItem(mpoxCollectionA))
@@ -87,7 +87,7 @@ class CollectionsGetTest(
         val collectionA = collectionsClient.postCollection(dummyCollectionRequest.copy(name = "User A"), userA)
         val collectionB = collectionsClient.postCollection(dummyCollectionRequest.copy(name = "User B"), userB)
 
-        val collectionsForUserA = collectionsClient.getCollections(userId = userA)
+        val collectionsForUserA = collectionsClient.getCollections(userId = userA, includeVariants = true)
 
         assertThat(collectionsForUserA, hasItem(collectionA))
         assertThat(collectionsForUserA, not(hasItem(collectionB)))
@@ -98,7 +98,7 @@ class CollectionsGetTest(
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
 
-        collectionsClient.getCollectionsRaw(userId = userId)
+        collectionsClient.getCollectionsRaw(userId = userId, includeVariants = true)
             .andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(createdCollection.id))
             .andExpect(jsonPath("$[0].variants[0].type").value("query"))
@@ -127,7 +127,10 @@ class CollectionsGetTest(
             userId,
         )
 
-        val covidCollections = collectionsClient.getCollections(organism = KnownTestOrganisms.Covid.name)
+        val covidCollections = collectionsClient.getCollections(
+            organism = KnownTestOrganisms.Covid.name,
+            includeVariants = true,
+        )
 
         assertThat(covidCollections, hasItem(covidCollection))
         assertThat(covidCollections, not(hasItem(mpoxCollection)))
@@ -161,6 +164,7 @@ class CollectionsGetTest(
         val filteredCollections = collectionsClient.getCollections(
             userId = userA,
             organism = KnownTestOrganisms.Covid.name,
+            includeVariants = true,
         )
 
         assertThat(filteredCollections, hasItem(covidCollectionA))
@@ -186,19 +190,20 @@ class CollectionsGetTest(
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
 
-        val collections = collectionsClient.getCollections(userId = userId)
+        val collections = collectionsClient.getCollections(userId = userId, includeVariants = true)
         val retrievedCollection = collections.first { it.id == createdCollection.id }
 
-        assertThat(retrievedCollection.variants, hasSize(2))
+        val variants = retrievedCollection.variants!!
+        assertThat(variants, hasSize(2))
 
-        val queryVariant = retrievedCollection.variants.first { it is Variant.QueryVariant } as Variant.QueryVariant
+        val queryVariant = variants.first { it is Variant.QueryVariant } as Variant.QueryVariant
         assertThat(queryVariant.name, equalTo("BA.2 in USA"))
         assertThat(queryVariant.description, equalTo("BA.2 lineage cases in USA"))
         assertThat(queryVariant.countQuery, equalTo("country='USA' & lineage='BA.2'"))
         assertThat(queryVariant.coverageQuery, equalTo("country='USA'"))
 
         val filterObjectVariant =
-            retrievedCollection.variants.first { it is Variant.FilterObjectVariant } as Variant.FilterObjectVariant
+            variants.first { it is Variant.FilterObjectVariant } as Variant.FilterObjectVariant
         assertThat(filterObjectVariant.name, equalTo("Omicron mutations"))
         assertThat(filterObjectVariant.description, equalTo("Key mutations"))
         assertThat(
@@ -212,11 +217,12 @@ class CollectionsGetTest(
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
 
-        val collections = collectionsClient.getCollections(userId = userId)
+        val collections = collectionsClient.getCollections(userId = userId, includeVariants = true)
         val retrievedCollection = collections.first { it.id == createdCollection.id }
 
-        val queryVariants = retrievedCollection.variants.filterIsInstance<Variant.QueryVariant>()
-        val filterObjectVariants = retrievedCollection.variants.filterIsInstance<Variant.FilterObjectVariant>()
+        val allVariants = retrievedCollection.variants!!
+        val queryVariants = allVariants.filterIsInstance<Variant.QueryVariant>()
+        val filterObjectVariants = allVariants.filterIsInstance<Variant.FilterObjectVariant>()
 
         assertThat(queryVariants, hasSize(1))
         assertThat(filterObjectVariants, hasSize(1))
@@ -237,7 +243,7 @@ class CollectionsGetTest(
         assertThat(retrievedCollection.ownedBy, equalTo(userId))
         assertThat(retrievedCollection.organism, equalTo(dummyCollectionRequest.organism))
         assertThat(retrievedCollection.description, equalTo(dummyCollectionRequest.description))
-        assertThat(retrievedCollection.variants, hasSize(2))
+        assertThat(retrievedCollection.variants!!, hasSize(2))
     }
 
     @Test
@@ -281,5 +287,28 @@ class CollectionsGetTest(
         collectionsClient.getCollectionsRaw(userId = 999999999L)
             .andExpect(status().isNotFound)
             .andExpect(jsonPath("$.detail").value("User 999999999 not found"))
+    }
+
+    @Test
+    fun `WHEN getting collections without includeVariants THEN variantCount is set and variants is absent`() {
+        val userId = usersClient.createUser()
+        collectionsClient.postCollection(dummyCollectionRequest, userId)
+
+        collectionsClient.getCollectionsRaw(userId = userId)
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].variantCount").value(2))
+            .andExpect(jsonPath("$[0].variants").doesNotExist())
+    }
+
+    @Test
+    fun `WHEN getting collections with includeVariants=true THEN variantCount and variants are both present`() {
+        val userId = usersClient.createUser()
+        collectionsClient.postCollection(dummyCollectionRequest, userId)
+
+        collectionsClient.getCollectionsRaw(userId = userId, includeVariants = true)
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].variantCount").value(2))
+            .andExpect(jsonPath("$[0].variants").isArray)
+            .andExpect(jsonPath("$[0].variants", hasSize<Any>(2)))
     }
 }

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsPostTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsPostTest.kt
@@ -43,7 +43,7 @@ class CollectionsPostTest(
         assertThat(createdCollection.createdAt, notNullValue())
         assertThat(createdCollection.updatedAt, notNullValue())
         assertThat(createdCollection.createdAt, equalTo(createdCollection.updatedAt))
-        createdCollection.variants.forEach { variant ->
+        createdCollection.variants!!.forEach { variant ->
             when (variant) {
                 is Variant.QueryVariant -> {
                     assertThat(variant.createdAt, notNullValue())
@@ -89,9 +89,10 @@ class CollectionsPostTest(
         assertThat(createdCollection.ownedBy, equalTo(userId))
         assertThat(createdCollection.organism, equalTo(dummyCollectionRequest.organism))
         assertThat(createdCollection.description, equalTo(dummyCollectionRequest.description))
-        assertThat(createdCollection.variants, hasSize(2))
-        assertThat(createdCollection.variants[0].id, notNullValue())
-        assertThat(createdCollection.variants[1].id, notNullValue())
+        val variants = createdCollection.variants!!
+        assertThat(variants, hasSize(2))
+        assertThat(variants[0].id, notNullValue())
+        assertThat(variants[1].id, notNullValue())
     }
 
     @Test
@@ -103,8 +104,9 @@ class CollectionsPostTest(
 
         val createdCollection = collectionsClient.postCollection(request, userId)
 
-        assertThat(createdCollection.variants, hasSize(1))
-        assertThat(createdCollection.variants[0], instanceOf(Variant.QueryVariant::class.java))
+        val variants = createdCollection.variants!!
+        assertThat(variants, hasSize(1))
+        assertThat(variants[0], instanceOf(Variant.QueryVariant::class.java))
     }
 
     @Test
@@ -116,8 +118,9 @@ class CollectionsPostTest(
 
         val createdCollection = collectionsClient.postCollection(request, userId)
 
-        assertThat(createdCollection.variants, hasSize(1))
-        assertThat(createdCollection.variants[0], instanceOf(Variant.FilterObjectVariant::class.java))
+        val variants = createdCollection.variants!!
+        assertThat(variants, hasSize(1))
+        assertThat(variants[0], instanceOf(Variant.FilterObjectVariant::class.java))
     }
 
     @Test
@@ -127,7 +130,7 @@ class CollectionsPostTest(
 
         val createdCollection = collectionsClient.postCollection(request, userId)
 
-        assertThat(createdCollection.variants, empty())
+        assertThat(createdCollection.variants!!, empty())
     }
 
     @Test
@@ -164,8 +167,9 @@ class CollectionsPostTest(
 
         val createdCollection = collectionsClient.postCollection(request, userId)
 
-        assertThat(createdCollection.variants, hasSize(1))
-        val variant = createdCollection.variants[0] as Variant.FilterObjectVariant
+        val variants = createdCollection.variants!!
+        assertThat(variants, hasSize(1))
+        val variant = variants[0] as Variant.FilterObjectVariant
         assertThat(variant.filterObject.aminoAcidMutations, equalTo(listOf("S:N501Y")))
         assertThat(variant.filterObject.getFilters()["pangoLineage"], equalTo("BA.2*"))
     }
@@ -205,7 +209,7 @@ class CollectionsPostTest(
 
         val createdCollection = collectionsClient.postCollection(request, userId)
 
-        val variant = createdCollection.variants[0] as Variant.FilterObjectVariant
+        val variant = createdCollection.variants!![0] as Variant.FilterObjectVariant
         assertThat(variant.filterObject.getFilters()["pangoLineage"], equalTo("BA.2*"))
         assertThat(variant.filterObject.getFilters()["nextcladePangoLineage"], equalTo("BA.2.75*"))
     }
@@ -224,7 +228,7 @@ class CollectionsPostTest(
 
         val createdCollection = collectionsClient.postCollection(request, userId)
 
-        val variant = createdCollection.variants[0] as Variant.FilterObjectVariant
+        val variant = createdCollection.variants!![0] as Variant.FilterObjectVariant
         assertThat(variant.filterObject.aminoAcidMutations, equalTo(listOf("S:N501Y", "S:E484K")))
         assertThat(variant.filterObject.nucleotideMutations, nullValue())
     }
@@ -245,7 +249,7 @@ class CollectionsPostTest(
 
         val createdCollection = collectionsClient.postCollection(request, userId)
 
-        val variant = createdCollection.variants[0] as Variant.FilterObjectVariant
+        val variant = createdCollection.variants!![0] as Variant.FilterObjectVariant
         assertThat(variant.filterObject.aminoAcidInsertions, equalTo(listOf("ins_S:214:EPE")))
         assertThat(variant.filterObject.nucleotideInsertions, equalTo(listOf("ins_22204:GAG")))
     }

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsPutTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsPutTest.kt
@@ -55,8 +55,9 @@ class CollectionsPutTest(
 
         assertThat(updated.name, equalTo("Updated Name"))
         assertThat(updated.description, equalTo("Updated Description"))
-        assertThat(updated.variants.size, equalTo(1))
-        val firstVariant = updated.variants[0] as Variant.QueryVariant
+        val resultVariants = updated.variants!!
+        assertThat(resultVariants.size, equalTo(1))
+        val firstVariant = resultVariants[0] as Variant.QueryVariant
         assertThat(firstVariant.name, equalTo("New Variant"))
     }
 
@@ -64,7 +65,7 @@ class CollectionsPutTest(
     fun `WHEN owner updates only name THEN only name changes`() {
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
-        val originalVariantCount = createdCollection.variants.size
+        val originalVariantCount = createdCollection.variants!!.size
 
         val update = CollectionUpdate(name = "Just Name Change")
 
@@ -72,7 +73,7 @@ class CollectionsPutTest(
 
         assertThat(updated.name, equalTo("Just Name Change"))
         assertThat(updated.description, equalTo(createdCollection.description))
-        assertThat(updated.variants.size, equalTo(originalVariantCount))
+        assertThat(updated.variants!!.size, equalTo(originalVariantCount))
     }
 
     @Test
@@ -84,7 +85,7 @@ class CollectionsPutTest(
 
         assertThat(updated.name, equalTo(createdCollection.name))
         assertThat(updated.description, equalTo(createdCollection.description))
-        assertThat(updated.variants.size, equalTo(createdCollection.variants.size))
+        assertThat(updated.variants!!.size, equalTo(createdCollection.variants!!.size))
         assertThat(updated.createdAt, equalTo(createdCollection.createdAt))
     }
 
@@ -131,7 +132,7 @@ class CollectionsPutTest(
     fun `WHEN owner adds new variant without ID THEN variant is created`() {
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
-        val originalVariantCount = createdCollection.variants.size
+        val originalVariantCount = createdCollection.variants!!.size
 
         val newVariant = VariantUpdate.FilterObjectVariantUpdate(
             id = null,
@@ -141,7 +142,7 @@ class CollectionsPutTest(
             },
         )
 
-        val existingVariants = createdCollection.variants.map { variant ->
+        val existingVariants = createdCollection.variants!!.map { variant ->
             when (variant) {
                 is Variant.QueryVariant -> VariantUpdate.QueryVariantUpdate(
                     id = variant.id,
@@ -163,9 +164,10 @@ class CollectionsPutTest(
 
         val updated = collectionsClient.putCollection(update, createdCollection.id, userId)
 
-        assertThat(updated.variants.size, equalTo(originalVariantCount + 1))
+        val updatedVariants2 = updated.variants!!
+        assertThat(updatedVariants2.size, equalTo(originalVariantCount + 1))
         assertThat(
-            updated.variants.any { variant ->
+            updatedVariants2.any { variant ->
                 when (variant) {
                     is Variant.QueryVariant -> variant.name == "New Variant"
                     is Variant.FilterObjectVariant -> variant.name == "New Variant"
@@ -195,7 +197,7 @@ class CollectionsPutTest(
     fun `WHEN owner updates existing variant with ID THEN variant is updated in place`() {
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
-        val firstVariant = createdCollection.variants[0] as Variant.QueryVariant
+        val firstVariant = createdCollection.variants!![0] as Variant.QueryVariant
 
         val updatedVariant = VariantUpdate.QueryVariantUpdate(
             id = firstVariant.id,
@@ -209,9 +211,10 @@ class CollectionsPutTest(
 
         val updated = collectionsClient.putCollection(update, createdCollection.id, userId)
 
-        assertThat(updated.variants.size, equalTo(1))
-        assertThat(updated.variants[0].id, equalTo(firstVariant.id))
-        val queryVariant = updated.variants[0] as Variant.QueryVariant
+        val updatedVariants3 = updated.variants!!
+        assertThat(updatedVariants3.size, equalTo(1))
+        assertThat(updatedVariants3[0].id, equalTo(firstVariant.id))
+        val queryVariant = updatedVariants3[0] as Variant.QueryVariant
         assertThat(queryVariant.name, equalTo("Updated Name"))
         assertThat(queryVariant.countQuery, equalTo("country='France'"))
     }
@@ -232,7 +235,7 @@ class CollectionsPutTest(
         val collectionRequest = dummyCollectionRequest.copy(variants = originalVariants)
         val createdCollection = collectionsClient.postCollection(collectionRequest, userId)
 
-        val firstVariant = createdCollection.variants[0]
+        val firstVariant = createdCollection.variants!![0]
         val keepVariant = VariantUpdate.QueryVariantUpdate(
             id = firstVariant.id,
             name = (firstVariant as Variant.QueryVariant).name,
@@ -243,8 +246,9 @@ class CollectionsPutTest(
 
         val updated = collectionsClient.putCollection(update, createdCollection.id, userId)
 
-        assertThat(updated.variants.size, equalTo(1))
-        assertThat(updated.variants[0].id, equalTo(firstVariant.id))
+        val updatedVariants4 = updated.variants!!
+        assertThat(updatedVariants4.size, equalTo(1))
+        assertThat(updatedVariants4[0].id, equalTo(firstVariant.id))
     }
 
     @Test
@@ -272,7 +276,7 @@ class CollectionsPutTest(
     fun `WHEN updating variant type THEN returns 400`() {
         val userId = usersClient.createUser()
         val createdCollection = collectionsClient.postCollection(dummyCollectionRequest, userId)
-        val firstVariant = createdCollection.variants[0] as Variant.QueryVariant
+        val firstVariant = createdCollection.variants!![0] as Variant.QueryVariant
 
         val invalidUpdate = VariantUpdate.FilterObjectVariantUpdate(
             id = firstVariant.id,
@@ -310,7 +314,7 @@ class CollectionsPutTest(
             userId,
         )
 
-        val variantFromCollection2 = collection2.variants[0] as Variant.QueryVariant
+        val variantFromCollection2 = collection2.variants!![0] as Variant.QueryVariant
         val invalidUpdate = VariantUpdate.QueryVariantUpdate(
             id = variantFromCollection2.id,
             name = variantFromCollection2.name,

--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -8,7 +8,7 @@ import { type OrganismsConfig } from './src/config';
 import type { CollectionRaw } from './src/covspectrum/types.ts';
 import type { LapisInfo } from './src/lapis/getLastUpdatedDate.ts';
 import type { ParsedQueryResult, ParseQueryRequest } from './src/lapis/parseQuery.ts';
-import type { Collection } from './src/types/Collection.ts';
+import type { CollectionSummary } from './src/types/Collection.ts';
 import type { ProblemDetail } from './src/types/ProblemDetail.ts';
 import type {
     SubscriptionPutRequest,
@@ -30,7 +30,7 @@ export class AstroApiRouteMocker {
         this.workerOrServer.use(http.post(`${ASTRO_SERVER_URL}/log`, () => Response.json({})));
     }
 
-    mockGetCollections(response: Collection[], organism?: string, statusCode = 200) {
+    mockGetCollectionSummaries(response: CollectionSummary[], organism?: string, statusCode = 200) {
         this.workerOrServer.use(
             http.get(
                 `${ASTRO_SERVER_URL}/collections`,
@@ -216,7 +216,7 @@ export class BackendRouteMocker {
         );
     }
 
-    mockGetCollections(response: Collection[], organism?: string, statusCode = 200) {
+    mockGetCollectionSummaries(response: CollectionSummary[], organism?: string, statusCode = 200) {
         this.workerOrServer.use(
             http.get(
                 `${DUMMY_BACKEND_URL}/collections`,

--- a/website/src/backendApi/backendService.spec.ts
+++ b/website/src/backendApi/backendService.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { BackendError, BackendService, UnknownBackendError } from './backendService.ts';
 import { DUMMY_BACKEND_URL } from '../../routeMocker.ts';
 import { backendRouteMocker } from '../../vitest.setup.ts';
-import type { Collection } from '../types/Collection.ts';
+import type { CollectionSummary } from '../types/Collection.ts';
 import type { SubscriptionRequest, SubscriptionResponse, TriggerEvaluationResponse } from '../types/Subscription.ts';
 
 describe('backendService', () => {
@@ -172,24 +172,26 @@ describe('backendService', () => {
         );
     });
 
-    const aCollection: Collection = {
+    const aCollection: CollectionSummary = {
         id: 1,
         name: 'Test collection',
         ownedBy: 123,
         organism: 'covid',
         description: 'A test collection',
-        variants: [],
+        variantCount: 0,
     };
 
-    test('should GET collections without organism filter', async () => {
-        backendRouteMocker.mockGetCollections([aCollection]);
+    test('should GET collection summaries without organism filter', async () => {
+        backendRouteMocker.mockGetCollectionSummaries([aCollection]);
 
-        await expect(backendService.getCollections()).resolves.to.deep.equal([aCollection]);
+        await expect(backendService.getCollectionSummaries()).resolves.to.deep.equal([aCollection]);
     });
 
-    test('should GET collections filtered by organism', async () => {
-        backendRouteMocker.mockGetCollections([aCollection], 'covid');
+    test('should GET collection summaries filtered by organism', async () => {
+        backendRouteMocker.mockGetCollectionSummaries([aCollection], 'covid');
 
-        await expect(backendService.getCollections({ organism: 'covid' })).resolves.to.deep.equal([aCollection]);
+        await expect(backendService.getCollectionSummaries({ organism: 'covid' })).resolves.to.deep.equal([
+            aCollection,
+        ]);
     });
 });

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -3,7 +3,12 @@ import { z, type ZodSchema } from 'zod';
 
 import { UserFacingError } from '../components/ErrorReportInstruction.tsx';
 import { apiKeyMetadataSchema, generatedApiKeySchema } from '../types/ApiKey.ts';
-import { collectionSchema, type CollectionRequest, type CollectionUpdate } from '../types/Collection.ts';
+import {
+    collectionSchema,
+    collectionSummarySchema,
+    type CollectionRequest,
+    type CollectionUpdate,
+} from '../types/Collection.ts';
 import { type ProblemDetail, problemDetailSchema } from '../types/ProblemDetail.ts';
 import { publicUserSchema } from '../types/PublicUser.ts';
 import {
@@ -172,8 +177,14 @@ export class BackendService extends ApiService {
         return this.get({ url: `/users/${id}`, schema: publicUserSchema });
     }
 
-    public async getCollections({ organism }: { organism?: string } = {}) {
+    public async getCollectionSummaries({ organism }: { organism?: string } = {}) {
         const requestParams = organism !== undefined ? { organism } : undefined;
+        return this.get({ url: '/collections', requestParams, schema: z.array(collectionSummarySchema) });
+    }
+
+    public async getCollections({ organism }: { organism?: string } = {}) {
+        const requestParams: Record<string, string> = { includeVariants: 'true' };
+        if (organism !== undefined) requestParams.organism = organism;
         return this.get({ url: '/collections', requestParams, schema: z.array(collectionSchema) });
     }
 

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -15,35 +15,7 @@ const mockCollections = [
         ownedBy: 1,
         organism: ORGANISM,
         description: 'A test collection',
-        variants: [
-            {
-                type: 'query' as const,
-                id: 10,
-                collectionId: 1,
-                name: 'Variant A',
-                description: null,
-                countQuery: '{}',
-                coverageQuery: null,
-            },
-            {
-                type: 'query' as const,
-                id: 11,
-                collectionId: 1,
-                name: 'Variant B',
-                description: null,
-                countQuery: '{}',
-                coverageQuery: null,
-            },
-            {
-                type: 'query' as const,
-                id: 12,
-                collectionId: 1,
-                name: 'Variant C',
-                description: null,
-                countQuery: '{}',
-                coverageQuery: null,
-            },
-        ],
+        variantCount: 3,
     },
     {
         id: 2,
@@ -51,13 +23,13 @@ const mockCollections = [
         ownedBy: 1,
         organism: ORGANISM,
         description: null,
-        variants: [],
+        variantCount: 0,
     },
 ];
 
 describe('CollectionsOverview', () => {
     it('shows the headline and collections table on success', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollections(mockCollections, ORGANISM);
+        astro.mockGetCollectionSummaries(mockCollections, ORGANISM);
 
         const { getByText, getByRole } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);
 
@@ -70,7 +42,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows the headline and empty message when there are no collections', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollections([], ORGANISM);
+        astro.mockGetCollectionSummaries([], ORGANISM);
 
         const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);
 
@@ -79,7 +51,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows the headline and error message when the fetch fails', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollections([], ORGANISM, 500);
+        astro.mockGetCollectionSummaries([], ORGANISM, 500);
         astro.mockLog();
 
         const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -4,7 +4,7 @@ import { getBackendServiceForClientside } from '../../../backendApi/backendServi
 import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
 import { getClientLogger } from '../../../clientLogger.ts';
 import { PageHeadline } from '../../../styles/containers/PageHeadline.tsx';
-import type { Collection } from '../../../types/Collection.ts';
+import type { CollectionSummary } from '../../../types/Collection.ts';
 import { organismConfig, type Organism } from '../../../types/Organism.ts';
 import { Page } from '../../../types/pages.ts';
 import { getErrorLogMessage } from '../../../util/getErrorLogMessage.ts';
@@ -21,7 +21,7 @@ function CollectionsOverviewInner({ organism, isLoggedIn }: { organism: Organism
         error,
     } = useQuery({
         queryKey: ['collections', organism],
-        queryFn: () => getBackendServiceForClientside().getCollections({ organism }),
+        queryFn: () => getBackendServiceForClientside().getCollectionSummaries({ organism }),
     });
 
     if (isError) {
@@ -62,7 +62,7 @@ function CollectionsOverviewInner({ organism, isLoggedIn }: { organism: Organism
     );
 }
 
-function CollectionsTable({ collections, organism }: { collections: Collection[]; organism: Organism }) {
+function CollectionsTable({ collections, organism }: { collections: CollectionSummary[]; organism: Organism }) {
     return (
         <div className='my-6 overflow-x-auto'>
             <table className='table-zebra table w-full'>
@@ -104,7 +104,7 @@ function CollectionsTable({ collections, organism }: { collections: Collection[]
                                 </td>
                                 <td className='p-0'>
                                     <a href={href} className='block px-4 py-3 text-right'>
-                                        {collection.variants.length}
+                                        {collection.variantCount}
                                     </a>
                                 </td>
                             </tr>

--- a/website/src/types/Collection.ts
+++ b/website/src/types/Collection.ts
@@ -36,7 +36,7 @@ const collectionBaseSchema = z.object({
     ownedBy: z.number(),
     organism: z.string(),
     description: z.string().nullable(),
-    variantCount: z.number(),
+    variantCount: z.number().int().nonnegative(),
 });
 
 export const collectionSummarySchema = collectionBaseSchema;

--- a/website/src/types/Collection.ts
+++ b/website/src/types/Collection.ts
@@ -30,12 +30,19 @@ const filterObjectVariantSchema = z.object({
 
 const variantSchema = z.discriminatedUnion('type', [queryVariantSchema, filterObjectVariantSchema]);
 
-export const collectionSchema = z.object({
+const collectionBaseSchema = z.object({
     id: z.number(),
     name: z.string(),
     ownedBy: z.number(),
     organism: z.string(),
     description: z.string().nullable(),
+    variantCount: z.number(),
+});
+
+export const collectionSummarySchema = collectionBaseSchema;
+export type CollectionSummary = z.infer<typeof collectionSummarySchema>;
+
+export const collectionSchema = collectionBaseSchema.extend({
     variants: z.array(variantSchema),
 });
 


### PR DESCRIPTION
resolves #1107

## Summary

### Backend
- Added `variantCount: Int` field to the `Collection` response — always present on all collection endpoints
- Added `includeVariants` query parameter (default `false`) to `GET /collections`: when false, the `variants` key is omitted from the response, giving callers a lighter payload for list views
- `GET /collections/{id}` is unchanged — always returns the full variant list (plus the new `variantCount`)
- POST/PUT responses are unchanged — always include full variants and `variantCount`

#### API Example

`GET /collections` (default, `includeVariants=false`):
```json
{ "id": 1, "name": "...", "variantCount": 3, "createdAt": "..." }
```

`GET /collections?includeVariants=true`:
```json
{ "id": 1, "name": "...", "variantCount": 3, "variants": [...], "createdAt": "..." }
```

### Frontend
- Split the `collectionSchema` Zod schema into `collectionSummarySchema` (no `variants`, for the list endpoint) and `collectionSchema` (with required `variants`, for single-collection/create/update endpoints), with `variantCount` on both
- Renamed `backendService.getCollections` → `getCollectionSummaries` (returns `CollectionSummary[]`); added `getCollections` that passes `includeVariants=true` and returns `Collection[]`
- `CollectionsOverview` now uses `getCollectionSummaries` and reads `variantCount` directly instead of `variants.length`

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.