### PR TITLE
feat(website): change wastewater default view for covid

### DIFF
--- a/website/src/components/views/wasap/WasapPage.tsx
+++ b/website/src/components/views/wasap/WasapPage.tsx
@@ -1,4 +1,3 @@
-import type { MeanProportionInterval } from '@genspectrum/dashboard-components/util';
 import { useMemo } from 'react';
 import { type FC } from 'react';
 
@@ -6,6 +5,7 @@ import { CollectionInfo } from './components/CollectionInfo';
 import { NoDataHelperText } from './components/NoDataHelperText';
 import { VariantFetchInfo } from './components/VariantFetchInfo';
 import { WasapStats } from './components/WasapStats';
+import { getInitialMeanProportionInterval } from './initialMeanProportionInterval';
 import type { ResistanceData } from './resistanceData';
 import { useWasapPageData } from './useWasapPageData';
 import type { WasapPageConfig } from './wasapPageConfig';
@@ -39,10 +39,7 @@ export const WasapPageInner: FC<WasapPageProps> = ({ config, resistanceData }) =
     // fetch which mutations should be analyzed
     const { data, isPending, isError } = useWasapPageData(config, displayMutationsBySet, analysis);
 
-    let initialMeanProportionInterval: MeanProportionInterval = { min: 0.0, max: 1.0 };
-    if (analysis.mode === 'manual' && analysis.mutations === undefined) {
-        initialMeanProportionInterval = { min: 0.05, max: 0.95 };
-    }
+    const initialMeanProportionInterval = getInitialMeanProportionInterval(analysis);
 
     const lapisFilter = {
         ...(base.locationName && { locationName: base.locationName }),

--- a/website/src/components/views/wasap/initialMeanProportionInterval.spec.ts
+++ b/website/src/components/views/wasap/initialMeanProportionInterval.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+
+import { getInitialMeanProportionInterval } from './initialMeanProportionInterval';
+import type { WasapAnalysisFilter } from './wasapPageConfig';
+
+describe('getInitialMeanProportionInterval', () => {
+    test('resistance mutations initially show mean proportion from 5 to 100 percent', () => {
+        const analysis: WasapAnalysisFilter = {
+            mode: 'resistance',
+            sequenceType: 'amino acid',
+            resistanceSet: 'Spike',
+        };
+
+        expect(getInitialMeanProportionInterval(analysis)).toEqual({ min: 0.05, max: 1.0 });
+    });
+
+    test('manual mode without mutations keeps the previous 5 to 95 percent default', () => {
+        const analysis: WasapAnalysisFilter = {
+            mode: 'manual',
+            sequenceType: 'nucleotide',
+            mutations: undefined,
+        };
+
+        expect(getInitialMeanProportionInterval(analysis)).toEqual({ min: 0.05, max: 0.95 });
+    });
+
+    test('other analysis states initially show the full mean proportion range', () => {
+        const analysis: WasapAnalysisFilter = {
+            mode: 'variant',
+            sequenceType: 'nucleotide',
+            variant: 'XFG*',
+            minProportion: 0.8,
+            minCount: 15,
+            minJaccard: 0.75,
+            timeFrame: 'all',
+        };
+
+        expect(getInitialMeanProportionInterval(analysis)).toEqual({ min: 0.0, max: 1.0 });
+    });
+});

--- a/website/src/components/views/wasap/initialMeanProportionInterval.ts
+++ b/website/src/components/views/wasap/initialMeanProportionInterval.ts
@@ -1,0 +1,13 @@
+import type { MeanProportionInterval } from '@genspectrum/dashboard-components/util';
+
+import type { WasapAnalysisFilter } from './wasapPageConfig';
+
+export function getInitialMeanProportionInterval(analysis: WasapAnalysisFilter): MeanProportionInterval {
+    if (analysis.mode === 'resistance') {
+        return { min: 0.05, max: 1.0 };
+    }
+    if (analysis.mode === 'manual' && analysis.mutations === undefined) {
+        return { min: 0.05, max: 0.95 };
+    }
+    return { min: 0.0, max: 1.0 };
+}

--- a/website/src/components/views/wasap/wasapPageConfig.ts
+++ b/website/src/components/views/wasap/wasapPageConfig.ts
@@ -38,6 +38,8 @@ export type WasapPageConfigBase = {
 
     browseDataUrl: string;
     browseDataDescription: string;
+
+    defaultAnalysisMode?: WasapAnalysisMode;
 };
 
 /**

--- a/website/src/types/wastewaterConfig.spec.ts
+++ b/website/src/types/wastewaterConfig.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
-import { wastewaterOrganismConfigs } from './wastewaterConfig';
+import { wastewaterOrganismConfigs, wastewaterOrganisms } from './wastewaterConfig';
+import { enabledAnalysisModes } from '../components/views/wasap/wasapPageConfig';
 
 describe.each(Object.entries(wastewaterOrganismConfigs))('wastewaterConfig %s', (_configName, config) => {
     test('default resistance set name is valid', () => {
@@ -10,4 +11,25 @@ describe.each(Object.entries(wastewaterOrganismConfigs))('wastewaterConfig %s', 
             expect(resistanceSetNames).include(defaultSetName);
         }
     });
+
+    test('configured default mode must be enabled', () => {
+        const defaultMode = config.defaultAnalysisMode;
+        if (defaultMode === undefined) {
+            return;
+        }
+
+        // Prevent configs from pointing the URL-less page state at a disabled mode.
+        expect(enabledAnalysisModes(config)).include(defaultMode);
+    });
+});
+
+test('COVID wastewater opens on Spike resistance mutations by default', () => {
+    const covidConfig = wastewaterOrganismConfigs[wastewaterOrganisms.covid];
+
+    // This pins the default requested for the COVID wastewater dashboard landing state.
+    expect(covidConfig.defaultAnalysisMode).toBe('resistance');
+    if (!covidConfig.resistanceAnalysisModeEnabled) {
+        throw new Error('COVID wastewater resistance analysis mode must be enabled.');
+    }
+    expect(covidConfig.filterDefaults.resistance.resistanceSet).toBe('Spike');
 });

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -29,6 +29,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         resistanceAnalysisModeEnabled: true,
         untrackedAnalysisModeEnabled: true,
         collectionAnalysisModeEnabled: true,
+        defaultAnalysisMode: 'resistance',
         resistanceMutationCollections: [
             {
                 collectionId: 1,
@@ -85,7 +86,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
             resistance: {
                 mode: 'resistance',
                 sequenceType: 'amino acid',
-                resistanceSet: '3CLpro',
+                resistanceSet: 'Spike',
             },
             untracked: {
                 mode: 'untracked',

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
@@ -93,6 +93,19 @@ describe('WasapPageStateHandler', () => {
             const url = handler.getDefaultPageUrl();
             expect(url).toBe('/wastewater/covid');
         });
+
+        it('uses configured default mode when URL has no analysisMode', () => {
+            const handlerWithDefaultMode = new WasapPageStateHandler({
+                ...config,
+                defaultAnalysisMode: 'resistance',
+            });
+
+            // A bare URL should use the configured mode instead of the first enabled mode.
+            const filter = handlerWithDefaultMode.parsePageStateFromUrl(new URL('http://example.com/wastewater/covid'));
+
+            expect(filter.analysis.mode).toBe('resistance');
+            expect((filter.analysis as WasapResistanceFilter).resistanceSet).toBe('3CLpro');
+        });
     });
 
     describe('base filter', () => {

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -35,7 +35,7 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
         const providedMode = texts.analysisMode as WasapAnalysisMode | undefined;
 
         // config provided defaults
-        const defaultMode = enabledAnalysisModes(this.config)[0];
+        const defaultMode = this.config.defaultAnalysisMode ?? enabledAnalysisModes(this.config)[0];
 
         const mode = providedMode ?? defaultMode;
 


### PR DESCRIPTION
resolves #1074

### Summary

The default view of the wastewater dashboard has been changed for SARS-CoV-2 to resistance mutations. For RSV, nothing changes.

## PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by an appropriate test.
