### PR TITLE
feat(backend): configure genspectrum-bot system user for prod and staging

### DIFF
--- a/backend/src/main/resources/application-dashboards-prod.yaml
+++ b/backend/src/main/resources/application-dashboards-prod.yaml
@@ -1,4 +1,8 @@
 dashboards:
+  systemUser:
+    githubId: "218605180"
+    name: "genspectrum-bot"
+    apiKey: "${DASHBOARDS_SYSTEM_USER_API_KEY}"
   features:
     subscriptions:
       enabled: false

--- a/backend/src/main/resources/application-dashboards-staging.yaml
+++ b/backend/src/main/resources/application-dashboards-staging.yaml
@@ -1,4 +1,8 @@
 dashboards:
+  systemUser:
+    githubId: "218605180"
+    name: "genspectrum-bot"
+    apiKey: "${DASHBOARDS_SYSTEM_USER_API_KEY}"
   organisms:
     covid:
       lapis:


### PR DESCRIPTION
## Summary

- Adds `systemUser` block to `application-dashboards-prod.yaml` and `application-dashboards-staging.yaml`
- Uses `genspectrum-bot` (GitHub ID `218605180`) as the system user
- `apiKey` is bound to the `DASHBOARDS_SYSTEM_USER_API_KEY` environment variable — startup fails if the env var is not set

## Deployment

Related PR here: https://github.com/GenSpectrum/servers/pull/491

~~The var is set on both prod and staging already.~~ (Can't set it now, because it breaks staging because github ID isn't set yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)