### PR TITLE
fix(website): use correct collections user ID for COVID wastewater variant selector on prod

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -206,7 +206,7 @@ function withResistanceCollectionOverrides(config: WasapPageConfig): WasapPageCo
                 collectionId: stagingIds[set.name] ?? set.collectionId,
             })),
         }),
-        ...(config.predefinedVariantsSource !== undefined && {
+        ...(config.variantAnalysisModeEnabled && config.predefinedVariantsSource !== undefined && {
             predefinedVariantsSource: {
                 ...config.predefinedVariantsSource,
                 collectionsUserId: 1,

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -58,7 +58,7 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
         samplingDateField: 'samplingDate',
         locationNameField: 'locationName',
         predefinedVariantsSource: {
-            collectionsUserId: 1,
+            collectionsUserId: 3,
             collectionsTag: '#pango-lineage',
             variantSourceLabel: 'Nextclade',
         },
@@ -196,15 +196,22 @@ export const wastewaterOrganismConfigs: Record<WastewaterOrganismName, WasapPage
 };
 
 function withResistanceCollectionOverrides(config: WasapPageConfig): WasapPageConfig {
-    if (!config.resistanceAnalysisModeEnabled) return config;
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const stagingIds: Record<string, number> = { '3CLpro': 4, 'RdRp': 5, 'Spike': 6 };
     return {
         ...config,
-        resistanceMutationCollections: config.resistanceMutationCollections.map((set) => ({
-            ...set,
-            collectionId: stagingIds[set.name] ?? set.collectionId,
-        })),
+        ...(config.resistanceAnalysisModeEnabled && {
+            resistanceMutationCollections: config.resistanceMutationCollections.map((set) => ({
+                ...set,
+                collectionId: stagingIds[set.name] ?? set.collectionId,
+            })),
+        }),
+        ...(config.predefinedVariantsSource !== undefined && {
+            predefinedVariantsSource: {
+                ...config.predefinedVariantsSource,
+                collectionsUserId: 1,
+            },
+        }),
     };
 }
 

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -206,12 +206,13 @@ function withResistanceCollectionOverrides(config: WasapPageConfig): WasapPageCo
                 collectionId: stagingIds[set.name] ?? set.collectionId,
             })),
         }),
-        ...(config.variantAnalysisModeEnabled && config.predefinedVariantsSource !== undefined && {
-            predefinedVariantsSource: {
-                ...config.predefinedVariantsSource,
-                collectionsUserId: 1,
-            },
-        }),
+        ...(config.variantAnalysisModeEnabled &&
+            config.predefinedVariantsSource !== undefined && {
+                predefinedVariantsSource: {
+                    ...config.predefinedVariantsSource,
+                    collectionsUserId: 1,
+                },
+            }),
     };
 }
 


### PR DESCRIPTION
## Summary
- The COVID wastewater predefined variant selector was querying collections for user ID 1 on prod; it should be user ID 3
- Added `collectionsUserId: 1` override into the existing `withResistanceCollectionOverrides` staging config function, so staging keeps user ID 1
- Removed the early return guard in `withResistanceCollectionOverrides` so each override (resistance collections, predefined variants source) is applied independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)