### PR TITLE
feat(website): predefined COVID variant signatures from collections (W-ASAP)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16,6 +16,7 @@
                 "better-auth": "^1.6.14",
                 "cookie": "^1.1.1",
                 "dayjs": "^1.11.21",
+                "downshift": "^9.3.3",
                 "katex": "^0.17.0",
                 "patch-package": "^8.0.1",
                 "react": "^19.2.7",
@@ -6495,9 +6496,9 @@
             }
         },
         "node_modules/downshift": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.2.tgz",
-            "integrity": "sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow==",
+            "version": "9.3.3",
+            "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.3.tgz",
+            "integrity": "sha512-otjI/WtoFcIXwPOyIQYkbrAZJA2Gjz67F8ENOh1RvmJalOg6fk0KEx4ljJSFuJB54ryc6doymPkCM+GjAZ7zjA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.28.6",
@@ -8224,6 +8225,13 @@
                 "@types/set-cookie-parser": "^2.4.10",
                 "set-cookie-parser": "^3.0.1"
             }
+        },
+        "node_modules/headers-polyfill/node_modules/set-cookie-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+            "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/html-escaper": {
             "version": "3.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,7 @@
         "cookie": "^1.1.1",
         "dayjs": "^1.11.21",
         "katex": "^0.17.0",
+        "downshift": "^9.3.3",
         "patch-package": "^8.0.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -177,14 +177,21 @@ export class BackendService extends ApiService {
         return this.get({ url: `/users/${id}`, schema: publicUserSchema });
     }
 
-    public async getCollectionSummaries(requestParams: { organism?: string; excludeSystemCollections?: boolean } = {}) {
-        return this.get({ url: '/collections', requestParams, schema: z.array(collectionSummarySchema) });
-    }
-
-    public async getCollections({ organism, userId }: { organism?: string; userId?: number } = {}) {
-        const requestParams: Record<string, string> = { includeVariants: 'true' };
+    public async getCollectionSummaries({ organism, userId, excludeSystemCollections }: { organism?: string; userId?: number; excludeSystemCollections?: boolean } = {}) {
+        const requestParams: Record<string, string> = {};
         if (organism !== undefined) requestParams.organism = organism;
         if (userId !== undefined) requestParams.userId = String(userId);
+        if (excludeSystemCollections !== undefined) requestParams.excludeSystemCollections = String(excludeSystemCollections);
+        return this.get({
+            url: '/collections',
+            requestParams: Object.keys(requestParams).length > 0 ? requestParams : undefined,
+            schema: z.array(collectionSummarySchema),
+        });
+    }
+
+    public async getCollections({ organism }: { organism?: string } = {}) {
+        const requestParams: Record<string, string> = { includeVariants: 'true' };
+        if (organism !== undefined) requestParams.organism = organism;
         return this.get({ url: '/collections', requestParams, schema: z.array(collectionSchema) });
     }
 

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -177,11 +177,16 @@ export class BackendService extends ApiService {
         return this.get({ url: `/users/${id}`, schema: publicUserSchema });
     }
 
-    public async getCollectionSummaries({ organism, userId, excludeSystemCollections }: { organism?: string; userId?: number; excludeSystemCollections?: boolean } = {}) {
+    public async getCollectionSummaries({
+        organism,
+        userId,
+        excludeSystemCollections,
+    }: { organism?: string; userId?: number; excludeSystemCollections?: boolean } = {}) {
         const requestParams: Record<string, string> = {};
         if (organism !== undefined) requestParams.organism = organism;
         if (userId !== undefined) requestParams.userId = String(userId);
-        if (excludeSystemCollections !== undefined) requestParams.excludeSystemCollections = String(excludeSystemCollections);
+        if (excludeSystemCollections !== undefined)
+            requestParams.excludeSystemCollections = String(excludeSystemCollections);
         return this.get({
             url: '/collections',
             requestParams: Object.keys(requestParams).length > 0 ? requestParams : undefined,

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -181,9 +181,10 @@ export class BackendService extends ApiService {
         return this.get({ url: '/collections', requestParams, schema: z.array(collectionSummarySchema) });
     }
 
-    public async getCollections({ organism }: { organism?: string } = {}) {
+    public async getCollections({ organism, userId }: { organism?: string; userId?: number } = {}) {
         const requestParams: Record<string, string> = { includeVariants: 'true' };
         if (organism !== undefined) requestParams.organism = organism;
+        if (userId !== undefined) requestParams.userId = String(userId);
         return this.get({ url: '/collections', requestParams, schema: z.array(collectionSchema) });
     }
 

--- a/website/src/components/pageStateSelectors/wasap/InfoBlocks.tsx
+++ b/website/src/components/pageStateSelectors/wasap/InfoBlocks.tsx
@@ -144,12 +144,12 @@ export function ExplorationModeInfo() {
                 </li>
                 <li>
                     <span className='font-semibold text-gray-900'>Variant Explorer:</span> track variant-specific
-                    mutations over time. Variant-specific mutations are computed based on user parameters and filtering
-                    clinical sequences from{' '}
+                    mutations over time. Variants can be defined in two ways: by selecting a predefined variant from a
+                    curated list, or by filtering clinical sequences from{' '}
                     <a className='link' href='https://cov-spectrum.org'>
                         CovSpectrum
-                    </a>
-                    .
+                    </a>{' '}
+                    based on user parameters.
                 </li>
                 <li>
                     <span className='font-semibold text-gray-900'>Untracked Mutations:</span> novel mutations not yet

--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -112,9 +112,9 @@ export function WasapPageStateSelector({
                     "This predefined variants query was called despite it being disabled. This should not happen.",
                 );
             }
-            const { collectionsUserId, collectionsTag } = config.predefinedVariantsSource;
+            const { collectionsUserId, collectionsOrganism, collectionsTag } = config.predefinedVariantsSource;
             return getBackendServiceForClientside()
-                .getCollections({ userId: collectionsUserId, organism: config.name })
+                .getCollectionSummaries({ userId: collectionsUserId, organism: collectionsOrganism })
                 .then((collections) => collections.filter((c) => c.description?.includes(collectionsTag) ?? false));
         },
     });

--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
+import { getBackendServiceForClientside } from '../../../backendApi/backendService';
+
 import { ApplyFilterButton } from '../ApplyFilterButton';
 import { DynamicDateFilter } from '../DynamicDateFilter';
 import { SelectorHeadline } from '../SelectorHeadline';
@@ -101,6 +103,22 @@ export function WasapPageStateSelector({
         },
     });
 
+    const predefinedVariantsQueryResult = useQuery({
+        enabled: config.variantAnalysisModeEnabled && config.predefinedVariantsSource !== undefined,
+        queryKey: ['predefinedVariants', config.variantAnalysisModeEnabled && config.predefinedVariantsSource],
+        queryFn: () => {
+            if (!config.variantAnalysisModeEnabled || config.predefinedVariantsSource === undefined) {
+                throw Error(
+                    "This predefined variants query was called despite it being disabled. This should not happen.",
+                );
+            }
+            const { collectionsUserId, collectionsTag } = config.predefinedVariantsSource;
+            return getBackendServiceForClientside()
+                .getCollections({ userId: collectionsUserId, organism: config.name })
+                .then((collections) => collections.filter((c) => c.description?.includes(collectionsTag) ?? false));
+        },
+    });
+
     return (
         <div className='flex flex-col gap-4'>
             <SelectorHeadline>Filter dataset</SelectorHeadline>
@@ -181,6 +199,11 @@ export function WasapPageStateSelector({
                                     setPageState={setVariantFilter}
                                     clinicalSequenceLapisBaseUrl={config.clinicalLapis.lapisBaseUrl}
                                     clinicalSequenceLapisLineageField={config.clinicalLapis.lineageField}
+                                    predefinedVariantsQueryResult={
+                                        config.predefinedVariantsSource !== undefined
+                                            ? predefinedVariantsQueryResult
+                                            : undefined
+                                    }
                                 />
                             );
                         case 'resistance':

--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -111,9 +111,9 @@ export function WasapPageStateSelector({
                     'This predefined variants query was called despite it being disabled. This should not happen.',
                 );
             }
-            const { collectionsUserId, collectionsOrganism, collectionsTag } = config.predefinedVariantsSource;
+            const { collectionsUserId, collectionsTag } = config.predefinedVariantsSource;
             return getBackendServiceForClientside()
-                .getCollectionSummaries({ userId: collectionsUserId, organism: collectionsOrganism })
+                .getCollectionSummaries({ userId: collectionsUserId, organism: config.internalName })
                 .then((collections) => collections.filter((c) => c.description?.includes(collectionsTag) ?? false));
         },
     });

--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
 import { getBackendServiceForClientside } from '../../../backendApi/backendService';
-
 import { ApplyFilterButton } from '../ApplyFilterButton';
 import { DynamicDateFilter } from '../DynamicDateFilter';
 import { SelectorHeadline } from '../SelectorHeadline';
@@ -109,7 +108,7 @@ export function WasapPageStateSelector({
         queryFn: () => {
             if (!config.variantAnalysisModeEnabled || config.predefinedVariantsSource === undefined) {
                 throw Error(
-                    "This predefined variants query was called despite it being disabled. This should not happen.",
+                    'This predefined variants query was called despite it being disabled. This should not happen.',
                 );
             }
             const { collectionsUserId, collectionsOrganism, collectionsTag } = config.predefinedVariantsSource;
@@ -204,6 +203,7 @@ export function WasapPageStateSelector({
                                             ? predefinedVariantsQueryResult
                                             : undefined
                                     }
+                                    predefinedVariantsLabel={config.predefinedVariantsSource?.variantSourceLabel}
                                 />
                             );
                         case 'resistance':

--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -105,16 +105,18 @@ export function WasapPageStateSelector({
     const predefinedVariantsQueryResult = useQuery({
         enabled: config.variantAnalysisModeEnabled && config.predefinedVariantsSource !== undefined,
         queryKey: ['predefinedVariants', config.variantAnalysisModeEnabled && config.predefinedVariantsSource],
-        queryFn: () => {
+        queryFn: async () => {
             if (!config.variantAnalysisModeEnabled || config.predefinedVariantsSource === undefined) {
                 throw Error(
                     'This predefined variants query was called despite it being disabled. This should not happen.',
                 );
             }
             const { collectionsUserId, collectionsTag } = config.predefinedVariantsSource;
-            return getBackendServiceForClientside()
-                .getCollectionSummaries({ userId: collectionsUserId, organism: config.internalName })
-                .then((collections) => collections.filter((c) => c.description?.includes(collectionsTag) ?? false));
+            const collections = await getBackendServiceForClientside().getCollectionSummaries({
+                userId: collectionsUserId,
+                organism: config.internalName,
+            });
+            return collections.filter((c) => c.description?.includes(collectionsTag) ?? false);
         },
     });
 

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx
@@ -12,6 +12,7 @@ const DUMMY_LAPIS_URL_2 = 'http://lapis2.dummy';
 describe('VariantExplorerFilter', () => {
     const defaultPageState: WasapVariantFilter = {
         mode: 'variant',
+        signatureType: 'computed',
         sequenceType: 'nucleotide',
         variant: undefined,
         minProportion: 0.05,

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx
@@ -1,5 +1,5 @@
-import { page, userEvent } from '@vitest/browser/context';
 import { type UseQueryResult } from '@tanstack/react-query';
+import { page, userEvent } from '@vitest/browser/context';
 import { describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx
@@ -1,13 +1,21 @@
-import { userEvent } from '@vitest/browser/context';
+import { page, userEvent } from '@vitest/browser/context';
+import { type UseQueryResult } from '@tanstack/react-query';
 import { describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { VariantExplorerFilter } from './VariantExplorerFilter';
 import { DUMMY_LAPIS_URL, type LapisRouteMocker } from '../../../../../routeMocker';
 import { it } from '../../../../../test-extend';
+import type { CollectionSummary } from '../../../../types/Collection';
 import type { WasapVariantFilter } from '../../../views/wasap/wasapPageConfig';
 
 const DUMMY_LAPIS_URL_2 = 'http://lapis2.dummy';
+
+const DUMMY_COLLECTIONS: CollectionSummary[] = [
+    { id: 1, name: 'XBB.1.5', ownedBy: 1, organism: 'SARS-CoV-2', description: null, variantCount: 5 },
+    { id: 2, name: 'JN.1', ownedBy: 1, organism: 'SARS-CoV-2', description: null, variantCount: 3 },
+];
+const mockPredefinedQueryResult = { data: DUMMY_COLLECTIONS } as unknown as UseQueryResult<CollectionSummary[]>;
 
 describe('VariantExplorerFilter', () => {
     const defaultPageState: WasapVariantFilter = {
@@ -19,6 +27,11 @@ describe('VariantExplorerFilter', () => {
         minCount: 10,
         minJaccard: 0.5,
         timeFrame: 'all',
+    };
+
+    const predefinedPageState: WasapVariantFilter = {
+        ...defaultPageState,
+        signatureType: 'predefined',
     };
 
     it('calls setPageState when changing sequence type', async ({ routeMockers: { lapis } }) => {
@@ -97,6 +110,87 @@ describe('VariantExplorerFilter', () => {
         expect(mockSetPageState).toHaveBeenCalledWith({
             ...defaultPageState,
             minProportion: 0.1,
+        });
+    });
+
+    it('calls setPageState when switching to predefined signature type', async ({ routeMockers: { lapis } }) => {
+        setupLapisMocks(lapis);
+        const mockSetPageState = vi.fn();
+
+        render(
+            <gs-app lapis={DUMMY_LAPIS_URL}>
+                <VariantExplorerFilter
+                    pageState={defaultPageState}
+                    setPageState={mockSetPageState}
+                    clinicalSequenceLapisBaseUrl={DUMMY_LAPIS_URL_2}
+                    clinicalSequenceLapisLineageField='pangoLineage'
+                    predefinedVariantsQueryResult={mockPredefinedQueryResult}
+                />
+            </gs-app>,
+        );
+
+        const variantSourceSelect = page.getByRole('combobox').first();
+        await variantSourceSelect.selectOptions('predefined');
+
+        expect(mockSetPageState).toHaveBeenCalledWith({
+            ...defaultPageState,
+            signatureType: 'predefined',
+        });
+    });
+
+    it('calls setPageState when selecting a predefined collection', async ({ routeMockers: { lapis } }) => {
+        setupLapisMocks(lapis);
+        const mockSetPageState = vi.fn();
+
+        const { getByRole } = render(
+            <gs-app lapis={DUMMY_LAPIS_URL}>
+                <VariantExplorerFilter
+                    pageState={predefinedPageState}
+                    setPageState={mockSetPageState}
+                    clinicalSequenceLapisBaseUrl={DUMMY_LAPIS_URL_2}
+                    clinicalSequenceLapisLineageField='pangoLineage'
+                    predefinedVariantsQueryResult={mockPredefinedQueryResult}
+                />
+            </gs-app>,
+        );
+
+        const collectionInput = page.getByPlaceholder('Select variant');
+        await collectionInput.click();
+        await userEvent.type(collectionInput, 'XBB');
+
+        const option = await vi.waitFor(() => getByRole('option', { name: 'XBB.1.5', exact: true }));
+        await option.click();
+
+        await vi.waitFor(() => {
+            expect(mockSetPageState).toHaveBeenCalledWith({
+                ...predefinedPageState,
+                collectionId: 1,
+            });
+        });
+    });
+
+    it('calls setPageState when toggling "Mutation not in parent"', async ({ routeMockers: { lapis } }) => {
+        setupLapisMocks(lapis);
+        const mockSetPageState = vi.fn();
+
+        const { getByLabelText } = render(
+            <gs-app lapis={DUMMY_LAPIS_URL}>
+                <VariantExplorerFilter
+                    pageState={predefinedPageState}
+                    setPageState={mockSetPageState}
+                    clinicalSequenceLapisBaseUrl={DUMMY_LAPIS_URL_2}
+                    clinicalSequenceLapisLineageField='pangoLineage'
+                    predefinedVariantsQueryResult={mockPredefinedQueryResult}
+                />
+            </gs-app>,
+        );
+
+        const checkbox = getByLabelText('Mutation not in parent');
+        await checkbox.click();
+
+        expect(mockSetPageState).toHaveBeenCalledWith({
+            ...predefinedPageState,
+            newMutationsOnly: true,
         });
     });
 });

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -1,23 +1,21 @@
 import { type UseQueryResult } from '@tanstack/react-query';
-import { useState } from 'react';
 
-import { type CollectionSummary } from '../../../../types/Collection';
-import { CollectionCombobox } from '../utils/CollectionCombobox';
 import { Inset } from '../../../../styles/Inset';
+import { type CollectionSummary } from '../../../../types/Collection';
 import { GsLineageFilter } from '../../../genspectrum/GsLineageFilter';
 import {
     VARIANT_TIME_FRAME,
     variantTimeFrameLabel,
+    type SignatureType,
     type VariantTimeFrame,
     type WasapVariantFilter,
 } from '../../../views/wasap/wasapPageConfig';
 import { SelectorHeadline } from '../../SelectorHeadline';
 import { DefineClinicalSignatureInfo } from '../InfoBlocks';
+import { CollectionCombobox } from '../utils/CollectionCombobox';
 import { LabeledField } from '../utils/LabeledField';
 import { NumericInput } from '../utils/NumericInput';
 import { SequenceTypeSelector } from '../utils/SequenceTypeSelector';
-
-type SignatureType = 'computed' | 'nextclade';
 
 interface VariantExplorerFilterProps {
     pageState: WasapVariantFilter;
@@ -29,6 +27,7 @@ interface VariantExplorerFilterProps {
     clinicalSequenceLapisBaseUrl: string;
     clinicalSequenceLapisLineageField: string;
     predefinedVariantsQueryResult?: UseQueryResult<CollectionSummary[]>;
+    predefinedVariantsLabel?: string;
 }
 
 export function VariantExplorerFilter({
@@ -37,8 +36,11 @@ export function VariantExplorerFilter({
     clinicalSequenceLapisBaseUrl,
     clinicalSequenceLapisLineageField,
     predefinedVariantsQueryResult,
+    predefinedVariantsLabel = 'Predefined',
 }: VariantExplorerFilterProps) {
-    const [signatureType, setSignatureType] = useState<SignatureType>('computed');
+    const handleSignatureTypeChange = (newType: SignatureType) => {
+        setPageState({ ...pageState, signatureType: newType });
+    };
 
     return (
         <>
@@ -50,18 +52,22 @@ export function VariantExplorerFilter({
                 <LabeledField label='Variant definition source'>
                     <select
                         className='select select-bordered'
-                        value={signatureType}
-                        onChange={(e) => setSignatureType(e.target.value as SignatureType)}
+                        value={pageState.signatureType}
+                        onChange={(e) => handleSignatureTypeChange(e.target.value as SignatureType)}
                     >
                         <option value='computed'>Extracted from clinical sequences</option>
-                        <option value='nextclade'>Nextclade</option>
+                        <option value='predefined'>{predefinedVariantsLabel}</option>
                     </select>
                 </LabeledField>
             )}
-            {signatureType === 'nextclade' && (
-                <NextcladeSignature predefinedVariantsQueryResult={predefinedVariantsQueryResult} />
+            {pageState.signatureType === 'predefined' && (
+                <PredefinedSignature
+                    pageState={pageState}
+                    setPageState={setPageState}
+                    predefinedVariantsQueryResult={predefinedVariantsQueryResult}
+                />
             )}
-            {signatureType === 'computed' && (
+            {pageState.signatureType === 'computed' && (
                 <Inset className='mt-4 p-2'>
                     <SelectorHeadline info={<DefineClinicalSignatureInfo />}>
                         Define Clinical Signature
@@ -132,28 +138,34 @@ export function VariantExplorerFilter({
     );
 }
 
-function NextcladeSignature({
+function PredefinedSignature({
+    pageState,
+    setPageState,
     predefinedVariantsQueryResult,
 }: {
+    pageState: WasapVariantFilter;
+    setPageState: (newState: WasapVariantFilter) => void;
     predefinedVariantsQueryResult: UseQueryResult<CollectionSummary[]> | undefined;
 }) {
-    const [selectedCollection, setSelectedCollection] = useState<CollectionSummary | null>(null);
-    const [newMutationsOnly, setNewMutationsOnly] = useState(false);
-
     const collections = predefinedVariantsQueryResult?.data ?? [];
+    const selectedCollection = collections.find((c) => c.id === pageState.collectionId) ?? null;
 
     return (
         <Inset className='mt-4 p-2'>
             <LabeledField label='Variant'>
-                <CollectionCombobox collections={collections} value={selectedCollection} onChange={setSelectedCollection} />
+                <CollectionCombobox
+                    collections={collections}
+                    value={selectedCollection}
+                    onChange={(c) => setPageState({ ...pageState, collectionId: c?.id })}
+                />
             </LabeledField>
             <div className='pt-2 text-sm'>
                 <input
                     className='accent-primary'
                     type='checkbox'
                     id='newMutationsOnly'
-                    checked={newMutationsOnly}
-                    onChange={(e) => setNewMutationsOnly(e.target.checked)}
+                    checked={pageState.newMutationsOnly ?? false}
+                    onChange={(e) => setPageState({ ...pageState, newMutationsOnly: e.target.checked })}
                 />
                 <label htmlFor='newMutationsOnly' className='pl-2'>
                     Mutation not in parent

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -1,4 +1,5 @@
 import { type UseQueryResult } from '@tanstack/react-query';
+import { useId } from 'react';
 
 import { Inset } from '../../../../styles/Inset';
 import { type CollectionSummary } from '../../../../types/Collection';
@@ -149,6 +150,7 @@ function PredefinedSignature({
 }) {
     const collections = predefinedVariantsQueryResult?.data ?? [];
     const selectedCollection = collections.find((c) => c.id === pageState.collectionId) ?? null;
+    const newMutationsCheckBoxId = useId();
 
     return (
         <Inset className='mt-4 p-2'>
@@ -163,7 +165,7 @@ function PredefinedSignature({
                 <input
                     className='accent-primary'
                     type='checkbox'
-                    id='newMutationsOnly'
+                    id={newMutationsCheckBoxId}
                     checked={pageState.newMutationsOnly ?? false}
                     onChange={(e) => setPageState({ ...pageState, newMutationsOnly: e.target.checked })}
                 />
@@ -171,7 +173,7 @@ function PredefinedSignature({
                     className='tooltip tooltip-right inline'
                     data-tip='Only show mutations that were not observed in the parent variant'
                 >
-                    <label htmlFor='newMutationsOnly' className='cursor-pointer pl-2'>
+                    <label htmlFor={newMutationsCheckBoxId} className='cursor-pointer pl-2'>
                         Mutation not in parent
                     </label>
                 </div>

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -1,5 +1,7 @@
+import { type UseQueryResult } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { type Collection } from '../../../../types/Collection';
 import { Inset } from '../../../../styles/Inset';
 import { GsLineageFilter } from '../../../genspectrum/GsLineageFilter';
 import {
@@ -25,6 +27,7 @@ interface VariantExplorerFilterProps {
      */
     clinicalSequenceLapisBaseUrl: string;
     clinicalSequenceLapisLineageField: string;
+    predefinedVariantsQueryResult?: UseQueryResult<Collection[]>;
 }
 
 export function VariantExplorerFilter({
@@ -32,6 +35,7 @@ export function VariantExplorerFilter({
     setPageState,
     clinicalSequenceLapisBaseUrl,
     clinicalSequenceLapisLineageField,
+    predefinedVariantsQueryResult,
 }: VariantExplorerFilterProps) {
     const [signatureType, setSignatureType] = useState<SignatureType>('computed');
 
@@ -41,17 +45,21 @@ export function VariantExplorerFilter({
                 value={pageState.sequenceType}
                 onChange={(sequenceType) => setPageState({ ...pageState, sequenceType })}
             />
-            <LabeledField label='Variant definition source'>
-                <select
-                    className='select select-bordered'
-                    value={signatureType}
-                    onChange={(e) => setSignatureType(e.target.value as SignatureType)}
-                >
-                    <option value='computed'>Computed</option>
-                    <option value='nextclade'>Nextclade</option>
-                </select>
-            </LabeledField>
-            {signatureType === 'nextclade' && <NextcladeSignature />}
+            {predefinedVariantsQueryResult !== undefined && (
+                <LabeledField label='Variant definition source'>
+                    <select
+                        className='select select-bordered'
+                        value={signatureType}
+                        onChange={(e) => setSignatureType(e.target.value as SignatureType)}
+                    >
+                        <option value='computed'>Extracted from clinical sequences</option>
+                        <option value='nextclade'>Nextclade</option>
+                    </select>
+                </LabeledField>
+            )}
+            {signatureType === 'nextclade' && (
+                <NextcladeSignature predefinedVariantsQueryResult={predefinedVariantsQueryResult} />
+            )}
             {signatureType === 'computed' && (
                 <Inset className='mt-4 p-2'>
                     <SelectorHeadline info={<DefineClinicalSignatureInfo />}>
@@ -123,22 +131,15 @@ export function VariantExplorerFilter({
     );
 }
 
-const DUMMY_NEXTCLADE_LINEAGES = [
-    'XEC',
-    'KP.1.1',
-    'KP.2',
-    'KP.3',
-    'JN.1',
-    'XFG',
-    'LP.8.1',
-    'NB.1.8.1',
-    'MC.10.1',
-    'XEC.4',
-];
-
-function NextcladeSignature() {
+function NextcladeSignature({
+    predefinedVariantsQueryResult,
+}: {
+    predefinedVariantsQueryResult: UseQueryResult<Collection[]> | undefined;
+}) {
     const [variant, setVariant] = useState('');
     const [newMutationsOnly, setNewMutationsOnly] = useState(false);
+
+    const collections = predefinedVariantsQueryResult?.data ?? [];
 
     return (
         <Inset className='mt-4 p-2'>
@@ -147,9 +148,9 @@ function NextcladeSignature() {
                     <option value='' disabled>
                         Select variant
                     </option>
-                    {DUMMY_NEXTCLADE_LINEAGES.map((lineage) => (
-                        <option key={lineage} value={lineage}>
-                            {lineage}
+                    {collections.map((collection) => (
+                        <option key={collection.id} value={String(collection.id)}>
+                            {collection.name}
                         </option>
                     ))}
                 </select>
@@ -163,7 +164,7 @@ function NextcladeSignature() {
                     onChange={(e) => setNewMutationsOnly(e.target.checked)}
                 />
                 <label htmlFor='newMutationsOnly' className='pl-2'>
-                    New mutations only
+                    Mutation not in parent
                 </label>
             </div>
         </Inset>

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -167,9 +167,11 @@ function PredefinedSignature({
                     checked={pageState.newMutationsOnly ?? false}
                     onChange={(e) => setPageState({ ...pageState, newMutationsOnly: e.target.checked })}
                 />
-                <label htmlFor='newMutationsOnly' className='pl-2'>
-                    Mutation not in parent
-                </label>
+                <div className='tooltip tooltip-right inline' data-tip='Only show mutations that were not observed in the parent variant'>
+                    <label htmlFor='newMutationsOnly' className='cursor-pointer pl-2'>
+                        Mutation not in parent
+                    </label>
+                </div>
             </div>
         </Inset>
     );

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -1,7 +1,7 @@
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useState } from 'react';
 
-import { type Collection } from '../../../../types/Collection';
+import { type CollectionSummary } from '../../../../types/Collection';
 import { Inset } from '../../../../styles/Inset';
 import { GsLineageFilter } from '../../../genspectrum/GsLineageFilter';
 import {
@@ -27,7 +27,7 @@ interface VariantExplorerFilterProps {
      */
     clinicalSequenceLapisBaseUrl: string;
     clinicalSequenceLapisLineageField: string;
-    predefinedVariantsQueryResult?: UseQueryResult<Collection[]>;
+    predefinedVariantsQueryResult?: UseQueryResult<CollectionSummary[]>;
 }
 
 export function VariantExplorerFilter({
@@ -134,7 +134,7 @@ export function VariantExplorerFilter({
 function NextcladeSignature({
     predefinedVariantsQueryResult,
 }: {
-    predefinedVariantsQueryResult: UseQueryResult<Collection[]> | undefined;
+    predefinedVariantsQueryResult: UseQueryResult<CollectionSummary[]> | undefined;
 }) {
     const [variant, setVariant] = useState('');
     const [newMutationsOnly, setNewMutationsOnly] = useState(false);

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -2,6 +2,7 @@ import { type UseQueryResult } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import { type CollectionSummary } from '../../../../types/Collection';
+import { CollectionCombobox } from '../utils/CollectionCombobox';
 import { Inset } from '../../../../styles/Inset';
 import { GsLineageFilter } from '../../../genspectrum/GsLineageFilter';
 import {
@@ -136,7 +137,7 @@ function NextcladeSignature({
 }: {
     predefinedVariantsQueryResult: UseQueryResult<CollectionSummary[]> | undefined;
 }) {
-    const [variant, setVariant] = useState('');
+    const [selectedCollection, setSelectedCollection] = useState<CollectionSummary | null>(null);
     const [newMutationsOnly, setNewMutationsOnly] = useState(false);
 
     const collections = predefinedVariantsQueryResult?.data ?? [];
@@ -144,16 +145,7 @@ function NextcladeSignature({
     return (
         <Inset className='mt-4 p-2'>
             <LabeledField label='Variant'>
-                <select className='select select-bordered' value={variant} onChange={(e) => setVariant(e.target.value)}>
-                    <option value='' disabled>
-                        Select variant
-                    </option>
-                    {collections.map((collection) => (
-                        <option key={collection.id} value={String(collection.id)}>
-                            {collection.name}
-                        </option>
-                    ))}
-                </select>
+                <CollectionCombobox collections={collections} value={selectedCollection} onChange={setSelectedCollection} />
             </LabeledField>
             <div className='pt-2 text-sm'>
                 <input

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { Inset } from '../../../../styles/Inset';
 import { GsLineageFilter } from '../../../genspectrum/GsLineageFilter';
 import {
@@ -11,6 +13,8 @@ import { DefineClinicalSignatureInfo } from '../InfoBlocks';
 import { LabeledField } from '../utils/LabeledField';
 import { NumericInput } from '../utils/NumericInput';
 import { SequenceTypeSelector } from '../utils/SequenceTypeSelector';
+
+type SignatureType = 'computed' | 'nextclade';
 
 interface VariantExplorerFilterProps {
     pageState: WasapVariantFilter;
@@ -29,68 +33,139 @@ export function VariantExplorerFilter({
     clinicalSequenceLapisBaseUrl,
     clinicalSequenceLapisLineageField,
 }: VariantExplorerFilterProps) {
+    const [signatureType, setSignatureType] = useState<SignatureType>('computed');
+
     return (
         <>
             <SequenceTypeSelector
                 value={pageState.sequenceType}
                 onChange={(sequenceType) => setPageState({ ...pageState, sequenceType })}
             />
-            <Inset className='mt-4 p-2'>
-                <SelectorHeadline info={<DefineClinicalSignatureInfo />}>Define Clinical Signature</SelectorHeadline>
-                <LabeledField label='Variant'>
-                    <gs-app lapis={clinicalSequenceLapisBaseUrl}>
-                        <GsLineageFilter
-                            lapisField={clinicalSequenceLapisLineageField}
-                            lapisFilter={{}}
-                            placeholderText='Variant'
-                            value={pageState.variant}
-                            onLineageChange={(lineages) => {
-                                setPageState({ ...pageState, variant: lineages[clinicalSequenceLapisLineageField] });
-                            }}
-                            hideCounts={true}
-                        />
-                    </gs-app>
-                </LabeledField>
-                <NumericInput
-                    label='Min. proportion'
-                    value={pageState.minProportion}
-                    min={0}
-                    max={1}
-                    step={0.01}
-                    onChange={(v) => setPageState({ ...pageState, minProportion: v })}
-                />
-                <NumericInput
-                    label='Min. count'
-                    value={pageState.minCount}
-                    min={1}
-                    max={250}
-                    step={1}
-                    onChange={(v) => setPageState({ ...pageState, minCount: Math.round(v) })}
-                />
-                <NumericInput
-                    label='Min. Jaccard index'
-                    value={pageState.minJaccard}
-                    min={0}
-                    max={1}
-                    step={0.01}
-                    onChange={(v) => setPageState({ ...pageState, minJaccard: v })}
-                />
-                <LabeledField label='Time frame'>
-                    <select
-                        className='select select-bordered'
-                        value={pageState.timeFrame}
-                        onChange={(e) => setPageState({ ...pageState, timeFrame: e.target.value as VariantTimeFrame })}
-                    >
-                        <option value={VARIANT_TIME_FRAME.all}>{variantTimeFrameLabel(VARIANT_TIME_FRAME.all)}</option>
-                        <option value={VARIANT_TIME_FRAME.sixMonths}>
-                            Past {variantTimeFrameLabel(VARIANT_TIME_FRAME.sixMonths)}
-                        </option>
-                        <option value={VARIANT_TIME_FRAME.threeMonths}>
-                            Past {variantTimeFrameLabel(VARIANT_TIME_FRAME.threeMonths)}
-                        </option>
-                    </select>
-                </LabeledField>
-            </Inset>
+            <LabeledField label='Variant definition source'>
+                <select
+                    className='select select-bordered'
+                    value={signatureType}
+                    onChange={(e) => setSignatureType(e.target.value as SignatureType)}
+                >
+                    <option value='computed'>Computed</option>
+                    <option value='nextclade'>Nextclade</option>
+                </select>
+            </LabeledField>
+            {signatureType === 'nextclade' && <NextcladeSignature />}
+            {signatureType === 'computed' && (
+                <Inset className='mt-4 p-2'>
+                    <SelectorHeadline info={<DefineClinicalSignatureInfo />}>
+                        Define Clinical Signature
+                    </SelectorHeadline>
+                    <LabeledField label='Variant'>
+                        <gs-app lapis={clinicalSequenceLapisBaseUrl}>
+                            <GsLineageFilter
+                                lapisField={clinicalSequenceLapisLineageField}
+                                lapisFilter={{}}
+                                placeholderText='Variant'
+                                value={pageState.variant}
+                                onLineageChange={(lineages) => {
+                                    setPageState({
+                                        ...pageState,
+                                        variant: lineages[clinicalSequenceLapisLineageField],
+                                    });
+                                }}
+                                hideCounts={true}
+                            />
+                        </gs-app>
+                    </LabeledField>
+                    <NumericInput
+                        label='Min. proportion'
+                        value={pageState.minProportion}
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        onChange={(v) => setPageState({ ...pageState, minProportion: v })}
+                    />
+                    <NumericInput
+                        label='Min. count'
+                        value={pageState.minCount}
+                        min={1}
+                        max={250}
+                        step={1}
+                        onChange={(v) => setPageState({ ...pageState, minCount: Math.round(v) })}
+                    />
+                    <NumericInput
+                        label='Min. Jaccard index'
+                        value={pageState.minJaccard}
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        onChange={(v) => setPageState({ ...pageState, minJaccard: v })}
+                    />
+                    <LabeledField label='Time frame'>
+                        <select
+                            className='select select-bordered'
+                            value={pageState.timeFrame}
+                            onChange={(e) =>
+                                setPageState({ ...pageState, timeFrame: e.target.value as VariantTimeFrame })
+                            }
+                        >
+                            <option value={VARIANT_TIME_FRAME.all}>
+                                {variantTimeFrameLabel(VARIANT_TIME_FRAME.all)}
+                            </option>
+                            <option value={VARIANT_TIME_FRAME.sixMonths}>
+                                Past {variantTimeFrameLabel(VARIANT_TIME_FRAME.sixMonths)}
+                            </option>
+                            <option value={VARIANT_TIME_FRAME.threeMonths}>
+                                Past {variantTimeFrameLabel(VARIANT_TIME_FRAME.threeMonths)}
+                            </option>
+                        </select>
+                    </LabeledField>
+                </Inset>
+            )}
         </>
+    );
+}
+
+const DUMMY_NEXTCLADE_LINEAGES = [
+    'XEC',
+    'KP.1.1',
+    'KP.2',
+    'KP.3',
+    'JN.1',
+    'XFG',
+    'LP.8.1',
+    'NB.1.8.1',
+    'MC.10.1',
+    'XEC.4',
+];
+
+function NextcladeSignature() {
+    const [variant, setVariant] = useState('');
+    const [newMutationsOnly, setNewMutationsOnly] = useState(false);
+
+    return (
+        <Inset className='mt-4 p-2'>
+            <LabeledField label='Variant'>
+                <select className='select select-bordered' value={variant} onChange={(e) => setVariant(e.target.value)}>
+                    <option value='' disabled>
+                        Select variant
+                    </option>
+                    {DUMMY_NEXTCLADE_LINEAGES.map((lineage) => (
+                        <option key={lineage} value={lineage}>
+                            {lineage}
+                        </option>
+                    ))}
+                </select>
+            </LabeledField>
+            <div className='pt-2 text-sm'>
+                <input
+                    className='accent-primary'
+                    type='checkbox'
+                    id='newMutationsOnly'
+                    checked={newMutationsOnly}
+                    onChange={(e) => setNewMutationsOnly(e.target.checked)}
+                />
+                <label htmlFor='newMutationsOnly' className='pl-2'>
+                    New mutations only
+                </label>
+            </div>
+        </Inset>
     );
 }

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.tsx
@@ -167,7 +167,10 @@ function PredefinedSignature({
                     checked={pageState.newMutationsOnly ?? false}
                     onChange={(e) => setPageState({ ...pageState, newMutationsOnly: e.target.checked })}
                 />
-                <div className='tooltip tooltip-right inline' data-tip='Only show mutations that were not observed in the parent variant'>
+                <div
+                    className='tooltip tooltip-right inline'
+                    data-tip='Only show mutations that were not observed in the parent variant'
+                >
                     <label htmlFor='newMutationsOnly' className='cursor-pointer pl-2'>
                         Mutation not in parent
                     </label>

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.browser.spec.tsx
@@ -1,0 +1,154 @@
+import { describe, expect, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+import { CollectionCombobox } from './CollectionCombobox';
+import type { CollectionSummary } from '../../../../types/Collection';
+import { it } from '../../../../../test-extend';
+
+const makeCollection = (id: number, name: string): CollectionSummary => ({
+    id,
+    name,
+    ownedBy: 1,
+    organism: 'test',
+    description: null,
+    variantCount: 0,
+});
+
+const collections = [makeCollection(1, 'Alpha'), makeCollection(2, 'Beta'), makeCollection(3, 'Gamma')];
+
+describe('CollectionCombobox', () => {
+    describe('onInputBlur', () => {
+        it('calls onChange(null) when blurred with empty input', async () => {
+            const onChange = vi.fn();
+            const { getByRole } = render(
+                <CollectionCombobox collections={collections} value={collections[0]} onChange={onChange} />,
+            );
+
+            await getByRole('combobox').fill('');
+            getByRole('combobox').element().blur();
+
+            expect(onChange).toHaveBeenCalledWith(null);
+        });
+
+        it('calls onChange with matched collection when blurred with an exact name', async () => {
+            const onChange = vi.fn();
+            const { getByRole } = render(
+                <CollectionCombobox collections={collections} value={null} onChange={onChange} />,
+            );
+
+            await getByRole('combobox').fill('Beta');
+            getByRole('combobox').element().blur();
+
+            expect(onChange).toHaveBeenCalledWith(collections[1]);
+        });
+
+        it('calls onChange with matched collection when input has surrounding whitespace', async () => {
+            const onChange = vi.fn();
+            const { getByRole } = render(
+                <CollectionCombobox collections={collections} value={null} onChange={onChange} />,
+            );
+
+            await getByRole('combobox').fill('  Beta  ');
+            getByRole('combobox').element().blur();
+
+            expect(onChange).toHaveBeenCalledWith(collections[1]);
+        });
+
+        it('shows error state and does not call onChange when blurred with an unrecognised name', async () => {
+            const onChange = vi.fn();
+            const { getByRole } = render(
+                <CollectionCombobox collections={collections} value={null} onChange={onChange} />,
+            );
+
+            await getByRole('combobox').fill('Unknown');
+            getByRole('combobox').element().blur();
+
+            expect(onChange).not.toHaveBeenCalled();
+            const wrapper = getByRole('combobox').element().closest('.input');
+            await expect.element(wrapper as HTMLElement).toHaveClass('input-error');
+        });
+
+        it('clears error state when user starts typing after an invalid blur', async () => {
+            const onChange = vi.fn();
+            const { getByRole } = render(
+                <CollectionCombobox collections={collections} value={null} onChange={onChange} />,
+            );
+
+            await getByRole('combobox').fill('Unknown');
+            getByRole('combobox').element().blur();
+
+            const wrapper = getByRole('combobox').element().closest('.input');
+            await expect.element(wrapper as HTMLElement).toHaveClass('input-error');
+
+            await getByRole('combobox').fill('A');
+            await expect.element(wrapper as HTMLElement).not.toHaveClass('input-error');
+        });
+    });
+
+    describe('clear button', () => {
+        it('is not rendered when input is empty', async () => {
+            const { getByLabelText } = render(
+                <CollectionCombobox collections={collections} value={null} onChange={vi.fn()} />,
+            );
+
+            expect(getByLabelText('clear selection').elements()).toHaveLength(0);
+        });
+
+        it('is visible when a value is selected', async () => {
+            const { getByLabelText } = render(
+                <CollectionCombobox collections={collections} value={collections[0]} onChange={vi.fn()} />,
+            );
+
+            await expect.element(getByLabelText('clear selection')).toBeVisible();
+        });
+
+        it('clears the input and calls onChange(null) when clicked', async () => {
+            const onChange = vi.fn();
+            const { getByLabelText, getByRole } = render(
+                <CollectionCombobox collections={collections} value={collections[0]} onChange={onChange} />,
+            );
+
+            await getByLabelText('clear selection').click();
+
+            expect(onChange).toHaveBeenCalledWith(null);
+            await expect.element(getByRole('combobox')).toHaveValue('');
+        });
+
+        it('disappears after being clicked', async () => {
+            const onChange = vi.fn();
+            const { getByLabelText } = render(
+                <CollectionCombobox collections={collections} value={collections[0]} onChange={onChange} />,
+            );
+
+            await getByLabelText('clear selection').click();
+
+            expect(getByLabelText('clear selection').elements()).toHaveLength(0);
+        });
+    });
+
+    describe('filtering', () => {
+        it('shows only matching items when typing', async () => {
+            const { getByRole, getByText } = render(
+                <CollectionCombobox collections={collections} value={null} onChange={vi.fn()} />,
+            );
+
+            await getByRole('button', { name: 'toggle menu' }).click();
+            await getByRole('combobox').fill('Al');
+
+            await expect.element(getByText('Alpha')).toBeVisible();
+            expect(getByText('Beta').elements()).toHaveLength(0);
+            expect(getByText('Gamma').elements()).toHaveLength(0);
+        });
+
+        it('shows "No variants found" when no collections match the input', async () => {
+            const { getByRole, getByText } = render(
+                <CollectionCombobox collections={collections} value={null} onChange={vi.fn()} />,
+            );
+
+            await getByRole('button', { name: 'toggle menu' }).click();
+            await getByRole('combobox').fill('zzz');
+
+            await expect.element(getByText('No variants found.')).toBeVisible();
+        });
+    });
+});

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.browser.spec.tsx
@@ -1,9 +1,10 @@
+import { userEvent } from '@vitest/browser/context';
 import { describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { CollectionCombobox } from './CollectionCombobox';
-import type { CollectionSummary } from '../../../../types/Collection';
 import { it } from '../../../../../test-extend';
+import type { CollectionSummary } from '../../../../types/Collection';
 
 const makeCollection = (id: number, name: string): CollectionSummary => ({
     id,
@@ -25,7 +26,7 @@ describe('CollectionCombobox', () => {
             );
 
             await getByRole('combobox').fill('');
-            getByRole('combobox').element().blur();
+            await userEvent.tab();
 
             expect(onChange).toHaveBeenCalledWith(null);
         });
@@ -37,7 +38,7 @@ describe('CollectionCombobox', () => {
             );
 
             await getByRole('combobox').fill('Beta');
-            getByRole('combobox').element().blur();
+            await userEvent.tab();
 
             expect(onChange).toHaveBeenCalledWith(collections[1]);
         });
@@ -49,7 +50,7 @@ describe('CollectionCombobox', () => {
             );
 
             await getByRole('combobox').fill('  Beta  ');
-            getByRole('combobox').element().blur();
+            await userEvent.tab();
 
             expect(onChange).toHaveBeenCalledWith(collections[1]);
         });
@@ -61,7 +62,7 @@ describe('CollectionCombobox', () => {
             );
 
             await getByRole('combobox').fill('Unknown');
-            getByRole('combobox').element().blur();
+            await userEvent.tab();
 
             expect(onChange).not.toHaveBeenCalled();
             const wrapper = getByRole('combobox').element().closest('.input');
@@ -75,7 +76,7 @@ describe('CollectionCombobox', () => {
             );
 
             await getByRole('combobox').fill('Unknown');
-            getByRole('combobox').element().blur();
+            await userEvent.tab();
 
             const wrapper = getByRole('combobox').element().closest('.input');
             await expect.element(wrapper as HTMLElement).toHaveClass('input-error');
@@ -86,7 +87,7 @@ describe('CollectionCombobox', () => {
     });
 
     describe('clear button', () => {
-        it('is not rendered when input is empty', async () => {
+        it('is not rendered when input is empty', () => {
             const { getByLabelText } = render(
                 <CollectionCombobox collections={collections} value={null} onChange={vi.fn()} />,
             );

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
@@ -27,19 +27,28 @@ export function CollectionCombobox({
 
     const buttonRef = useRef<HTMLButtonElement>(null);
 
-    const { isOpen, getToggleButtonProps, getMenuProps, getInputProps, highlightedIndex, getItemProps, inputValue, closeMenu, reset } =
-        useCombobox({
-            items: filteredCollections,
-            itemToString: (item) => item?.name ?? '',
-            selectedItem: value,
-            onInputValueChange({ inputValue }) {
-                setInputIsInvalid(false);
-                setInputFilter(inputValue.trim());
-            },
-            onSelectedItemChange({ selectedItem }) {
-                onChange(selectedItem ?? null);
-            },
-        });
+    const {
+        isOpen,
+        getToggleButtonProps,
+        getMenuProps,
+        getInputProps,
+        highlightedIndex,
+        getItemProps,
+        inputValue,
+        closeMenu,
+        reset,
+    } = useCombobox({
+        items: filteredCollections,
+        itemToString: (item) => item?.name ?? '',
+        selectedItem: value,
+        onInputValueChange({ inputValue }) {
+            setInputIsInvalid(false);
+            setInputFilter(inputValue.trim());
+        },
+        onSelectedItemChange({ selectedItem }) {
+            onChange(selectedItem ?? null);
+        },
+    });
 
     const onInputBlur = () => {
         if (inputValue === '') {
@@ -57,45 +66,59 @@ export function CollectionCombobox({
     return (
         <div className='relative w-full'>
             <div
-                className={`flex gap-0.5 input w-full ${inputIsInvalid ? 'input-error' : 'input-bordered'}`}
+                className={`input flex w-full gap-0.5 ${inputIsInvalid ? 'input-error' : 'input-bordered'}`}
                 onBlur={(e) => {
                     if (e.relatedTarget !== buttonRef.current) {
                         closeMenu();
                     }
                 }}
             >
-                <input placeholder={placeholderText} className='w-full p-1.5' {...getInputProps()} onBlur={onInputBlur} />
+                <input
+                    placeholder={placeholderText}
+                    className='w-full p-1.5'
+                    {...getInputProps()}
+                    onBlur={onInputBlur}
+                />
                 {inputValue !== '' && (
                     <button
                         aria-label='clear selection'
                         className='px-2'
                         type='button'
                         tabIndex={-1}
-                        onClick={() => { reset(); onChange(null); }}
+                        onClick={() => {
+                            reset();
+                            onChange(null);
+                        }}
                     >
                         ×
                     </button>
                 )}
-                <button aria-label='toggle menu' className='px-2' type='button' {...getToggleButtonProps()} ref={buttonRef}>
+                <button
+                    aria-label='toggle menu'
+                    className='px-2'
+                    type='button'
+                    {...getToggleButtonProps()}
+                    ref={buttonRef}
+                >
                     {isOpen ? <>↑</> : <>↓</>}
                 </button>
             </div>
             <ul
-                className={`absolute bg-base-100 border border-base-300 mt-1 shadow-md max-h-80 overflow-y-auto z-10 w-full ${isOpen ? '' : 'hidden'}`}
+                className={`bg-base-100 border-base-300 absolute z-10 mt-1 max-h-80 w-full overflow-y-auto border shadow-md ${isOpen ? '' : 'hidden'}`}
                 {...getMenuProps()}
             >
                 {filteredCollections.length > 0 ? (
                     filteredCollections.map((item, index) => (
                         <li
                             key={item.id}
-                            className={`py-2 px-3 cursor-pointer ${highlightedIndex === index ? 'bg-base-200' : ''} ${value?.id === item.id ? 'font-bold' : ''}`}
+                            className={`cursor-pointer px-3 py-2 ${highlightedIndex === index ? 'bg-base-200' : ''} ${value?.id === item.id ? 'font-bold' : ''}`}
                             {...getItemProps({ item, index })}
                         >
                             {item.name}
                         </li>
                     ))
                 ) : (
-                    <li className='py-2 px-3 text-sm text-base-content/60'>No variants found.</li>
+                    <li className='text-base-content/60 px-3 py-2 text-sm'>No variants found.</li>
                 )}
             </ul>
         </div>

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
@@ -1,0 +1,103 @@
+import { useCombobox } from 'downshift';
+import { useMemo, useRef, useState } from 'react';
+
+import { type CollectionSummary } from '../../../../types/Collection';
+
+export function CollectionCombobox({
+    collections,
+    value,
+    onChange,
+    placeholderText = 'Select variant',
+}: {
+    collections: CollectionSummary[];
+    value: CollectionSummary | null;
+    onChange: (item: CollectionSummary | null) => void;
+    placeholderText?: string;
+}) {
+    const [inputFilter, setInputFilter] = useState(() => value?.name ?? '');
+    const [inputIsInvalid, setInputIsInvalid] = useState(false);
+
+    const filteredCollections = useMemo(
+        () =>
+            collections
+                .filter((c) => c.name.toLowerCase().includes(inputFilter.toLowerCase()))
+                .sort((a, b) => a.name.localeCompare(b.name)),
+        [collections, inputFilter],
+    );
+
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    const { isOpen, getToggleButtonProps, getMenuProps, getInputProps, highlightedIndex, getItemProps, inputValue, closeMenu, reset } =
+        useCombobox({
+            items: filteredCollections,
+            itemToString: (item) => item?.name ?? '',
+            selectedItem: value,
+            onInputValueChange({ inputValue }) {
+                setInputIsInvalid(false);
+                setInputFilter(inputValue.trim());
+            },
+            onSelectedItemChange({ selectedItem }) {
+                onChange(selectedItem ?? null);
+            },
+        });
+
+    const onInputBlur = () => {
+        if (inputValue === '') {
+            onChange(null);
+            return;
+        }
+        const match = collections.find((c) => c.name === inputValue.trim());
+        if (match !== undefined) {
+            onChange(match);
+            return;
+        }
+        setInputIsInvalid(true);
+    };
+
+    return (
+        <div className='relative w-full'>
+            <div
+                className={`flex gap-0.5 input w-full ${inputIsInvalid ? 'input-error' : 'input-bordered'}`}
+                onBlur={(e) => {
+                    if (e.relatedTarget !== buttonRef.current) {
+                        closeMenu();
+                    }
+                }}
+            >
+                <input placeholder={placeholderText} className='w-full p-1.5' {...getInputProps()} onBlur={onInputBlur} />
+                {inputValue !== '' && (
+                    <button
+                        aria-label='clear selection'
+                        className='px-2'
+                        type='button'
+                        tabIndex={-1}
+                        onClick={() => { reset(); onChange(null); }}
+                    >
+                        ×
+                    </button>
+                )}
+                <button aria-label='toggle menu' className='px-2' type='button' {...getToggleButtonProps()} ref={buttonRef}>
+                    {isOpen ? <>↑</> : <>↓</>}
+                </button>
+            </div>
+            <ul
+                className={`absolute bg-base-100 border border-base-300 mt-1 shadow-md max-h-80 overflow-y-auto z-10 w-full ${isOpen ? '' : 'hidden'}`}
+                {...getMenuProps()}
+            >
+                {filteredCollections.length > 0 ? (
+                    filteredCollections.map((item, index) => (
+                        <li
+                            key={item.id}
+                            className={`py-2 px-3 cursor-pointer ${highlightedIndex === index ? 'bg-base-200' : ''} ${value?.id === item.id ? 'font-bold' : ''}`}
+                            {...getItemProps({ item, index })}
+                        >
+                            {item.name}
+                        </li>
+                    ))
+                ) : (
+                    <li className='py-2 px-3 text-sm text-base-content/60'>No variants found.</li>
+                )}
+            </ul>
+        </div>
+    );
+}

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
@@ -76,15 +76,14 @@ export function CollectionCombobox({
                 <input
                     placeholder={placeholderText}
                     className='w-full p-1.5'
-                    {...getInputProps()}
-                    onBlur={onInputBlur}
+                    {...getInputProps({ onBlur: onInputBlur })}
                 />
                 {inputValue !== '' && (
                     <button
                         aria-label='clear selection'
                         className='px-2'
                         type='button'
-                        tabIndex={-1}
+
                         onClick={() => {
                             reset();
                             onChange(null);

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
@@ -82,6 +82,7 @@ export function CollectionCombobox({
                     <button
                         aria-label='clear selection'
                         className='px-2'
+                        tabIndex={-1}
                         type='button'
 
                         onClick={() => {

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
@@ -84,7 +84,6 @@ export function CollectionCombobox({
                         className='px-2'
                         tabIndex={-1}
                         type='button'
-
                         onClick={() => {
                             reset();
                             onChange(null);

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.tsx
@@ -17,12 +17,14 @@ export function CollectionCombobox({
     const [inputFilter, setInputFilter] = useState(() => value?.name ?? '');
     const [inputIsInvalid, setInputIsInvalid] = useState(false);
 
+    const sortedCollections = useMemo(
+        () => [...collections].sort((a, b) => a.name.localeCompare(b.name)),
+        [collections],
+    );
+
     const filteredCollections = useMemo(
-        () =>
-            collections
-                .filter((c) => c.name.toLowerCase().includes(inputFilter.toLowerCase()))
-                .sort((a, b) => a.name.localeCompare(b.name)),
-        [collections, inputFilter],
+        () => sortedCollections.filter((c) => c.name.toLowerCase().includes(inputFilter.toLowerCase())),
+        [sortedCollections, inputFilter],
     );
 
     const buttonRef = useRef<HTMLButtonElement>(null);

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -1,19 +1,8 @@
 import { useEffect, useMemo } from 'react';
 import { type FC } from 'react';
 
-import { getClientLogger } from '../../../clientLogger';
-
-const logger = getClientLogger('WasapPage');
-
-import { CollectionInfo } from './components/CollectionInfo';
-import { NoDataHelperText } from './components/NoDataHelperText';
-import { VariantFetchInfo } from './components/VariantFetchInfo';
-import { WasapStats } from './components/WasapStats';
-import { getInitialMeanProportionInterval } from './initialMeanProportionInterval';
-import type { ResistanceData } from './resistanceData';
-import { useWasapPageData } from './useWasapPageData';
-import type { WasapPageConfig } from './wasapPageConfig';
 import { withQueryProvider } from '../../../backendApi/withQueryProvider';
+import { getClientLogger } from '../../../clientLogger';
 import { defaultBreadcrumbs } from '../../../layouts/Breadcrumbs.tsx';
 import { DataPageLayout } from '../../../layouts/OrganismPage/DataPageLayout.tsx';
 import { dataOrigins } from '../../../types/dataOrigins.ts';
@@ -24,6 +13,16 @@ import { GsMutationsOverTime } from '../../genspectrum/GsMutationsOverTime';
 import { GsQueriesOverTime } from '../../genspectrum/GsQueriesOverTime.tsx';
 import { WasapPageStateSelector } from '../../pageStateSelectors/wasap/WasapPageStateSelector';
 import { usePageState } from '../usePageState.ts';
+import { CollectionInfo } from './components/CollectionInfo';
+import { NoDataHelperText } from './components/NoDataHelperText';
+import { VariantFetchInfo } from './components/VariantFetchInfo';
+import { WasapStats } from './components/WasapStats';
+import { getInitialMeanProportionInterval } from './initialMeanProportionInterval';
+import type { ResistanceData } from './resistanceData';
+import { useWasapPageData } from './useWasapPageData';
+import type { WasapPageConfig } from './wasapPageConfig';
+
+const logger = getClientLogger('WasapPage');
 
 export type WasapPageProps = {
     config: WasapPageConfig;

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -1,5 +1,9 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { type FC } from 'react';
+
+import { getClientLogger } from '../../../clientLogger';
+
+const logger = getClientLogger('WasapPage');
 
 import { CollectionInfo } from './components/CollectionInfo';
 import { NoDataHelperText } from './components/NoDataHelperText';
@@ -37,7 +41,13 @@ export const WasapPageInner: FC<WasapPageProps> = ({ config, resistanceData }) =
 
     const { mutationAnnotations, displayMutationsBySet } = resistanceData;
     // fetch which mutations should be analyzed
-    const { data, isPending, isError } = useWasapPageData(config, displayMutationsBySet, analysis);
+    const { data, isPending, isError, error } = useWasapPageData(config, displayMutationsBySet, analysis);
+
+    useEffect(() => {
+        if (error) {
+            logger.error(`Failed to fetch wasap page data: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }, [error]);
 
     const initialMeanProportionInterval = getInitialMeanProportionInterval(analysis);
 

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -101,15 +101,17 @@ export const WasapPageInner: FC<WasapPageProps> = ({ config, resistanceData }) =
                                             customColumns={data.customColumns}
                                         />
                                     )}
-                                    {analysis.mode === 'variant' && config.variantAnalysisModeEnabled && (
-                                        <VariantFetchInfo
-                                            analysis={analysis}
-                                            clinicalLapisBaseUrl={config.clinicalLapis.lapisBaseUrl}
-                                            clinicalLapisLineageField={config.clinicalLapis.lineageField}
-                                            clinicalLapisDateField={config.clinicalLapis.dateField}
-                                            warningThreshold={config.clinicalSequenceCountWarningThreshold}
-                                        />
-                                    )}
+                                    {analysis.mode === 'variant' &&
+                                        analysis.signatureType === 'computed' &&
+                                        config.variantAnalysisModeEnabled && (
+                                            <VariantFetchInfo
+                                                analysis={analysis}
+                                                clinicalLapisBaseUrl={config.clinicalLapis.lapisBaseUrl}
+                                                clinicalLapisLineageField={config.clinicalLapis.lineageField}
+                                                clinicalLapisDateField={config.clinicalLapis.dateField}
+                                                warningThreshold={config.clinicalSequenceCountWarningThreshold}
+                                            />
+                                        )}
                                 </>
                             ) : (
                                 <>

--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -86,7 +86,16 @@ export const WasapPageInner: FC<WasapPageProps> = ({ config, resistanceData }) =
                         />
                     </div>
                     {isError ? (
-                        <span>There was an error fetching the data to display.</span>
+                        analysis.mode === 'variant' &&
+                        analysis.signatureType === 'predefined' &&
+                        analysis.collectionId === undefined ? (
+                            <div className='rounded-md border-2 border-gray-100 p-4'>
+                                <h1 className='text-lg font-semibold'>No variant selected</h1>
+                                <p className='text-sm'>Please select a variant from the filter panel.</p>
+                            </div>
+                        ) : (
+                            <span>There was an error fetching the data to display.</span>
+                        )
                     ) : isPending ? (
                         <Loading />
                     ) : (

--- a/website/src/components/views/wasap/initialMeanProportionInterval.spec.ts
+++ b/website/src/components/views/wasap/initialMeanProportionInterval.spec.ts
@@ -27,6 +27,7 @@ describe('getInitialMeanProportionInterval', () => {
     test('other analysis states initially show the full mean proportion range', () => {
         const analysis: WasapAnalysisFilter = {
             mode: 'variant',
+            signatureType: 'computed',
             sequenceType: 'nucleotide',
             variant: 'XFG*',
             minProportion: 0.8,

--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -119,6 +119,7 @@ async function fetchVariantPredefinedModeData(analysis: WasapVariantFilter): Pro
     }
     const collection = await getBackendServiceForClientside().getCollection({ id: String(analysis.collectionId) });
 
+    // These names match the variant names hardcoded in the collection seeder.
     let variantName: string;
     if (analysis.sequenceType === 'nucleotide') {
         variantName = analysis.newMutationsOnly ? 'New nucleotide substitutions' : 'Nucleotide substitutions';

--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -72,6 +72,23 @@ async function fetchVariantModeData(
     if (!config.variantAnalysisModeEnabled) {
         throw Error("Cannot fetch data, 'variant' mode is not enabled.");
     }
+    switch (analysis.signatureType) {
+        case 'computed':
+            return fetchVariantComputedModeData(config, analysis);
+        case 'predefined':
+            // TODO - Implement the fetching.
+            // we need to fetch the collection by ID
+            throw new Error('Predefined variant mode is not yet implemented.');
+    }
+}
+
+async function fetchVariantComputedModeData(
+    config: WasapPageConfig,
+    analysis: WasapVariantFilter,
+): Promise<WasapMutationsData> {
+    if (!config.variantAnalysisModeEnabled) {
+        throw Error("Cannot fetch data, 'variant' mode is not enabled.");
+    }
     const mutationsWithScore = await getMutationsForVariant(
         config.clinicalLapis.lapisBaseUrl,
         analysis.sequenceType,

--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -114,7 +114,7 @@ async function fetchVariantComputedModeData(
 }
 
 async function fetchVariantPredefinedModeData(analysis: WasapVariantFilter): Promise<WasapMutationsData> {
-    if (!analysis.collectionId) {
+    if (!analysis.collectionId === undefined) {
         throw new Error('No collection selected for predefined variant mode.');
     }
     const collection = await getBackendServiceForClientside().getCollection({ id: String(analysis.collectionId) });

--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -12,6 +12,7 @@ import type {
     WasapUntrackedFilter,
     WasapVariantFilter,
 } from './wasapPageConfig';
+import { getBackendServiceForClientside } from '../../../backendApi/backendService';
 import { getCollection } from '../../../covspectrum/getCollection';
 import { detailedMutationsToQuery } from '../../../covspectrum/variantConversionUtil';
 import { getCladeLineages } from '../../../lapis/getCladeLineages';
@@ -76,9 +77,7 @@ async function fetchVariantModeData(
         case 'computed':
             return fetchVariantComputedModeData(config, analysis);
         case 'predefined':
-            // TODO - Implement the fetching.
-            // we need to fetch the collection by ID
-            throw new Error('Predefined variant mode is not yet implemented.');
+            return fetchVariantPredefinedModeData(analysis);
     }
 }
 
@@ -112,6 +111,35 @@ async function fetchVariantComputedModeData(
             },
         ],
     };
+}
+
+async function fetchVariantPredefinedModeData(analysis: WasapVariantFilter): Promise<WasapMutationsData> {
+    if (!analysis.collectionId) {
+        throw new Error('No collection selected for predefined variant mode.');
+    }
+    const collection = await getBackendServiceForClientside().getCollection({ id: String(analysis.collectionId) });
+
+    let variantName: string;
+    if (analysis.sequenceType === 'nucleotide') {
+        variantName = analysis.newMutationsOnly ? 'New nucleotide substitutions' : 'Nucleotide substitutions';
+    } else {
+        variantName = analysis.newMutationsOnly ? 'New amino acid substitutions' : 'Amino acid substitutions';
+    }
+
+    const variant = collection.variants.find((v) => v.name === variantName);
+    if (!variant) {
+        throw new Error(`Variant "${variantName}" not found in collection ${collection.id}.`);
+    }
+    if (variant.type !== 'filterObject') {
+        throw new Error(`Variant "${variantName}" in collection ${collection.id} is not a filterObject variant.`);
+    }
+
+    const mutations =
+        analysis.sequenceType === 'nucleotide'
+            ? (variant.filterObject.nucleotideMutations ?? [])
+            : (variant.filterObject.aminoAcidMutations ?? []);
+
+    return { type: 'mutations', displayMutations: mutations };
 }
 
 function fetchResistanceModeData(

--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -114,7 +114,7 @@ async function fetchVariantComputedModeData(
 }
 
 async function fetchVariantPredefinedModeData(analysis: WasapVariantFilter): Promise<WasapMutationsData> {
-    if (!analysis.collectionId === undefined) {
+    if (analysis.collectionId === undefined) {
         throw new Error('No collection selected for predefined variant mode.');
     }
     const collection = await getBackendServiceForClientside().getCollection({ id: String(analysis.collectionId) });

--- a/website/src/components/views/wasap/wasapPageConfig.ts
+++ b/website/src/components/views/wasap/wasapPageConfig.ts
@@ -10,6 +10,11 @@ export type WasapPageConfig = WasapPageConfigBase & AnalysisModeConfigs;
  */
 export type WasapPageConfigBase = {
     /**
+     * The internal identifier of the organism, i.e. 'covid'. Used as a key in maps and API parameters.
+     */
+    internalName: string;
+
+    /**
      * The name of the organism, i.e. 'Sars-CoV-2'
      */
     name: string;
@@ -72,8 +77,6 @@ type VariantAnalysisModeConfig =
           variantAnalysisModeEnabled: true;
           predefinedVariantsSource?: {
               collectionsUserId: number;
-              // TODO: find a better source for this — the organism key should already be known from the page config
-              collectionsOrganism: string;
               collectionsTag: string;
               variantSourceLabel?: string;
           };

--- a/website/src/components/views/wasap/wasapPageConfig.ts
+++ b/website/src/components/views/wasap/wasapPageConfig.ts
@@ -70,6 +70,10 @@ type VariantAnalysisModeConfig =
       }
     | {
           variantAnalysisModeEnabled: true;
+          predefinedVariantsSource?: {
+              collectionsUserId: number;
+              collectionsTag: string;
+          };
           clinicalLapis: {
               lapisBaseUrl: string;
               dateField: string;

--- a/website/src/components/views/wasap/wasapPageConfig.ts
+++ b/website/src/components/views/wasap/wasapPageConfig.ts
@@ -72,6 +72,8 @@ type VariantAnalysisModeConfig =
           variantAnalysisModeEnabled: true;
           predefinedVariantsSource?: {
               collectionsUserId: number;
+              // TODO: find a better source for this — the organism key should already be known from the page config
+              collectionsOrganism: string;
               collectionsTag: string;
           };
           clinicalLapis: {

--- a/website/src/components/views/wasap/wasapPageConfig.ts
+++ b/website/src/components/views/wasap/wasapPageConfig.ts
@@ -202,6 +202,10 @@ export function variantTimeFrameLabel(timeFrame: VariantTimeFrame): string {
     }
 }
 
+/**
+ * The type of variant mutation signature. `predefined` is a pre-defined list pulled from online,
+ * `computed` computes the list of signature mutations for a variant based on user parameters.
+ */
 export type SignatureType = 'computed' | 'predefined';
 
 export type WasapVariantFilter = {

--- a/website/src/components/views/wasap/wasapPageConfig.ts
+++ b/website/src/components/views/wasap/wasapPageConfig.ts
@@ -75,6 +75,7 @@ type VariantAnalysisModeConfig =
               // TODO: find a better source for this — the organism key should already be known from the page config
               collectionsOrganism: string;
               collectionsTag: string;
+              variantSourceLabel?: string;
           };
           clinicalLapis: {
               lapisBaseUrl: string;
@@ -201,14 +202,21 @@ export function variantTimeFrameLabel(timeFrame: VariantTimeFrame): string {
     }
 }
 
+export type SignatureType = 'computed' | 'predefined';
+
 export type WasapVariantFilter = {
     mode: 'variant';
+    signatureType: SignatureType;
     sequenceType: SequenceType;
+    // computed signature fields
     variant?: string;
     minProportion: number;
     minCount: number;
     minJaccard: number;
     timeFrame: VariantTimeFrame;
+    // predefined signature fields
+    collectionId?: number;
+    newMutationsOnly?: boolean;
 };
 
 export type WasapResistanceFilter = {

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -60,6 +60,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
             collectionsUserId: 1,
             collectionsOrganism: wastewaterOrganisms.covid,
             collectionsTag: '#pango-lineage',
+            variantSourceLabel: 'Nextclade',
         },
         clinicalLapis: {
             lapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
@@ -81,6 +82,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
             },
             variant: {
                 mode: 'variant',
+                signatureType: 'computed',
                 sequenceType: 'nucleotide',
                 variant: 'XFG*',
                 minProportion: 0.8,
@@ -136,6 +138,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
             },
             variant: {
                 mode: 'variant',
+                signatureType: 'computed',
                 sequenceType: 'nucleotide',
                 variant: 'A.D.1*',
                 minProportion: 0.8,
@@ -177,6 +180,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
             },
             variant: {
                 mode: 'variant',
+                signatureType: 'computed',
                 sequenceType: 'nucleotide',
                 variant: 'B.D.E.1*',
                 minProportion: 0.8,

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -89,6 +89,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
                 minCount: 15,
                 minJaccard: 0.75,
                 timeFrame: VARIANT_TIME_FRAME.all,
+                collectionId: 4961,
             },
             resistance: {
                 mode: 'resistance',

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -56,6 +56,10 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         lapisBaseUrl: 'https://lapis.wasap.genspectrum.org/covid',
         samplingDateField: 'samplingDate',
         locationNameField: 'locationName',
+        predefinedVariantsSource: {
+            collectionsUserId: 1,
+            collectionsTag: '#pango-lineage'
+        },
         clinicalLapis: {
             lapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',
             dateField: 'date',

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -15,6 +15,7 @@ export const wastewaterPathFragment = 'swiss-wastewater';
 
 export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPageConfig> = {
     [wastewaterOrganisms.covid]: {
+        internalName: wastewaterOrganisms.covid,
         name: 'SARS-CoV-2',
         path: `/${wastewaterPathFragment}/covid`,
         description: 'Analyze SARS-CoV-2 data that was collected by the WISE project.',
@@ -58,7 +59,6 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         locationNameField: 'locationName',
         predefinedVariantsSource: {
             collectionsUserId: 1,
-            collectionsOrganism: wastewaterOrganisms.covid,
             collectionsTag: '#pango-lineage',
             variantSourceLabel: 'Nextclade',
         },
@@ -107,6 +107,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         },
     },
     [wastewaterOrganisms.rsvA]: {
+        internalName: wastewaterOrganisms.rsvA,
         name: 'RSV-A',
         path: `/${wastewaterPathFragment}/rsv-a`,
         description: 'Analyze RSV-A data that was collected by the WISE project.',
@@ -149,6 +150,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         },
     },
     [wastewaterOrganisms.rsvB]: {
+        internalName: wastewaterOrganisms.rsvB,
         name: 'RSV-B',
         path: `/${wastewaterPathFragment}/rsv-b`,
         description: 'Analyze RSV-B data that was collected by the WISE project.',

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -58,7 +58,8 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         locationNameField: 'locationName',
         predefinedVariantsSource: {
             collectionsUserId: 1,
-            collectionsTag: '#pango-lineage'
+            collectionsOrganism: wastewaterOrganisms.covid,
+            collectionsTag: '#pango-lineage',
         },
         clinicalLapis: {
             lapisBaseUrl: 'https://lapis.cov-spectrum.org/open/v2',

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
@@ -51,6 +51,7 @@ const config: WasapPageConfig = {
         },
         variant: {
             mode: 'variant',
+            signatureType: 'computed',
             sequenceType: 'nucleotide',
             variant: 'XFG*',
             minProportion: 0.8,

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
@@ -269,6 +269,56 @@ describe('WasapPageStateHandler', () => {
             expect(analysis2.minProportion).toBe(analysis1.minProportion);
             expect(analysis2.minJaccard).toBe(analysis1.minJaccard);
         });
+
+        it('defaults signatureType to computed when absent from URL', () => {
+            const url = '/wastewater/covid?analysisMode=variant&';
+            const filter = handler.parsePageStateFromUrl(new URL(`http://example.com${url}`));
+
+            const analysis = filter.analysis as WasapVariantFilter;
+            expect(analysis.signatureType).toBe('computed');
+        });
+
+        it('parses and encodes predefined variant filter with collectionId (round-trip)', () => {
+            const url =
+                '/wastewater/covid?' +
+                'locationName=Z%C3%BCrich+%28ZH%29&' +
+                'granularity=day&' +
+                'analysisMode=variant&' +
+                'sequenceType=nucleotide&' +
+                'signatureType=predefined&' +
+                'collectionId=42&';
+            const filter = handler.parsePageStateFromUrl(new URL(`http://example.com${url}`));
+
+            expect(filter.analysis.mode).toBe('variant');
+            const analysis = filter.analysis as WasapVariantFilter;
+            expect(analysis.signatureType).toBe('predefined');
+            expect(analysis.collectionId).toBe(42);
+            expect(analysis.newMutationsOnly).toBe(false);
+
+            const newUrl = handler.toUrl(filter);
+            expect(newUrl).toBe(url);
+        });
+
+        it('parses and encodes newMutationsOnly=true in predefined variant mode (round-trip)', () => {
+            const url =
+                '/wastewater/covid?' +
+                'locationName=Z%C3%BCrich+%28ZH%29&' +
+                'granularity=day&' +
+                'analysisMode=variant&' +
+                'sequenceType=nucleotide&' +
+                'signatureType=predefined&' +
+                'collectionId=42&' +
+                'newMutationsOnly=true&';
+            const filter = handler.parsePageStateFromUrl(new URL(`http://example.com${url}`));
+
+            expect(filter.analysis.mode).toBe('variant');
+            const analysis = filter.analysis as WasapVariantFilter;
+            expect(analysis.signatureType).toBe('predefined');
+            expect(analysis.newMutationsOnly).toBe(true);
+
+            const newUrl = handler.toUrl(filter);
+            expect(newUrl).toBe(url);
+        });
     });
 
     describe('resistance mode', () => {

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
@@ -220,6 +220,7 @@ describe('WasapPageStateHandler', () => {
                 'granularity=week&' +
                 'analysisMode=variant&' +
                 'sequenceType=nucleotide&' +
+                'signatureType=computed&' +
                 'variant=BA.2*&' +
                 'minProportion=0.5&' +
                 'minCount=10&' +

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../../components/views/wasap/wasapPageConfig';
 
 const config: WasapPageConfig = {
+    internalName: 'covid',
     name: 'SARS-CoV-2',
     path: `/wastewater/covid`,
     description: 'Analyze SARS-CoV-2 data that was collected by the WISE project.',

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -59,7 +59,9 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                 }
                 analysis = {
                     mode,
-                    signatureType: (texts.signatureType as SignatureType | undefined) ?? this.config.filterDefaults.variant.signatureType,
+                    signatureType:
+                        (texts.signatureType as SignatureType | undefined) ??
+                        this.config.filterDefaults.variant.signatureType,
                     sequenceType: providedSequenceType ?? this.config.filterDefaults.variant.sequenceType,
                     variant: texts.variant ?? this.config.filterDefaults.variant.variant,
                     minProportion: Number(texts.minProportion ?? this.config.filterDefaults.variant.minProportion),

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -7,6 +7,7 @@ import type { BaselineFilterConfig } from '../../components/pageStateSelectors/B
 import {
     enabledAnalysisModes,
     type ExcludeSetName,
+    type SignatureType,
     type VariantTimeFrame,
     type WasapAnalysisFilter,
     type WasapAnalysisMode,
@@ -52,12 +53,13 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                     mutations: texts.mutations?.split('|'),
                 };
                 break;
-            case 'variant':
+            case 'variant': {
                 if (!this.config.variantAnalysisModeEnabled) {
                     throw Error("The 'variant' analysis mode is not enabled.");
                 }
                 analysis = {
                     mode,
+                    signatureType: (texts.signatureType as SignatureType | undefined) ?? 'computed',
                     sequenceType: providedSequenceType ?? this.config.filterDefaults.variant.sequenceType,
                     variant: texts.variant ?? this.config.filterDefaults.variant.variant,
                     minProportion: Number(texts.minProportion ?? this.config.filterDefaults.variant.minProportion),
@@ -66,8 +68,11 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                     timeFrame:
                         (texts.timeFrame as VariantTimeFrame | undefined) ??
                         this.config.filterDefaults.variant.timeFrame,
+                    collectionId: texts.collectionId ? Number(texts.collectionId) : undefined,
+                    newMutationsOnly: texts.newMutationsOnly === 'true',
                 };
                 break;
+            }
             case 'resistance':
                 if (!this.config.resistanceAnalysisModeEnabled) {
                     throw Error("The 'resistance' analysis mode is not enabled.");
@@ -135,11 +140,23 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                 break;
             case 'variant':
                 setSearchFromString(search, 'sequenceType', analysis.sequenceType);
-                setSearchFromString(search, 'variant', analysis.variant);
-                setSearchFromString(search, 'minProportion', String(analysis.minProportion));
-                setSearchFromString(search, 'minCount', String(analysis.minCount));
-                setSearchFromString(search, 'minJaccard', String(analysis.minJaccard));
-                setSearchFromString(search, 'timeFrame', analysis.timeFrame);
+                if (analysis.signatureType === 'predefined') {
+                    setSearchFromString(search, 'signatureType', 'predefined');
+                    setSearchFromString(
+                        search,
+                        'collectionId',
+                        analysis.collectionId ? String(analysis.collectionId) : undefined,
+                    );
+                    if (analysis.newMutationsOnly) {
+                        setSearchFromString(search, 'newMutationsOnly', 'true');
+                    }
+                } else {
+                    setSearchFromString(search, 'variant', analysis.variant);
+                    setSearchFromString(search, 'minProportion', String(analysis.minProportion));
+                    setSearchFromString(search, 'minCount', String(analysis.minCount));
+                    setSearchFromString(search, 'minJaccard', String(analysis.minJaccard));
+                    setSearchFromString(search, 'timeFrame', analysis.timeFrame);
+                }
                 break;
             case 'resistance':
                 setSearchFromString(search, 'resistanceSet', analysis.resistanceSet);
@@ -235,6 +252,14 @@ function generateWasapFilterConfig(pageConfig: WasapPageConfig): BaselineFilterC
         {
             type: 'text',
             lapisField: 'collectionId',
+        },
+        {
+            type: 'text',
+            lapisField: 'signatureType',
+        },
+        {
+            type: 'text',
+            lapisField: 'newMutationsOnly',
         },
     ];
 }

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -59,7 +59,7 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                 }
                 analysis = {
                     mode,
-                    signatureType: (texts.signatureType as SignatureType | undefined) ?? 'computed',
+                    signatureType: (texts.signatureType as SignatureType | undefined) ?? this.config.filterDefaults.variant.signatureType,
                     sequenceType: providedSequenceType ?? this.config.filterDefaults.variant.sequenceType,
                     variant: texts.variant ?? this.config.filterDefaults.variant.variant,
                     minProportion: Number(texts.minProportion ?? this.config.filterDefaults.variant.minProportion),

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -68,7 +68,9 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                     timeFrame:
                         (texts.timeFrame as VariantTimeFrame | undefined) ??
                         this.config.filterDefaults.variant.timeFrame,
-                    collectionId: texts.collectionId ? Number(texts.collectionId) : undefined,
+                    collectionId: texts.collectionId
+                        ? Number(texts.collectionId)
+                        : this.config.filterDefaults.variant.collectionId,
                     newMutationsOnly: texts.newMutationsOnly === 'true',
                 };
                 break;

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -144,8 +144,8 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                 break;
             case 'variant':
                 setSearchFromString(search, 'sequenceType', analysis.sequenceType);
+                setSearchFromString(search, 'signatureType', analysis.signatureType);
                 if (analysis.signatureType === 'predefined') {
-                    setSearchFromString(search, 'signatureType', 'predefined');
                     setSearchFromString(
                         search,
                         'collectionId',


### PR DESCRIPTION
resolves #1199 

Adds support for predefined variant signatures in the W-ASAP Variant Explorer mode, as an alternative to computing signatures from clinical sequences. For COVID, these come from a configured collections source (filtered by user ID, organism, and a tag in the description).

### Summary

- Adds a `predefinedVariantsSource` config to `WasapPageConfig` specifying where to fetch predefined variant collections from (userId, tag, label); the organism is taken from the new `internalName` field on the base config
- Pre-fetches matching collections via `getCollectionSummaries` and exposes them in a **downshift autocomplete combobox** in the filter panel
- Extends `WasapVariantFilter` with a `signatureType` field (`'computed'` | `'predefined'`) and predefined-specific fields (`collectionId`, `newMutationsOnly`); serialised to/from URL
- `signatureType` defaults to `'computed'` and is omitted from the URL for backwards compatibility with existing bookmarks
- Refactors the variant filter type from a discriminated union to a flat type (consistent with `WasapUntrackedFilter`), removing the need to pass `computedDefaults` through the component tree
- Extracts `SignatureType` to `wasapPageConfig.ts` alongside all other WASAP types
- Adds `internalName` to `WasapPageConfigBase` so the organism key is accessible from the config directly
- Updates the Variant Explorer info box to describe both predefined and computed signature modes

### Screenshot

<img width="320" height="359" alt="image" src="https://github.com/user-attachments/assets/34d14e26-8b82-4856-877b-c5737f8da205" />

### Testing

- **`WasapPageStateHandler.spec.ts`** — URL round-trip tests for the predefined `signatureType`: serialising a `WasapVariantFilter` with `signatureType: 'predefined'`, `collectionId`, and `newMutationsOnly` into URL params and parsing them back produces the original state.
- **`CollectionCombobox.browser.spec.tsx`** (new file) — Browser tests for the autocomplete combobox used to pick a predefined collection: selecting a collection from the dropdown, clearing the selection via the clear button, and blur behaviour (committing a valid value on blur, rejecting an invalid one with an error state).
- **`VariantExplorerFilter.browser.spec.tsx`** — Browser tests for the predefined path in the filter panel: switching the "Variant definition source" dropdown from computed → predefined, selecting a collection, and toggling the "Mutation not in parent" checkbox.

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.