### PR TITLE
fix(website): collection page URLs use pathFragment instead of organism enum value

### DIFF
--- a/website/src/pages/collections/[pathFragment]/[id]/edit.astro
+++ b/website/src/pages/collections/[pathFragment]/[id]/edit.astro
@@ -6,16 +6,16 @@ import { getDashboardsConfig, getBackendHost } from '../../../../config';
 import { defaultBreadcrumbs } from '../../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { getInstanceLogger } from '../../../../logger.ts';
-import { organismConfig, organismSchema } from '../../../../types/Organism';
+import { allOrganisms, organismConfig } from '../../../../types/Organism';
 import { Page } from '../../../../types/pages';
 import { getErrorLogMessage } from '../../../../util/getErrorLogMessage.ts';
 
 const logger = getInstanceLogger('CollectionEditPage');
 
-const { organism, id } = Astro.params;
+const { pathFragment, id } = Astro.params;
 
-const parsedOrganism = organismSchema.safeParse(organism);
-if (!parsedOrganism.success) {
+const organism = allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+if (organism === undefined) {
     return Astro.redirect('/404');
 }
 
@@ -23,7 +23,7 @@ if (id === undefined) {
     return Astro.redirect('/404');
 }
 
-const orgConfig = organismConfig[parsedOrganism.data];
+const orgConfig = organismConfig[organism];
 const currentUserId = Astro.locals.gsUserId;
 const config = getDashboardsConfig();
 
@@ -51,16 +51,16 @@ const collectionTitle = collection !== undefined ? `#${id} ${collection.name}` :
     breadcrumbs={[
         ...defaultBreadcrumbs,
         { name: 'Collections', href: Page.collectionsOverview },
-        { name: orgConfig.label, href: Page.collectionsForOrganism(parsedOrganism.data) },
-        { name: collectionTitle, href: Page.viewCollection(parsedOrganism.data, id) },
-        { name: 'Edit', href: Page.editCollection(parsedOrganism.data, id) },
+        { name: orgConfig.label, href: Page.collectionsForOrganism(organism) },
+        { name: collectionTitle, href: Page.viewCollection(organism, id) },
+        { name: 'Edit', href: Page.editCollection(organism, id) },
     ]}
 >
     {
         currentUserId !== undefined ? (
             <CollectionEdit
                 client:only='react'
-                organism={parsedOrganism.data}
+                organism={organism}
                 id={id}
                 config={config}
                 collection={

--- a/website/src/pages/collections/[pathFragment]/[id]/edit.astro
+++ b/website/src/pages/collections/[pathFragment]/[id]/edit.astro
@@ -6,7 +6,7 @@ import { getDashboardsConfig, getBackendHost } from '../../../../config';
 import { defaultBreadcrumbs } from '../../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { getInstanceLogger } from '../../../../logger.ts';
-import { allOrganisms, organismConfig } from '../../../../types/Organism';
+import { organismConfig, organismFromPathFragment } from '../../../../types/Organism';
 import { Page } from '../../../../types/pages';
 import { getErrorLogMessage } from '../../../../util/getErrorLogMessage.ts';
 
@@ -14,7 +14,7 @@ const logger = getInstanceLogger('CollectionEditPage');
 
 const { pathFragment, id } = Astro.params;
 
-const organism = allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+const organism = organismFromPathFragment(pathFragment);
 if (organism === undefined) {
     return Astro.redirect('/404');
 }

--- a/website/src/pages/collections/[pathFragment]/[id]/index.astro
+++ b/website/src/pages/collections/[pathFragment]/[id]/index.astro
@@ -6,7 +6,7 @@ import { defaultBreadcrumbs } from '../../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { getInstanceLogger } from '../../../../logger.ts';
 import type { Collection } from '../../../../types/Collection.ts';
-import { allOrganisms, organismConfig } from '../../../../types/Organism';
+import { organismConfig, organismFromPathFragment } from '../../../../types/Organism';
 import { Page } from '../../../../types/pages';
 import { getErrorLogMessage } from '../../../../util/getErrorLogMessage.ts';
 
@@ -14,7 +14,7 @@ const logger = getInstanceLogger('CollectionDetailPage');
 
 const { pathFragment, id } = Astro.params;
 
-const organism = allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+const organism = organismFromPathFragment(pathFragment);
 if (organism === undefined) {
     return Astro.redirect('/404');
 }

--- a/website/src/pages/collections/[pathFragment]/[id]/index.astro
+++ b/website/src/pages/collections/[pathFragment]/[id]/index.astro
@@ -6,16 +6,16 @@ import { defaultBreadcrumbs } from '../../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { getInstanceLogger } from '../../../../logger.ts';
 import type { Collection } from '../../../../types/Collection.ts';
-import { organismConfig, organismSchema } from '../../../../types/Organism';
+import { allOrganisms, organismConfig } from '../../../../types/Organism';
 import { Page } from '../../../../types/pages';
 import { getErrorLogMessage } from '../../../../util/getErrorLogMessage.ts';
 
 const logger = getInstanceLogger('CollectionDetailPage');
 
-const { organism, id } = Astro.params;
+const { pathFragment, id } = Astro.params;
 
-const parsedOrganism = organismSchema.safeParse(organism);
-if (!parsedOrganism.success) {
+const organism = allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+if (organism === undefined) {
     return Astro.redirect('/404');
 }
 
@@ -23,8 +23,8 @@ if (id === undefined) {
     return Astro.redirect('/404');
 }
 
-const orgConfig = organismConfig[parsedOrganism.data];
-const lapisConfig = getOrganismConfig(parsedOrganism.data).lapis;
+const orgConfig = organismConfig[organism];
+const lapisConfig = getOrganismConfig(organism).lapis;
 
 let collection: Collection | undefined;
 
@@ -43,7 +43,7 @@ if (collection === undefined) {
 
 // It's possible a collection with the ID exists, but the organism in the path is different.
 // In that case, we want to treat this as 'not found'.
-if (collection.organism !== parsedOrganism.data) {
+if (collection.organism !== organism) {
     return Astro.redirect('/404');
 }
 
@@ -67,14 +67,14 @@ const userIsOwner = userIsLoggedIn && currentUserId === collection.ownedBy;
     breadcrumbs={[
         ...defaultBreadcrumbs,
         { name: 'Collections', href: Page.collectionsOverview },
-        { name: orgConfig.label, href: Page.collectionsForOrganism(parsedOrganism.data) },
-        { name: collectionTitle, href: Page.viewCollection(parsedOrganism.data, id) },
+        { name: orgConfig.label, href: Page.collectionsForOrganism(organism) },
+        { name: collectionTitle, href: Page.viewCollection(organism, id) },
     ]}
 >
     {
         collection !== undefined ? (
             <CollectionDetail
-                organism={parsedOrganism.data}
+                organism={organism}
                 collection={collection}
                 lapisConfig={lapisConfig}
                 isOwner={userIsOwner}

--- a/website/src/pages/collections/[pathFragment]/create.astro
+++ b/website/src/pages/collections/[pathFragment]/create.astro
@@ -4,17 +4,17 @@ import { CollectionCreate } from '../../../components/collections/create/Collect
 import { getDashboardsConfig } from '../../../config';
 import { defaultBreadcrumbs } from '../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
-import { organismConfig, organismSchema } from '../../../types/Organism';
+import { allOrganisms, organismConfig } from '../../../types/Organism';
 import { Page } from '../../../types/pages';
 
-const { organism } = Astro.params;
+const { pathFragment } = Astro.params;
 
-const parsedOrganism = organismSchema.safeParse(organism);
-if (!parsedOrganism.success) {
+const organism = allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+if (organism === undefined) {
     return Astro.redirect('/404');
 }
 
-const orgConfig = organismConfig[parsedOrganism.data];
+const orgConfig = organismConfig[organism];
 const config = getDashboardsConfig();
 ---
 
@@ -23,13 +23,13 @@ const config = getDashboardsConfig();
     breadcrumbs={[
         ...defaultBreadcrumbs,
         { name: 'Collections', href: Page.collectionsOverview },
-        { name: orgConfig.label, href: Page.collectionsForOrganism(parsedOrganism.data) },
-        { name: 'New collection', href: Page.createCollection(parsedOrganism.data) },
+        { name: orgConfig.label, href: Page.collectionsForOrganism(organism) },
+        { name: 'New collection', href: Page.createCollection(organism) },
     ]}
 >
     {
         Astro.locals.user !== undefined ? (
-            <CollectionCreate client:only='react' organism={parsedOrganism.data} config={config} />
+            <CollectionCreate client:only='react' organism={organism} config={config} />
         ) : (
             <NotLoggedIn />
         )

--- a/website/src/pages/collections/[pathFragment]/create.astro
+++ b/website/src/pages/collections/[pathFragment]/create.astro
@@ -4,12 +4,12 @@ import { CollectionCreate } from '../../../components/collections/create/Collect
 import { getDashboardsConfig } from '../../../config';
 import { defaultBreadcrumbs } from '../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
-import { allOrganisms, organismConfig } from '../../../types/Organism';
+import { organismConfig, organismFromPathFragment } from '../../../types/Organism';
 import { Page } from '../../../types/pages';
 
 const { pathFragment } = Astro.params;
 
-const organism = allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+const organism = organismFromPathFragment(pathFragment);
 if (organism === undefined) {
     return Astro.redirect('/404');
 }

--- a/website/src/pages/collections/[pathFragment]/index.astro
+++ b/website/src/pages/collections/[pathFragment]/index.astro
@@ -2,17 +2,17 @@
 import { CollectionsOverview } from '../../../components/collections/overview/CollectionsOverview';
 import { defaultBreadcrumbs } from '../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
-import { organismConfig, organismSchema } from '../../../types/Organism';
+import { allOrganisms, organismConfig } from '../../../types/Organism';
 import { Page } from '../../../types/pages';
 
-const { organism } = Astro.params;
+const { pathFragment } = Astro.params;
 
-const parsedOrganism = organismSchema.safeParse(organism);
-if (!parsedOrganism.success) {
+const organism = allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+if (organism === undefined) {
     return Astro.redirect('/404');
 }
 
-const orgConfig = organismConfig[parsedOrganism.data];
+const orgConfig = organismConfig[organism];
 const isLoggedIn = Astro.locals.user !== undefined;
 ---
 
@@ -21,8 +21,8 @@ const isLoggedIn = Astro.locals.user !== undefined;
     breadcrumbs={[
         ...defaultBreadcrumbs,
         { name: 'Collections', href: Page.collectionsOverview },
-        { name: orgConfig.label, href: Page.collectionsForOrganism(parsedOrganism.data) },
+        { name: orgConfig.label, href: Page.collectionsForOrganism(organism) },
     ]}
 >
-    <CollectionsOverview client:load organism={parsedOrganism.data} isLoggedIn={isLoggedIn} />
+    <CollectionsOverview client:load organism={organism} isLoggedIn={isLoggedIn} />
 </ContaineredPageLayout>

--- a/website/src/pages/collections/[pathFragment]/index.astro
+++ b/website/src/pages/collections/[pathFragment]/index.astro
@@ -2,12 +2,12 @@
 import { CollectionsOverview } from '../../../components/collections/overview/CollectionsOverview';
 import { defaultBreadcrumbs } from '../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
-import { allOrganisms, organismConfig } from '../../../types/Organism';
+import { organismConfig, organismFromPathFragment } from '../../../types/Organism';
 import { Page } from '../../../types/pages';
 
 const { pathFragment } = Astro.params;
 
-const organism = allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+const organism = organismFromPathFragment(pathFragment);
 if (organism === undefined) {
     return Astro.redirect('/404');
 }

--- a/website/src/types/Organism.ts
+++ b/website/src/types/Organism.ts
@@ -525,7 +525,7 @@ export const paths = {
 
 export const allOrganisms = Object.keys(organismConfig) as Organism[];
 
-export function organismFromPathFragment(pathFragment: string): Organism | undefined {
+export function organismFromPathFragment(pathFragment: string | undefined): Organism | undefined {
     return allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
 }
 

--- a/website/src/types/Organism.ts
+++ b/website/src/types/Organism.ts
@@ -525,6 +525,10 @@ export const paths = {
 
 export const allOrganisms = Object.keys(organismConfig) as Organism[];
 
+export function organismFromPathFragment(pathFragment: string): Organism | undefined {
+    return allOrganisms.find((o) => organismConfig[o].pathFragment === pathFragment);
+}
+
 export type Organism = keyof typeof organismConfig;
 export const organismSchema = z.enum(Object.keys(organismConfig) as [keyof typeof organismConfig]);
 

--- a/website/src/types/pages.ts
+++ b/website/src/types/pages.ts
@@ -1,5 +1,5 @@
 import type { Variant } from './Collection.ts';
-import { paths, type Organism } from './Organism.ts';
+import { organismConfig, paths, type Organism } from './Organism.ts';
 import { advancedQueryUrlParamForVariant } from '../components/genspectrum/advancedQueryUrlParamConstants.ts';
 
 export const Page = {
@@ -8,10 +8,11 @@ export const Page = {
     subscriptionsOverview: '/subscriptions',
     dataSources: '/data',
     collectionsOverview: '/collections',
-    collectionsForOrganism: (organism: Organism) => `/collections/${organism}`,
-    viewCollection: (organism: Organism, id: string) => `/collections/${organism}/${id}`,
-    editCollection: (organism: Organism, id: string) => `/collections/${organism}/${id}/edit`,
-    createCollection: (organism: Organism) => `/collections/${organism}/create`,
+    collectionsForOrganism: (organism: Organism) => `/collections/${organismConfig[organism].pathFragment}`,
+    viewCollection: (organism: Organism, id: string) => `/collections/${organismConfig[organism].pathFragment}/${id}`,
+    editCollection: (organism: Organism, id: string) =>
+        `/collections/${organismConfig[organism].pathFragment}/${id}/edit`,
+    createCollection: (organism: Organism) => `/collections/${organismConfig[organism].pathFragment}/create`,
     singleVariantView: (organism: Organism, variant: Variant) => {
         const basePath = paths[organism].basePath;
         const search = new URLSearchParams();


### PR DESCRIPTION
Closes #1258

## Summary

- Renames the Astro route directory `collections/[organism]` → `collections/[pathFragment]` so the URL segment is the kebab-case path fragment (e.g. `west-nile`, `rsv-a`) consistent with the rest of the site
- Updates the four URL builders in `pages.ts` to use `organismConfig[organism].pathFragment` instead of the raw enum key
- Updates all four collection Astro pages to resolve `pathFragment` → `Organism` via `allOrganisms.find()`

## Test plan

- [x] Visit `/collections/west-nile`, `/collections/rsv-a`, `/collections/rsv-b`, `/collections/ebola-sudan`, `/collections/ebola-zaire`, `/collections/influenza-a`, `/collections/influenza-b` and verify they load correctly
- [x] Verify the old URLs (e.g. `/collections/westNile`) now 404
- [x] Verify collection detail, edit, and create pages work for the affected organisms
- [x] Verify organisms where enum key = pathFragment (e.g. `covid`, `mpox`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)