### PR TITLE
feat(wasap): make location filter required

### DIFF
--- a/website/src/components/pageStateSelectors/ApplyFilterButton.tsx
+++ b/website/src/components/pageStateSelectors/ApplyFilterButton.tsx
@@ -12,10 +12,12 @@ export function ApplyFilterButton<PageState extends object>({
     newPageState,
     setPageState,
     className = '',
+    disabled = false,
 }: WithClassName<{
     pageStateHandler: PageStateHandler<PageState>;
     newPageState: PageState;
     setPageState: Dispatch<SetStateAction<PageState>>;
+    disabled?: boolean;
 }>) {
     const url = pageStateHandler.toUrl(newPageState);
     const fullUrl = `${window.location.origin}${url}`;
@@ -25,18 +27,26 @@ export function ApplyFilterButton<PageState extends object>({
         setPageState(newPageState);
     };
 
-    return urlTooLong ? (
-        <>
-            <span role='button' className={`btn btn-primary btn-disabled ${className}`}>
-                Apply filters
-            </span>
-            <div className='alert alert-error mt-2'>
-                <span>
-                    The URL is too long ({fullUrl.length} characters, maximum {MAX_URL_LENGTH}). Please reduce the
-                    amount of data in the filters.
+    if (urlTooLong) {
+        return (
+            <>
+                <span role='button' className={`btn btn-primary btn-disabled ${className}`}>
+                    Apply filters
                 </span>
-            </div>
-        </>
+                <div className='alert alert-error mt-2'>
+                    <span>
+                        The URL is too long ({fullUrl.length} characters, maximum {MAX_URL_LENGTH}). Please reduce the
+                        amount of data in the filters.
+                    </span>
+                </div>
+            </>
+        );
+    }
+
+    return disabled ? (
+        <span role='button' className={`btn btn-primary btn-disabled ${className}`}>
+            Apply filters
+        </span>
     ) : (
         <button type='button' onClick={applyFilters} className={`btn btn-primary ${className}`}>
             Apply filters

--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -105,7 +105,10 @@ export function WasapPageStateSelector({
         <div className='flex flex-col gap-4'>
             <SelectorHeadline>Filter dataset</SelectorHeadline>
             <Inset className='p-2'>
-                <LabeledField label='Sampling location'>
+                <LabeledField
+                    label='Sampling location'
+                    error={!baseFilterState.locationName ? 'Location is required' : undefined}
+                >
                     <GsTextFilter
                         placeholderText='Sampling location'
                         lapisField={config.locationNameField}
@@ -226,6 +229,7 @@ export function WasapPageStateSelector({
                 pageStateHandler={pageStateHandler}
                 newPageState={getMergedPageState()}
                 setPageState={setPageState}
+                disabled={!baseFilterState.locationName}
             />
         </div>
     );

--- a/website/src/components/pageStateSelectors/wasap/utils/LabeledField.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/LabeledField.tsx
@@ -16,9 +16,13 @@ interface LabeledFieldProps {
      * If provided, a help button will be shown next to the label.
      */
     info?: ReactNode;
+    /**
+     * Optional error message displayed below the field.
+     */
+    error?: string;
 }
 
-export function LabeledField({ label, children, info }: LabeledFieldProps) {
+export function LabeledField({ label, children, info, error }: LabeledFieldProps) {
     const modalRef = useModalRef();
 
     return (
@@ -44,6 +48,11 @@ export function LabeledField({ label, children, info }: LabeledFieldProps) {
                 )}
             </div>
             {children}
+            {error !== undefined && (
+                <label className='label'>
+                    <span className='label-text-alt text-error'>{error}</span>
+                </label>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
This is a quite simple implementation of forcing fields to be set. This is just to show the concept.

---

## Summary

- Adds an `error` prop to `LabeledField` that renders an inline error message below the field using DaisyUI's `label-text-alt text-error` pattern
- Adds a `disabled` prop to `ApplyFilterButton` that renders a greyed-out button when set
- Wires both up on the wastewater sampling location filter — if the user clears the field, an error appears and Apply is blocked

Since the location is always pre-populated from `defaultLocationName`, this only kicks in if the user explicitly clears the input.

## Screenshot


https://github.com/user-attachments/assets/2a1da1d0-f49f-4f4e-9a11-ffd0af4a6d16



## Test plan

- [ ] Load a wastewater dashboard and confirm the location field is pre-filled and Apply works normally
- [ ] Clear the location field and confirm the "Location is required" error appears below it
- [ ] Confirm the Apply button is greyed out and unclickable when the location is empty
- [ ] Re-enter a location and confirm the error disappears and Apply becomes clickable again
- [ ] Confirm the URL-too-long error case still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)