### PR TITLE
feat(website): enable collections pages in production

### DIFF
--- a/website/src/layouts/base/header/getPathogenMegaMenuSections.ts
+++ b/website/src/layouts/base/header/getPathogenMegaMenuSections.ts
@@ -1,5 +1,5 @@
 import type { MenuIconType } from '../../../components/iconCss.ts';
-import { getOrganismConfig, isStaging } from '../../../config.ts';
+import { getOrganismConfig } from '../../../config.ts';
 import { type Organism, organismConfig, paths } from '../../../types/Organism.ts';
 import { Page } from '../../../types/pages.ts';
 import {
@@ -51,8 +51,7 @@ export function getPathogenMegaMenuSections(): PathogenMegaMenuSections {
 
         const supplementaryEntries: MegaMenuSection[] = [];
 
-        // only on staging for now, remove when enabling on prod: https://github.com/GenSpectrum/dashboards/issues/1108
-        if (isStaging() && getOrganismConfig(config.organism).hasCollections) {
+        if (getOrganismConfig(config.organism).hasCollections) {
             supplementaryEntries.push({
                 label: 'Collections',
                 href: Page.collectionsForOrganism(config.organism),

--- a/website/src/pages/collections/[organism]/index.astro
+++ b/website/src/pages/collections/[organism]/index.astro
@@ -1,15 +1,9 @@
 ---
 import { CollectionsOverview } from '../../../components/collections/overview/CollectionsOverview';
-import { isStaging } from '../../../config';
 import { defaultBreadcrumbs } from '../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { organismConfig, organismSchema } from '../../../types/Organism';
 import { Page } from '../../../types/pages';
-
-// only on staging for now, remove when enabling on prod: https://github.com/GenSpectrum/dashboards/issues/1108
-if (!isStaging()) {
-    return Astro.redirect('/404');
-}
 
 const { organism } = Astro.params;
 

--- a/website/src/pages/collections/index.astro
+++ b/website/src/pages/collections/index.astro
@@ -1,14 +1,9 @@
 ---
-import { getOrganismConfig, isStaging } from '../../config';
+import { getOrganismConfig } from '../../config';
 import { defaultBreadcrumbs } from '../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { allOrganisms, organismConfig } from '../../types/Organism';
 import { Page } from '../../types/pages';
-
-// only on staging for now, remove when enabling on prod: https://github.com/GenSpectrum/dashboards/issues/1108
-if (!isStaging()) {
-    return Astro.redirect('/404');
-}
 ---
 
 <ContaineredPageLayout


### PR DESCRIPTION
## Summary

- Removes `isStaging()` guards that were redirecting `/collections` and `/collections/[organism]` to 404 in production
- Removes the `isStaging()` condition hiding the Collections entry in the pathogen mega menu (still gated by `hasCollections` per organism config)

Closes #1108