### PR TITLE
fix(github-actions): restore closing quote on body string in rebaseProd workflow

### DIFF
--- a/.github/workflows/rebaseProd.yml
+++ b/.github/workflows/rebaseProd.yml
@@ -26,9 +26,9 @@ jobs:
             echo "PR to update prod from main already exists - skipping creation"
           else
             body="This pull request updates the \`prod\` branch with the latest changes from the \`main\` branch.
-  
+
             # ⚠️ Do not squash-merge! ⚠️
-            Make sure to merge this creating a merge commit.
-        
+            Make sure to merge this creating a merge commit."
+
             gh pr create --base prod --head main --title "chore: update prod from main" --body "$body"
           fi


### PR DESCRIPTION
## Summary

- `0a186a8` removed the closing `"` from the `body` variable when updating the PR message wording
- This caused the shell to treat the `gh pr create` line as part of the string, erroring with `unexpected EOF while looking for matching '"'`
- Restores the closing quote and moves `gh pr create` back outside the string

🤖 Generated with [Claude Code](https://claude.com/claude-code)