### PR TITLE
feat: add excludeSystemCollections param to GET /collections

### DIFF
--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializer.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializer.kt
@@ -16,11 +16,17 @@ class SystemUserInitializer(
     private val userModel: UserModel,
     private val apiKeyModel: ApiKeyModel,
 ) : ApplicationRunner {
+    private var systemUserId: Long? = null
+
+    /** If a system user is configured, returns the internal system user ID. */
+    fun getSystemUserId(): Long? = systemUserId
+
     override fun run(args: ApplicationArguments) {
         val config = dashboardsConfig.systemUser ?: return
         val user = userModel.syncUser(
             UserSyncRequest(githubId = config.githubId, name = config.name, email = config.email),
         )
+        systemUserId = user.id
         log.info { "System user ready: id=${user.id}, $config" }
         config.apiKey?.let {
             apiKeyModel.upsertApiKey(userId = user.id, rawKey = it)

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializer.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/config/SystemUserInitializer.kt
@@ -16,17 +16,11 @@ class SystemUserInitializer(
     private val userModel: UserModel,
     private val apiKeyModel: ApiKeyModel,
 ) : ApplicationRunner {
-    private var systemUserId: Long? = null
-
-    /** If a system user is configured, returns the internal system user ID. */
-    fun getSystemUserId(): Long? = systemUserId
-
     override fun run(args: ApplicationArguments) {
         val config = dashboardsConfig.systemUser ?: return
         val user = userModel.syncUser(
             UserSyncRequest(githubId = config.githubId, name = config.name, email = config.email),
         )
-        systemUserId = user.id
         log.info { "System user ready: id=${user.id}, $config" }
         config.apiKey?.let {
             apiKeyModel.upsertApiKey(userId = user.id, rawKey = it)

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsController.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsController.kt
@@ -24,7 +24,8 @@ class CollectionsController(private val collectionModel: CollectionModel) {
     @Operation(
         summary = "Get collections",
         description = "Returns collections filtered by optional userId and/or organism parameters. " +
-            "Set includeVariants=true to include the full variant list; by default only variantCount is returned.",
+            "Set includeVariants=true to include the full variant list; by default only variantCount is returned. " +
+            "Set excludeSystemCollections=true to exclude collections owned by the system user.",
     )
     fun getCollections(
         @RequestParam(required = false) userId: Long?,

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsController.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsController.kt
@@ -30,10 +30,12 @@ class CollectionsController(private val collectionModel: CollectionModel) {
         @RequestParam(required = false) userId: Long?,
         @RequestParam(required = false) organism: String?,
         @RequestParam(required = false, defaultValue = "false") includeVariants: Boolean,
+        @RequestParam(required = false, defaultValue = "false") excludeSystemCollections: Boolean,
     ): List<Collection> = collectionModel.getCollections(
         userId = userId,
         organism = organism,
         includeVariants = includeVariants,
+        excludeSystemCollections = excludeSystemCollections,
     )
 
     @GetMapping("/collections/{id}", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
@@ -7,11 +7,11 @@ import org.genspectrum.dashboardsbackend.api.FilterObject
 import org.genspectrum.dashboardsbackend.api.VariantRequest
 import org.genspectrum.dashboardsbackend.api.VariantUpdate
 import org.genspectrum.dashboardsbackend.config.DashboardsConfig
-import org.genspectrum.dashboardsbackend.config.SystemUserInitializer
 import org.genspectrum.dashboardsbackend.controller.BadRequestException
 import org.genspectrum.dashboardsbackend.controller.ForbiddenException
 import org.genspectrum.dashboardsbackend.controller.NotFoundException
 import org.genspectrum.dashboardsbackend.model.user.UserEntity
+import org.genspectrum.dashboardsbackend.model.user.UserModel
 import org.genspectrum.dashboardsbackend.util.now
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.Op
@@ -29,10 +29,7 @@ import kotlin.time.Instant
 
 @Service
 @Transactional
-class CollectionModel(
-    private val dashboardsConfig: DashboardsConfig,
-    private val systemUserInitializer: SystemUserInitializer,
-) {
+class CollectionModel(private val dashboardsConfig: DashboardsConfig, private val userModel: UserModel) {
     fun getCollections(
         userId: Long?,
         organism: String?,
@@ -55,7 +52,7 @@ class CollectionModel(
             collectionConditions = collectionConditions and (CollectionTable.organism eq organism)
         }
         if (excludeSystemCollections) {
-            val systemUserId = systemUserInitializer.getSystemUserId()
+            val systemUserId = userModel.getSystemUserId()
             if (systemUserId != null) {
                 collectionConditions = collectionConditions and (CollectionTable.ownedBy neq systemUserId)
             }

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/collection/CollectionModel.kt
@@ -7,6 +7,7 @@ import org.genspectrum.dashboardsbackend.api.FilterObject
 import org.genspectrum.dashboardsbackend.api.VariantRequest
 import org.genspectrum.dashboardsbackend.api.VariantUpdate
 import org.genspectrum.dashboardsbackend.config.DashboardsConfig
+import org.genspectrum.dashboardsbackend.config.SystemUserInitializer
 import org.genspectrum.dashboardsbackend.controller.BadRequestException
 import org.genspectrum.dashboardsbackend.controller.ForbiddenException
 import org.genspectrum.dashboardsbackend.controller.NotFoundException
@@ -17,6 +18,7 @@ import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.count
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.neq
 import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.select
@@ -27,8 +29,16 @@ import kotlin.time.Instant
 
 @Service
 @Transactional
-class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
-    fun getCollections(userId: Long?, organism: String?, includeVariants: Boolean = false): List<Collection> {
+class CollectionModel(
+    private val dashboardsConfig: DashboardsConfig,
+    private val systemUserInitializer: SystemUserInitializer,
+) {
+    fun getCollections(
+        userId: Long?,
+        organism: String?,
+        includeVariants: Boolean = false,
+        excludeSystemCollections: Boolean = false,
+    ): List<Collection> {
         if (userId != null) {
             UserEntity.findById(userId) ?: throw NotFoundException("User $userId not found")
         }
@@ -43,6 +53,12 @@ class CollectionModel(private val dashboardsConfig: DashboardsConfig) {
         }
         if (organism != null) {
             collectionConditions = collectionConditions and (CollectionTable.organism eq organism)
+        }
+        if (excludeSystemCollections) {
+            val systemUserId = systemUserInitializer.getSystemUserId()
+            if (systemUserId != null) {
+                collectionConditions = collectionConditions and (CollectionTable.ownedBy neq systemUserId)
+            }
         }
 
         val join = CollectionTable.join(VariantTable, JoinType.LEFT)

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/user/UserModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/user/UserModel.kt
@@ -3,6 +3,7 @@ package org.genspectrum.dashboardsbackend.model.user
 import org.genspectrum.dashboardsbackend.api.PublicUser
 import org.genspectrum.dashboardsbackend.api.User
 import org.genspectrum.dashboardsbackend.api.UserSyncRequest
+import org.genspectrum.dashboardsbackend.config.DashboardsConfig
 import org.genspectrum.dashboardsbackend.controller.NotFoundException
 import org.genspectrum.dashboardsbackend.util.now
 import org.springframework.stereotype.Service
@@ -10,7 +11,17 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional
-class UserModel {
+class UserModel(private val dashboardsConfig: DashboardsConfig) {
+    private var systemUserId: Long? = null
+
+    fun getSystemUserId(): Long? {
+        systemUserId?.let { return it }
+        val githubId = dashboardsConfig.systemUser?.githubId ?: return null
+        val id = UserEntity.findByGithubId(githubId)?.id?.value ?: return null
+        systemUserId = id
+        return id
+    }
+
     fun syncUser(request: UserSyncRequest): User {
         val now = now()
         val existing = UserEntity.findByGithubId(request.githubId)

--- a/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/user/UserModel.kt
+++ b/backend/src/main/kotlin/org/genspectrum/dashboardsbackend/model/user/UserModel.kt
@@ -12,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional
 class UserModel(private val dashboardsConfig: DashboardsConfig) {
+    // Not `lazy {}` — needs @Transactional to run inside a DB transaction.
+    @Volatile
     private var systemUserId: Long? = null
 
     fun getSystemUserId(): Long? {

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsClient.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsClient.kt
@@ -31,12 +31,14 @@ class CollectionsClient(private val mockMvc: MockMvc, private val objectMapper: 
         userId: Long? = null,
         organism: String? = null,
         includeVariants: Boolean = false,
+        excludeSystemCollections: Boolean = false,
     ): ResultActions {
         val params = buildString {
             val queryParams = mutableListOf<String>()
             if (userId != null) queryParams.add("userId=$userId")
             if (organism != null) queryParams.add("organism=$organism")
             if (includeVariants) queryParams.add("includeVariants=true")
+            if (excludeSystemCollections) queryParams.add("excludeSystemCollections=true")
             if (queryParams.isNotEmpty()) {
                 append("?")
                 append(queryParams.joinToString("&"))
@@ -49,8 +51,9 @@ class CollectionsClient(private val mockMvc: MockMvc, private val objectMapper: 
         userId: Long? = null,
         organism: String? = null,
         includeVariants: Boolean = false,
+        excludeSystemCollections: Boolean = false,
     ): List<Collection> = deserializeJsonResponse(
-        getCollectionsRaw(userId, organism, includeVariants)
+        getCollectionsRaw(userId, organism, includeVariants, excludeSystemCollections)
             .andExpect(status().isOk),
     )
 

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsExcludeSystemCollectionsTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsExcludeSystemCollectionsTest.kt
@@ -1,0 +1,63 @@
+package org.genspectrum.dashboardsbackend.controller
+
+import org.genspectrum.dashboardsbackend.KnownTestOrganisms
+import org.genspectrum.dashboardsbackend.config.SystemUserInitializer
+import org.genspectrum.dashboardsbackend.dummyCollectionRequest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.TestPropertySource
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(
+    properties = [
+        "dashboards.system-user.github-id=test-system-user-exclude-test",
+        "dashboards.system-user.name=Test Bot",
+    ],
+)
+@Import(CollectionsClient::class, UsersClient::class)
+class CollectionsExcludeSystemCollectionsTest(
+    @param:Autowired private val collectionsClient: CollectionsClient,
+    @param:Autowired private val usersClient: UsersClient,
+    @param:Autowired private val systemUserInitializer: SystemUserInitializer,
+) {
+    @Test
+    fun `GIVEN system and regular user collections WHEN excludeSystemCollections=true THEN only regular returned`() {
+        val systemUserId = requireNotNull(systemUserInitializer.getSystemUserId())
+        val regularUserId = usersClient.createUser()
+
+        val systemCollection = collectionsClient.postCollection(
+            dummyCollectionRequest.copy(name = "System Collection", organism = KnownTestOrganisms.Covid.name),
+            systemUserId,
+        )
+        val regularCollection = collectionsClient.postCollection(
+            dummyCollectionRequest.copy(name = "Regular Collection", organism = KnownTestOrganisms.Covid.name),
+            regularUserId,
+        )
+
+        val collections = collectionsClient.getCollections(excludeSystemCollections = true)
+
+        assertThat(collections, hasItem(regularCollection))
+        assertThat(collections, not(hasItem(systemCollection)))
+    }
+
+    @Test
+    fun `GIVEN system user collection WHEN not excluding system collections THEN system collection is included`() {
+        val systemUserId = requireNotNull(systemUserInitializer.getSystemUserId())
+
+        val systemCollection = collectionsClient.postCollection(
+            dummyCollectionRequest.copy(name = "System Collection Visible", organism = KnownTestOrganisms.Covid.name),
+            systemUserId,
+        )
+
+        val collections = collectionsClient.getCollections(excludeSystemCollections = false)
+
+        assertThat(collections, hasItem(systemCollection))
+    }
+}

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsExcludeSystemCollectionsTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsExcludeSystemCollectionsTest.kt
@@ -41,7 +41,7 @@ class CollectionsExcludeSystemCollectionsTest(
             regularUserId,
         )
 
-        val collections = collectionsClient.getCollections(excludeSystemCollections = true)
+        val collections = collectionsClient.getCollections(includeVariants = true, excludeSystemCollections = true)
 
         assertThat(collections, hasItem(regularCollection))
         assertThat(collections, not(hasItem(systemCollection)))
@@ -56,7 +56,7 @@ class CollectionsExcludeSystemCollectionsTest(
             systemUserId,
         )
 
-        val collections = collectionsClient.getCollections(excludeSystemCollections = false)
+        val collections = collectionsClient.getCollections(includeVariants = true, excludeSystemCollections = false)
 
         assertThat(collections, hasItem(systemCollection))
     }

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsExcludeSystemCollectionsTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsExcludeSystemCollectionsTest.kt
@@ -1,8 +1,8 @@
 package org.genspectrum.dashboardsbackend.controller
 
 import org.genspectrum.dashboardsbackend.KnownTestOrganisms
-import org.genspectrum.dashboardsbackend.config.SystemUserInitializer
 import org.genspectrum.dashboardsbackend.dummyCollectionRequest
+import org.genspectrum.dashboardsbackend.model.user.UserModel
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.not
@@ -25,11 +25,11 @@ import org.springframework.test.context.TestPropertySource
 class CollectionsExcludeSystemCollectionsTest(
     @param:Autowired private val collectionsClient: CollectionsClient,
     @param:Autowired private val usersClient: UsersClient,
-    @param:Autowired private val systemUserInitializer: SystemUserInitializer,
+    @param:Autowired private val userModel: UserModel,
 ) {
     @Test
     fun `GIVEN system and regular user collections WHEN excludeSystemCollections=true THEN only regular returned`() {
-        val systemUserId = requireNotNull(systemUserInitializer.getSystemUserId())
+        val systemUserId = requireNotNull(userModel.getSystemUserId())
         val regularUserId = usersClient.createUser()
 
         val systemCollection = collectionsClient.postCollection(
@@ -49,7 +49,7 @@ class CollectionsExcludeSystemCollectionsTest(
 
     @Test
     fun `GIVEN system user collection WHEN not excluding system collections THEN system collection is included`() {
-        val systemUserId = requireNotNull(systemUserInitializer.getSystemUserId())
+        val systemUserId = requireNotNull(userModel.getSystemUserId())
 
         val systemCollection = collectionsClient.postCollection(
             dummyCollectionRequest.copy(name = "System Collection Visible", organism = KnownTestOrganisms.Covid.name),

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
@@ -301,6 +301,16 @@ class CollectionsGetTest(
     }
 
     @Test
+    fun `WHEN no system user configured THEN excludeSystemCollections=true returns all collections`() {
+        val userId = usersClient.createUser()
+        val collection = collectionsClient.postCollection(dummyCollectionRequest.copy(name = "No System User"), userId)
+
+        val collections = collectionsClient.getCollections(userId = userId, excludeSystemCollections = true)
+
+        assertThat(collections, hasItem(collection))
+    }
+
+    @Test
     fun `WHEN getting collections with includeVariants=true THEN variantCount and variants are both present`() {
         val userId = usersClient.createUser()
         collectionsClient.postCollection(dummyCollectionRequest, userId)

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
@@ -305,7 +305,11 @@ class CollectionsGetTest(
         val userId = usersClient.createUser()
         val collection = collectionsClient.postCollection(dummyCollectionRequest.copy(name = "No System User"), userId)
 
-        val collections = collectionsClient.getCollections(userId = userId, excludeSystemCollections = true)
+        val collections = collectionsClient.getCollections(
+            userId = userId,
+            includeVariants = true,
+            excludeSystemCollections = true,
+        )
 
         assertThat(collections, hasItem(collection))
     }

--- a/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
+++ b/backend/src/test/kotlin/org/genspectrum/dashboardsbackend/controller/CollectionsGetTest.kt
@@ -301,7 +301,7 @@ class CollectionsGetTest(
     }
 
     @Test
-    fun `WHEN no system user configured THEN excludeSystemCollections=true returns all collections`() {
+    fun `GIVEN no system user configured WHEN getting with excludeSystemCollections THEN returns all collections`() {
         val userId = usersClient.createUser()
         val collection = collectionsClient.postCollection(dummyCollectionRequest.copy(name = "No System User"), userId)
 

--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -231,7 +231,6 @@ export class BackendRouteMocker {
             }),
         );
     }
-
 }
 
 function resolver(cases: MockCase[]) {

--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -232,33 +232,6 @@ export class BackendRouteMocker {
         );
     }
 
-    mockGetCollectionSummaries(
-        response: CollectionSummary[],
-        organism?: string,
-        statusCode = 200,
-        excludeSystemCollections?: boolean,
-    ) {
-        this.workerOrServer.use(
-            http.get(
-                `${DUMMY_BACKEND_URL}/collections`,
-                resolver([
-                    {
-                        statusCode,
-                        response,
-                        requestParam:
-                            organism !== undefined || excludeSystemCollections !== undefined
-                                ? {
-                                      ...(organism !== undefined ? { organism } : {}),
-                                      ...(excludeSystemCollections !== undefined
-                                          ? { excludeSystemCollections: String(excludeSystemCollections) }
-                                          : {}),
-                                  }
-                                : undefined,
-                    },
-                ]),
-            ),
-        );
-    }
 }
 
 function resolver(cases: MockCase[]) {

--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -34,7 +34,16 @@ export class AstroApiRouteMocker {
         this.workerOrServer.use(
             http.get(
                 `${ASTRO_SERVER_URL}/collections`,
-                resolver([{ statusCode, response, requestParam: organism !== undefined ? { organism } : undefined }]),
+                resolver([
+                    {
+                        statusCode,
+                        response,
+                        requestParam: {
+                            ...(organism !== undefined ? { organism } : {}),
+                            excludeSystemCollections: 'true',
+                        },
+                    },
+                ]),
             ),
         );
     }

--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -30,7 +30,12 @@ export class AstroApiRouteMocker {
         this.workerOrServer.use(http.post(`${ASTRO_SERVER_URL}/log`, () => Response.json({})));
     }
 
-    mockGetCollectionSummaries(response: CollectionSummary[], organism?: string, statusCode = 200) {
+    mockGetCollectionSummaries(
+        response: CollectionSummary[],
+        organism?: string,
+        statusCode = 200,
+        excludeSystemCollections?: boolean,
+    ) {
         this.workerOrServer.use(
             http.get(
                 `${ASTRO_SERVER_URL}/collections`,
@@ -40,7 +45,9 @@ export class AstroApiRouteMocker {
                         response,
                         requestParam: {
                             ...(organism !== undefined ? { organism } : {}),
-                            excludeSystemCollections: 'true',
+                            ...(excludeSystemCollections !== undefined
+                                ? { excludeSystemCollections: String(excludeSystemCollections) }
+                                : {}),
                         },
                     },
                 ]),
@@ -225,11 +232,30 @@ export class BackendRouteMocker {
         );
     }
 
-    mockGetCollectionSummaries(response: CollectionSummary[], organism?: string, statusCode = 200) {
+    mockGetCollectionSummaries(
+        response: CollectionSummary[],
+        organism?: string,
+        statusCode = 200,
+        excludeSystemCollections?: boolean,
+    ) {
         this.workerOrServer.use(
             http.get(
                 `${DUMMY_BACKEND_URL}/collections`,
-                resolver([{ statusCode, response, requestParam: organism !== undefined ? { organism } : undefined }]),
+                resolver([
+                    {
+                        statusCode,
+                        response,
+                        requestParam:
+                            organism !== undefined || excludeSystemCollections !== undefined
+                                ? {
+                                      ...(organism !== undefined ? { organism } : {}),
+                                      ...(excludeSystemCollections !== undefined
+                                          ? { excludeSystemCollections: String(excludeSystemCollections) }
+                                          : {}),
+                                  }
+                                : undefined,
+                    },
+                ]),
             ),
         );
     }

--- a/website/src/backendApi/backendService.spec.ts
+++ b/website/src/backendApi/backendService.spec.ts
@@ -170,5 +170,4 @@ describe('backendService', () => {
             new UnknownBackendError('Bad Request', 400, '/subscriptions'),
         );
     });
-
 });

--- a/website/src/backendApi/backendService.spec.ts
+++ b/website/src/backendApi/backendService.spec.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from 'vitest';
 import { BackendError, BackendService, UnknownBackendError } from './backendService.ts';
 import { DUMMY_BACKEND_URL } from '../../routeMocker.ts';
 import { backendRouteMocker } from '../../vitest.setup.ts';
-import type { CollectionSummary } from '../types/Collection.ts';
 import type { SubscriptionRequest, SubscriptionResponse, TriggerEvaluationResponse } from '../types/Subscription.ts';
 
 describe('backendService', () => {
@@ -172,26 +171,4 @@ describe('backendService', () => {
         );
     });
 
-    const aCollection: CollectionSummary = {
-        id: 1,
-        name: 'Test collection',
-        ownedBy: 123,
-        organism: 'covid',
-        description: 'A test collection',
-        variantCount: 0,
-    };
-
-    test('should GET collection summaries without organism filter', async () => {
-        backendRouteMocker.mockGetCollectionSummaries([aCollection]);
-
-        await expect(backendService.getCollectionSummaries()).resolves.to.deep.equal([aCollection]);
-    });
-
-    test('should GET collection summaries filtered by organism', async () => {
-        backendRouteMocker.mockGetCollectionSummaries([aCollection], 'covid');
-
-        await expect(backendService.getCollectionSummaries({ organism: 'covid' })).resolves.to.deep.equal([
-            aCollection,
-        ]);
-    });
 });

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -177,8 +177,13 @@ export class BackendService extends ApiService {
         return this.get({ url: `/users/${id}`, schema: publicUserSchema });
     }
 
-    public async getCollectionSummaries({ organism }: { organism?: string } = {}) {
-        const requestParams = organism !== undefined ? { organism } : undefined;
+    public async getCollectionSummaries({
+        organism,
+        excludeSystemCollections = false,
+    }: { organism?: string; excludeSystemCollections?: boolean } = {}) {
+        const requestParams: Record<string, string> = {};
+        if (organism !== undefined) requestParams.organism = organism;
+        if (excludeSystemCollections) requestParams.excludeSystemCollections = 'true';
         return this.get({ url: '/collections', requestParams, schema: z.array(collectionSummarySchema) });
     }
 

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -22,7 +22,7 @@ const X_REQUEST_ID_HEADER = 'x-request-id';
 
 type EndpointParameters<Response> = {
     url: string;
-    requestParams?: Record<string, string>;
+    requestParams?: Record<string, string | boolean | undefined>;
     schema: ZodSchema<Response>;
 };
 
@@ -177,13 +177,7 @@ export class BackendService extends ApiService {
         return this.get({ url: `/users/${id}`, schema: publicUserSchema });
     }
 
-    public async getCollectionSummaries({
-        organism,
-        excludeSystemCollections = false,
-    }: { organism?: string; excludeSystemCollections?: boolean } = {}) {
-        const requestParams: Record<string, string> = {};
-        if (organism !== undefined) requestParams.organism = organism;
-        if (excludeSystemCollections) requestParams.excludeSystemCollections = 'true';
+    public async getCollectionSummaries(requestParams: { organism?: string; excludeSystemCollections?: boolean } = {}) {
         return this.get({ url: '/collections', requestParams, schema: z.array(collectionSummarySchema) });
     }
 

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -29,7 +29,7 @@ const mockCollections = [
 
 describe('CollectionsOverview', () => {
     it('shows the headline and collections table on success', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries(mockCollections, ORGANISM);
+        astro.mockGetCollectionSummaries(mockCollections, ORGANISM, 200, true);
 
         const { getByText, getByRole } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);
 
@@ -42,7 +42,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows the headline and empty message when there are no collections', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries([], ORGANISM);
+        astro.mockGetCollectionSummaries([], ORGANISM, 200, true);
 
         const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);
 
@@ -51,7 +51,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows the headline and error message when the fetch fails', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries([], ORGANISM, 500);
+        astro.mockGetCollectionSummaries([], ORGANISM, 500, true);
         astro.mockLog();
 
         const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -21,7 +21,8 @@ function CollectionsOverviewInner({ organism, isLoggedIn }: { organism: Organism
         error,
     } = useQuery({
         queryKey: ['collections', organism],
-        queryFn: () => getBackendServiceForClientside().getCollectionSummaries({ organism }),
+        queryFn: () =>
+            getBackendServiceForClientside().getCollectionSummaries({ organism, excludeSystemCollections: true }),
     });
 
     if (isError) {


### PR DESCRIPTION
resolves #1231 

## Summary

- Adds `excludeSystemCollections` query parameter to `GET /collections` (default `false`)
- The collections overview table in the frontend always passes `excludeSystemCollections=true`

## Screenshot

**No collections in the list, but individual collections can still be accessed**

https://github.com/user-attachments/assets/4c909dd3-2755-47c4-ac7b-55584b1fe222

## Test plan

- [x] `GET /collections` without the param returns all collections including system-owned ones (no regression)
- [x] `GET /collections?excludeSystemCollections=true` excludes collections owned by the system user
- [x] If no system user is configured, the param has no effect
- [x] Collections overview in the UI no longer shows system-owned collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)