### PR TITLE
feat(collection-seeder): add RSV-A/B Nextclade lineages from nextclade_data tree.json

### DIFF
--- a/collection-seeding/sources/registry.py
+++ b/collection-seeding/sources/registry.py
@@ -7,12 +7,15 @@ place that needs to change — seed.py discovers sources exclusively through thi
 from sources.covid_pango_lineages import CovidPangoLineagesSource, CovidPangoLineagesSampleSource
 from sources.covid_resistance_mutations import CovidResistanceMutationsSource
 from sources.rsv_resistance_mutations import RsvAResistanceMutationsSource, RsvBResistanceMutationsSource
+from sources.rsv_nextclade_lineages import RsvANextcladeLineagesSource, RsvBNextcladeLineagesSource
 from sources import Source
 
 ALL_SOURCES: list[type[Source]] = [
     CovidResistanceMutationsSource,
     RsvAResistanceMutationsSource,
     RsvBResistanceMutationsSource,
+    RsvANextcladeLineagesSource,
+    RsvBNextcladeLineagesSource,
     CovidPangoLineagesSource,
     CovidPangoLineagesSampleSource,
 ]

--- a/collection-seeding/sources/rsv_nextclade_lineages.py
+++ b/collection-seeding/sources/rsv_nextclade_lineages.py
@@ -16,45 +16,215 @@ RSV_B_TREE_URL = (
 )
 
 
-def _extract_clades(node, parent_clade=None):
-    """Walk the Nextclade reference tree, yielding (clade, parent_clade, nuc_muts, aa_muts) for each introduced clade.
+def _apply_nuc_mutations(
+    branch_muts: list[str],
+    accum: dict[str, tuple[str, str]],
+) -> dict[str, tuple[str, str]]:
+    """Apply a list of branch-level nucleotide mutations on top of an accumulated mutation dict.
+
+    Each mutation string has the form REF_BASE + POSITION + NEW_BASE, e.g. "C982T", where:
+      - REF_BASE  is the base in the *parent* node at this position.
+      - POSITION  is the 1-based coordinate in the genome.
+      - NEW_BASE  is the base introduced by this branch.
+
+    The accumulated dict maps POSITION (str) → (ORIG_REF_BASE, CURRENT_BASE), where:
+      - ORIG_REF_BASE  is the base in the root reference genome (not the parent).
+      - CURRENT_BASE   is the base after all mutations from root to here.
+
+    Three cases when applying a branch mutation at a position:
+
+      1. Position not yet in accum (first time this position is mutated on this path):
+         The parent base IS the reference base, so we record (ref_base_from_mut, new_base).
+
+      2. Position already in accum (mutated earlier on the path from root):
+         The parent base is no longer the reference base. We keep the original reference
+         base from the existing entry and update only the current base.
+
+      3. New base equals original reference base (reversion to reference):
+         Net effect from root is zero — remove the position from the dict entirely.
+
+    Returns a new dict; the input is not modified (so sibling branches are unaffected).
+    """
+    result = dict(accum)
+    for mut in branch_muts:
+        ref_base = mut[0]        # base in the parent (= reference if first mutation here)
+        pos = mut[1:-1]          # genome position as string, e.g. "982"
+        new_base = mut[-1]       # base introduced by this branch
+        existing = result.get(pos)
+        # If this position was already mutated earlier on the path, keep the original
+        # reference base; otherwise the parent base is the reference base.
+        orig_ref = existing[0] if existing else ref_base
+        if new_base == orig_ref:
+            # Reverted back to the reference state — remove from accumulated set.
+            result.pop(pos, None)
+        else:
+            result[pos] = (orig_ref, new_base)
+    return result
+
+
+def _apply_aa_mutations(
+    branch_muts_by_gene: dict[str, list[str]],
+    accum: dict[tuple[str, str], tuple[str, str]],
+) -> dict[tuple[str, str], tuple[str, str]]:
+    """Apply branch-level amino acid mutations on top of an accumulated AA mutation dict.
+
+    branch_muts_by_gene maps gene name → list of mutation strings, e.g.
+    {"F": ["T8A", "L20F"], "G": ["T4N"]}.
+
+    Each mutation string has the form REF_AA + POSITION + NEW_AA, e.g. "T8A", where:
+      - REF_AA   is the amino acid in the *parent* node at this codon.
+      - POSITION is the 1-based codon position within the gene.
+      - NEW_AA   is the amino acid introduced by this branch.
+
+    The accumulated dict maps (GENE, POSITION) → (ORIG_REF_AA, CURRENT_AA), where:
+      - ORIG_REF_AA  is the amino acid in the root reference genome.
+      - CURRENT_AA   is the amino acid after all mutations from root to here.
+
+    The same three accumulation cases apply as for nucleotide mutations.
+
+    Returns a new dict; the input is not modified.
+    """
+    result = dict(accum)
+    for gene, muts in branch_muts_by_gene.items():
+        for mut in muts:
+            ref_aa = mut[0]      # amino acid in the parent
+            pos = mut[1:-1]      # codon position within the gene
+            new_aa = mut[-1]     # amino acid introduced by this branch
+            key = (gene, pos)
+            existing = result.get(key)
+            orig_ref = existing[0] if existing else ref_aa
+            if new_aa == orig_ref:
+                result.pop(key, None)
+            else:
+                result[key] = (orig_ref, new_aa)
+    return result
+
+
+def _format_accum_nuc(accum: dict[str, tuple[str, str]]) -> list[str]:
+    """Render accumulated nucleotide mutations as ORIG_REF_BASE + POSITION + CURRENT_BASE strings.
+
+    E.g. {"982": ("A", "T")} → ["A982T"], meaning: at genome position 982 the reference
+    has A and this clade (from root) has T.
+    """
+    return [f"{ref}{pos}{cur}" for pos, (ref, cur) in accum.items()]
+
+
+def _format_accum_aa(accum: dict[tuple[str, str], tuple[str, str]]) -> list[str]:
+    """Render accumulated AA mutations as GENE:ORIG_REF_AA + POSITION + CURRENT_AA strings.
+
+    E.g. {("F", "8"): ("T", "G")} → ["F:T8G"], meaning: in gene F at codon 8 the reference
+    has T and this clade (from root) has G.
+    """
+    return [f"{gene}:{ref}{pos}{cur}" for (gene, pos), (ref, cur) in accum.items()]
+
+
+def _extract_clades(node, parent_clade=None, accum_nuc=None, accum_aa=None):
+    """Walk the Nextclade reference tree recursively, yielding one tuple per introduced clade.
+
+    Each yield is a 6-tuple:
+        (clade_name, parent_clade, branch_nuc, branch_aa, full_nuc, full_aa)
+
+      - clade_name:   the clade label from branch_attrs.labels.clade, e.g. "A.D.3.5"
+      - parent_clade: node_attrs.clade_membership of the parent node (None for the root clade)
+      - branch_nuc:   nucleotide mutations on this branch only (relative to parent node),
+                      e.g. ["C982T", "G108A"]
+      - branch_aa:    AA mutations on this branch only, formatted as GENE:MUT,
+                      e.g. ["F:T8A", "G:T4N"]
+      - full_nuc:     all nucleotide mutations from the reference root down to and including
+                      this clade's branch, expressed relative to the root reference sequence,
+                      e.g. ["A982T", "G108A", "C241T"]
+      - full_aa:      all AA mutations from root to this clade, expressed relative to root,
+                      e.g. ["F:T8G", "G:T4N"]
 
     A clade is introduced at any node where branch_attrs.labels.clade is set.
-    Parent clade comes from the parent node's node_attrs.clade_membership.
+
+    The root reference sequence (e.g. EPI_ISL_412866 for RSV-A) defines position zero
+    for all accumulated mutations — i.e. full_nuc and full_aa give the complete set of
+    substitutions needed to go from the reference to this clade.
+
+    accum_nuc / accum_aa carry the accumulated state downward. Because _apply_*_mutations
+    always returns a new dict rather than mutating in place, each recursive call receives
+    its own independent copy of the state — sibling subtrees cannot interfere with each other.
     """
+    if accum_nuc is None:
+        accum_nuc = {}
+    if accum_aa is None:
+        accum_aa = {}
+
     labels = node.get("branch_attrs", {}).get("labels", {})
     muts = node.get("branch_attrs", {}).get("mutations", {})
     node_clade = node.get("node_attrs", {}).get("clade_membership", {}).get("value")
 
+    # Separate nucleotide mutations (key "nuc") from amino acid mutations (all other keys
+    # are gene names such as "F", "G", "L", etc.).
+    branch_nuc = muts.get("nuc", [])
+    branch_aa_by_gene = {k: v for k, v in muts.items() if k != "nuc"}
+
+    # Fold this branch's mutations into the running accumulated state.
+    # The returned dicts are new objects — the parent's dicts are untouched.
+    accum_nuc = _apply_nuc_mutations(branch_nuc, accum_nuc)
+    accum_aa = _apply_aa_mutations(branch_aa_by_gene, accum_aa)
+
     if "clade" in labels:
-        nuc_muts = muts.get("nuc", [])
-        aa_muts = [
+        # Flatten branch-level AA mutations into GENE:MUT strings for the "new" variant.
+        branch_aa_flat = [
             f"{gene}:{m}"
-            for gene, gene_muts in muts.items()
-            if gene != "nuc"
+            for gene, gene_muts in branch_aa_by_gene.items()
             for m in gene_muts
         ]
-        yield labels["clade"], parent_clade, nuc_muts, aa_muts
+        yield (
+            labels["clade"],
+            parent_clade,
+            branch_nuc,
+            branch_aa_flat,
+            _format_accum_nuc(accum_nuc),
+            _format_accum_aa(accum_aa),
+        )
 
+    # Pass the current node's clade_membership as the parent context for children.
+    # If a node has no clade_membership (e.g. the synthetic root), fall back to whatever
+    # was passed in from above.
     next_parent = node_clade or parent_clade
     for child in node.get("children", []):
-        yield from _extract_clades(child, next_parent)
+        yield from _extract_clades(child, next_parent, accum_nuc, accum_aa)
 
 
 def _build_collections(tree_json: dict, organism: str, organism_label: str, owned_tag: str) -> list[Collection]:
+    """Build one Collection per clade in the Nextclade reference tree.
+
+    Each collection gets four variants, mirroring the shape used for COVID Pango lineages:
+
+      - "Nucleotide substitutions"      — full set from reference root (for searching
+                                          sequences that carry all defining substitutions
+                                          of this clade)
+      - "Amino acid substitutions"      — full AA set from reference root
+      - "New nucleotide substitutions"  — branch-only mutations (what is newly introduced
+                                          in this clade step relative to its parent clade)
+      - "New amino acid substitutions"  — branch-only AA mutations
+    """
     collections = []
-    for clade_name, parent_clade, nuc_muts, aa_muts in _extract_clades(tree_json["tree"]):
+    for clade_name, parent_clade, branch_nuc, branch_aa, full_nuc, full_aa in _extract_clades(tree_json["tree"]):
         parent_str = parent_clade or "—"
         variants: list[Variant] = [
             {
                 "type": "filterObject",
                 "name": "Nucleotide substitutions",
-                "filterObject": {"nucleotideMutations": nuc_muts},
+                "filterObject": {"nucleotideMutations": full_nuc},
             },
             {
                 "type": "filterObject",
                 "name": "Amino acid substitutions",
-                "filterObject": {"aminoAcidMutations": aa_muts},
+                "filterObject": {"aminoAcidMutations": full_aa},
+            },
+            {
+                "type": "filterObject",
+                "name": "New nucleotide substitutions",
+                "filterObject": {"nucleotideMutations": branch_nuc},
+            },
+            {
+                "type": "filterObject",
+                "name": "New amino acid substitutions",
+                "filterObject": {"aminoAcidMutations": branch_aa},
             },
         ]
         description = (

--- a/collection-seeding/sources/rsv_nextclade_lineages.py
+++ b/collection-seeding/sources/rsv_nextclade_lineages.py
@@ -1,3 +1,5 @@
+from typing import NamedTuple
+
 import requests
 
 from models import Collection, Variant
@@ -45,6 +47,15 @@ class RsvBNextcladeLineagesSource(_RsvNextcladeLineagesBase):
     _organism_label = "RSV-B"
 
 
+class _CladeInfo(NamedTuple):
+    clade_name: str
+    parent_clade: str | None
+    branch_nuc: list[str]
+    branch_aa: list[str]
+    full_nuc: list[str]
+    full_aa: list[str]
+
+
 def _build_collections(tree_json: dict, organism: str, organism_label: str, owned_tag: str) -> list[Collection]:
     """Build one Collection per clade in the Nextclade reference tree.
 
@@ -59,37 +70,37 @@ def _build_collections(tree_json: dict, organism: str, organism_label: str, owne
       - "New amino acid substitutions"  — branch-only AA mutations
     """
     collections = []
-    for clade_name, parent_clade, branch_nuc, branch_aa, full_nuc, full_aa in _extract_clades(tree_json["tree"]):
-        parent_str = parent_clade or "—"
+    for clade in _extract_clades(tree_json["tree"]):
+        parent_str = clade.parent_clade or "—"
         variants: list[Variant] = [
             {
                 "type": "filterObject",
                 "name": "Nucleotide substitutions",
-                "filterObject": {"nucleotideMutations": full_nuc},
+                "filterObject": {"nucleotideMutations": clade.full_nuc},
             },
             {
                 "type": "filterObject",
                 "name": "Amino acid substitutions",
-                "filterObject": {"aminoAcidMutations": full_aa},
+                "filterObject": {"aminoAcidMutations": clade.full_aa},
             },
             {
                 "type": "filterObject",
                 "name": "New nucleotide substitutions",
-                "filterObject": {"nucleotideMutations": branch_nuc},
+                "filterObject": {"nucleotideMutations": clade.branch_nuc},
             },
             {
                 "type": "filterObject",
                 "name": "New amino acid substitutions",
-                "filterObject": {"aminoAcidMutations": branch_aa},
+                "filterObject": {"aminoAcidMutations": clade.branch_aa},
             },
         ]
         description = (
-            f"{organism_label} Nextclade clade {clade_name}. "
+            f"{organism_label} Nextclade clade {clade.clade_name}. "
             f"Parent clade: {parent_str}. "
             f"{owned_tag}"
         )
         collections.append({
-            "name": clade_name,
+            "name": clade.clade_name,
             "organism": organism,
             "description": description,
             "variants": variants,
@@ -98,11 +109,9 @@ def _build_collections(tree_json: dict, organism: str, organism_label: str, owne
 
 
 def _extract_clades(node, parent_clade=None, accum_nuc=None, accum_aa=None):
-    """Walk the Nextclade reference tree recursively, yielding one tuple per introduced clade.
+    """Walk the Nextclade reference tree recursively, yielding one _CladeInfo per introduced clade.
 
-    Each yield is a 6-tuple:
-        (clade_name, parent_clade, branch_nuc, branch_aa, full_nuc, full_aa)
-
+    Fields:
       - clade_name:   the clade label from branch_attrs.labels.clade, e.g. "A.D.3.5"
       - parent_clade: node_attrs.clade_membership of the parent node (None for the root clade)
       - branch_nuc:   nucleotide mutations on this branch only (relative to parent node),
@@ -151,13 +160,13 @@ def _extract_clades(node, parent_clade=None, accum_nuc=None, accum_aa=None):
             for gene, gene_muts in branch_aa_by_gene.items()
             for m in gene_muts
         ]
-        yield (
-            labels["clade"],
-            parent_clade,
-            branch_nuc,
-            branch_aa_flat,
-            _format_accum_nuc(accum_nuc),
-            _format_accum_aa(accum_aa),
+        yield _CladeInfo(
+            clade_name=labels["clade"],
+            parent_clade=parent_clade,
+            branch_nuc=branch_nuc,
+            branch_aa=branch_aa_flat,
+            full_nuc=_format_accum_nuc(accum_nuc),
+            full_aa=_format_accum_aa(accum_aa),
         )
 
     # Pass the current node's clade_membership as the parent context for children.

--- a/collection-seeding/sources/rsv_nextclade_lineages.py
+++ b/collection-seeding/sources/rsv_nextclade_lineages.py
@@ -1,0 +1,100 @@
+import requests
+
+from models import Collection, Variant
+from sources import Source
+
+RSV_A_TREE_URL = (
+    "https://raw.githubusercontent.com/nextstrain/nextclade_data"
+    "/refs/heads/master/data_output/nextstrain/rsv/a"
+    "/EPI_ISL_412866/2026-04-14--11-55-23Z/tree.json"
+)
+
+RSV_B_TREE_URL = (
+    "https://raw.githubusercontent.com/nextstrain/nextclade_data"
+    "/refs/heads/master/data_output/nextstrain/rsv/b"
+    "/EPI_ISL_1653999/2026-04-14--11-55-23Z/tree.json"
+)
+
+
+def _extract_clades(node, parent_clade=None):
+    """Walk the Nextclade reference tree, yielding (clade, parent_clade, nuc_muts, aa_muts) for each introduced clade.
+
+    A clade is introduced at any node where branch_attrs.labels.clade is set.
+    Parent clade comes from the parent node's node_attrs.clade_membership.
+    """
+    labels = node.get("branch_attrs", {}).get("labels", {})
+    muts = node.get("branch_attrs", {}).get("mutations", {})
+    node_clade = node.get("node_attrs", {}).get("clade_membership", {}).get("value")
+
+    if "clade" in labels:
+        nuc_muts = muts.get("nuc", [])
+        aa_muts = [
+            f"{gene}:{m}"
+            for gene, gene_muts in muts.items()
+            if gene != "nuc"
+            for m in gene_muts
+        ]
+        yield labels["clade"], parent_clade, nuc_muts, aa_muts
+
+    next_parent = node_clade or parent_clade
+    for child in node.get("children", []):
+        yield from _extract_clades(child, next_parent)
+
+
+def _build_collections(tree_json: dict, organism: str, organism_label: str, owned_tag: str) -> list[Collection]:
+    collections = []
+    for clade_name, parent_clade, nuc_muts, aa_muts in _extract_clades(tree_json["tree"]):
+        parent_str = parent_clade or "—"
+        variants: list[Variant] = [
+            {
+                "type": "filterObject",
+                "name": "Nucleotide substitutions",
+                "filterObject": {"nucleotideMutations": nuc_muts},
+            },
+            {
+                "type": "filterObject",
+                "name": "Amino acid substitutions",
+                "filterObject": {"aminoAcidMutations": aa_muts},
+            },
+        ]
+        description = (
+            f"{organism_label} Nextclade clade {clade_name}. "
+            f"Parent clade: {parent_str}. "
+            f"{owned_tag}"
+        )
+        collections.append({
+            "name": clade_name,
+            "organism": organism,
+            "description": description,
+            "variants": variants,
+        })
+    return collections
+
+
+class _RsvNextcladeLineagesBase(Source):
+    owned_tag = "#nextclade-lineage"
+    _tree_url: str
+    _organism_label: str
+
+    def get_collections(self) -> list[Collection]:
+        print(f"Fetching Nextclade tree from {self._tree_url} ...")
+        response = requests.get(self._tree_url, timeout=60)
+        response.raise_for_status()
+        tree_json = response.json()
+        collections = _build_collections(tree_json, self.organism, self._organism_label, self.owned_tag)
+        print(f"  Loaded {len(collections)} clade(s).")
+        return collections
+
+
+class RsvANextcladeLineagesSource(_RsvNextcladeLineagesBase):
+    name = "rsv-a-nextclade-lineages"
+    organism = "rsvA"
+    _tree_url = RSV_A_TREE_URL
+    _organism_label = "RSV-A"
+
+
+class RsvBNextcladeLineagesSource(_RsvNextcladeLineagesBase):
+    name = "rsv-b-nextclade-lineages"
+    organism = "rsvB"
+    _tree_url = RSV_B_TREE_URL
+    _organism_label = "RSV-B"

--- a/collection-seeding/sources/rsv_nextclade_lineages.py
+++ b/collection-seeding/sources/rsv_nextclade_lineages.py
@@ -16,6 +16,158 @@ RSV_B_TREE_URL = (
 )
 
 
+class _RsvNextcladeLineagesBase(Source):
+    owned_tag = "#nextclade-lineage"
+    _tree_url: str
+    _organism_label: str
+
+    def get_collections(self) -> list[Collection]:
+        print(f"Fetching Nextclade tree from {self._tree_url} ...")
+        response = requests.get(self._tree_url, timeout=60)
+        response.raise_for_status()
+        tree_json = response.json()
+        collections = _build_collections(tree_json, self.organism, self._organism_label, self.owned_tag)
+        print(f"  Loaded {len(collections)} clade(s).")
+        return collections
+
+
+class RsvANextcladeLineagesSource(_RsvNextcladeLineagesBase):
+    name = "rsv-a-nextclade-lineages"
+    organism = "rsvA"
+    _tree_url = RSV_A_TREE_URL
+    _organism_label = "RSV-A"
+
+
+class RsvBNextcladeLineagesSource(_RsvNextcladeLineagesBase):
+    name = "rsv-b-nextclade-lineages"
+    organism = "rsvB"
+    _tree_url = RSV_B_TREE_URL
+    _organism_label = "RSV-B"
+
+
+def _build_collections(tree_json: dict, organism: str, organism_label: str, owned_tag: str) -> list[Collection]:
+    """Build one Collection per clade in the Nextclade reference tree.
+
+    Each collection gets four variants, mirroring the shape used for COVID Pango lineages:
+
+      - "Nucleotide substitutions"      — full set from reference root (for searching
+                                          sequences that carry all defining substitutions
+                                          of this clade)
+      - "Amino acid substitutions"      — full AA set from reference root
+      - "New nucleotide substitutions"  — branch-only mutations (what is newly introduced
+                                          in this clade step relative to its parent clade)
+      - "New amino acid substitutions"  — branch-only AA mutations
+    """
+    collections = []
+    for clade_name, parent_clade, branch_nuc, branch_aa, full_nuc, full_aa in _extract_clades(tree_json["tree"]):
+        parent_str = parent_clade or "—"
+        variants: list[Variant] = [
+            {
+                "type": "filterObject",
+                "name": "Nucleotide substitutions",
+                "filterObject": {"nucleotideMutations": full_nuc},
+            },
+            {
+                "type": "filterObject",
+                "name": "Amino acid substitutions",
+                "filterObject": {"aminoAcidMutations": full_aa},
+            },
+            {
+                "type": "filterObject",
+                "name": "New nucleotide substitutions",
+                "filterObject": {"nucleotideMutations": branch_nuc},
+            },
+            {
+                "type": "filterObject",
+                "name": "New amino acid substitutions",
+                "filterObject": {"aminoAcidMutations": branch_aa},
+            },
+        ]
+        description = (
+            f"{organism_label} Nextclade clade {clade_name}. "
+            f"Parent clade: {parent_str}. "
+            f"{owned_tag}"
+        )
+        collections.append({
+            "name": clade_name,
+            "organism": organism,
+            "description": description,
+            "variants": variants,
+        })
+    return collections
+
+
+def _extract_clades(node, parent_clade=None, accum_nuc=None, accum_aa=None):
+    """Walk the Nextclade reference tree recursively, yielding one tuple per introduced clade.
+
+    Each yield is a 6-tuple:
+        (clade_name, parent_clade, branch_nuc, branch_aa, full_nuc, full_aa)
+
+      - clade_name:   the clade label from branch_attrs.labels.clade, e.g. "A.D.3.5"
+      - parent_clade: node_attrs.clade_membership of the parent node (None for the root clade)
+      - branch_nuc:   nucleotide mutations on this branch only (relative to parent node),
+                      e.g. ["C982T", "G108A"]
+      - branch_aa:    AA mutations on this branch only, formatted as GENE:MUT,
+                      e.g. ["F:T8A", "G:T4N"]
+      - full_nuc:     all nucleotide mutations from the reference root down to and including
+                      this clade's branch, expressed relative to the root reference sequence,
+                      e.g. ["A982T", "G108A", "C241T"]
+      - full_aa:      all AA mutations from root to this clade, expressed relative to root,
+                      e.g. ["F:T8G", "G:T4N"]
+
+    A clade is introduced at any node where branch_attrs.labels.clade is set.
+
+    The root reference sequence (e.g. EPI_ISL_412866 for RSV-A) defines position zero
+    for all accumulated mutations — i.e. full_nuc and full_aa give the complete set of
+    substitutions needed to go from the reference to this clade.
+
+    accum_nuc / accum_aa carry the accumulated state downward. Because _apply_*_mutations
+    always returns a new dict rather than mutating in place, each recursive call receives
+    its own independent copy of the state — sibling subtrees cannot interfere with each other.
+    """
+    if accum_nuc is None:
+        accum_nuc = {}
+    if accum_aa is None:
+        accum_aa = {}
+
+    labels = node.get("branch_attrs", {}).get("labels", {})
+    muts = node.get("branch_attrs", {}).get("mutations", {})
+    node_clade = node.get("node_attrs", {}).get("clade_membership", {}).get("value")
+
+    # Separate nucleotide mutations (key "nuc") from amino acid mutations (all other keys
+    # are gene names such as "F", "G", "L", etc.).
+    branch_nuc = muts.get("nuc", [])
+    branch_aa_by_gene = {k: v for k, v in muts.items() if k != "nuc"}
+
+    # Fold this branch's mutations into the running accumulated state.
+    # The returned dicts are new objects — the parent's dicts are untouched.
+    accum_nuc = _apply_nuc_mutations(branch_nuc, accum_nuc)
+    accum_aa = _apply_aa_mutations(branch_aa_by_gene, accum_aa)
+
+    if "clade" in labels:
+        # Flatten branch-level AA mutations into GENE:MUT strings for the "new" variant.
+        branch_aa_flat = [
+            f"{gene}:{m}"
+            for gene, gene_muts in branch_aa_by_gene.items()
+            for m in gene_muts
+        ]
+        yield (
+            labels["clade"],
+            parent_clade,
+            branch_nuc,
+            branch_aa_flat,
+            _format_accum_nuc(accum_nuc),
+            _format_accum_aa(accum_aa),
+        )
+
+    # Pass the current node's clade_membership as the parent context for children.
+    # If a node has no clade_membership (e.g. the synthetic root), fall back to whatever
+    # was passed in from above.
+    next_parent = node_clade or parent_clade
+    for child in node.get("children", []):
+        yield from _extract_clades(child, next_parent, accum_nuc, accum_aa)
+
+
 def _apply_nuc_mutations(
     branch_muts: list[str],
     accum: dict[str, tuple[str, str]],
@@ -116,155 +268,3 @@ def _format_accum_aa(accum: dict[tuple[str, str], tuple[str, str]]) -> list[str]
     has T and this clade (from root) has G.
     """
     return [f"{gene}:{ref}{pos}{cur}" for (gene, pos), (ref, cur) in accum.items()]
-
-
-def _extract_clades(node, parent_clade=None, accum_nuc=None, accum_aa=None):
-    """Walk the Nextclade reference tree recursively, yielding one tuple per introduced clade.
-
-    Each yield is a 6-tuple:
-        (clade_name, parent_clade, branch_nuc, branch_aa, full_nuc, full_aa)
-
-      - clade_name:   the clade label from branch_attrs.labels.clade, e.g. "A.D.3.5"
-      - parent_clade: node_attrs.clade_membership of the parent node (None for the root clade)
-      - branch_nuc:   nucleotide mutations on this branch only (relative to parent node),
-                      e.g. ["C982T", "G108A"]
-      - branch_aa:    AA mutations on this branch only, formatted as GENE:MUT,
-                      e.g. ["F:T8A", "G:T4N"]
-      - full_nuc:     all nucleotide mutations from the reference root down to and including
-                      this clade's branch, expressed relative to the root reference sequence,
-                      e.g. ["A982T", "G108A", "C241T"]
-      - full_aa:      all AA mutations from root to this clade, expressed relative to root,
-                      e.g. ["F:T8G", "G:T4N"]
-
-    A clade is introduced at any node where branch_attrs.labels.clade is set.
-
-    The root reference sequence (e.g. EPI_ISL_412866 for RSV-A) defines position zero
-    for all accumulated mutations — i.e. full_nuc and full_aa give the complete set of
-    substitutions needed to go from the reference to this clade.
-
-    accum_nuc / accum_aa carry the accumulated state downward. Because _apply_*_mutations
-    always returns a new dict rather than mutating in place, each recursive call receives
-    its own independent copy of the state — sibling subtrees cannot interfere with each other.
-    """
-    if accum_nuc is None:
-        accum_nuc = {}
-    if accum_aa is None:
-        accum_aa = {}
-
-    labels = node.get("branch_attrs", {}).get("labels", {})
-    muts = node.get("branch_attrs", {}).get("mutations", {})
-    node_clade = node.get("node_attrs", {}).get("clade_membership", {}).get("value")
-
-    # Separate nucleotide mutations (key "nuc") from amino acid mutations (all other keys
-    # are gene names such as "F", "G", "L", etc.).
-    branch_nuc = muts.get("nuc", [])
-    branch_aa_by_gene = {k: v for k, v in muts.items() if k != "nuc"}
-
-    # Fold this branch's mutations into the running accumulated state.
-    # The returned dicts are new objects — the parent's dicts are untouched.
-    accum_nuc = _apply_nuc_mutations(branch_nuc, accum_nuc)
-    accum_aa = _apply_aa_mutations(branch_aa_by_gene, accum_aa)
-
-    if "clade" in labels:
-        # Flatten branch-level AA mutations into GENE:MUT strings for the "new" variant.
-        branch_aa_flat = [
-            f"{gene}:{m}"
-            for gene, gene_muts in branch_aa_by_gene.items()
-            for m in gene_muts
-        ]
-        yield (
-            labels["clade"],
-            parent_clade,
-            branch_nuc,
-            branch_aa_flat,
-            _format_accum_nuc(accum_nuc),
-            _format_accum_aa(accum_aa),
-        )
-
-    # Pass the current node's clade_membership as the parent context for children.
-    # If a node has no clade_membership (e.g. the synthetic root), fall back to whatever
-    # was passed in from above.
-    next_parent = node_clade or parent_clade
-    for child in node.get("children", []):
-        yield from _extract_clades(child, next_parent, accum_nuc, accum_aa)
-
-
-def _build_collections(tree_json: dict, organism: str, organism_label: str, owned_tag: str) -> list[Collection]:
-    """Build one Collection per clade in the Nextclade reference tree.
-
-    Each collection gets four variants, mirroring the shape used for COVID Pango lineages:
-
-      - "Nucleotide substitutions"      — full set from reference root (for searching
-                                          sequences that carry all defining substitutions
-                                          of this clade)
-      - "Amino acid substitutions"      — full AA set from reference root
-      - "New nucleotide substitutions"  — branch-only mutations (what is newly introduced
-                                          in this clade step relative to its parent clade)
-      - "New amino acid substitutions"  — branch-only AA mutations
-    """
-    collections = []
-    for clade_name, parent_clade, branch_nuc, branch_aa, full_nuc, full_aa in _extract_clades(tree_json["tree"]):
-        parent_str = parent_clade or "—"
-        variants: list[Variant] = [
-            {
-                "type": "filterObject",
-                "name": "Nucleotide substitutions",
-                "filterObject": {"nucleotideMutations": full_nuc},
-            },
-            {
-                "type": "filterObject",
-                "name": "Amino acid substitutions",
-                "filterObject": {"aminoAcidMutations": full_aa},
-            },
-            {
-                "type": "filterObject",
-                "name": "New nucleotide substitutions",
-                "filterObject": {"nucleotideMutations": branch_nuc},
-            },
-            {
-                "type": "filterObject",
-                "name": "New amino acid substitutions",
-                "filterObject": {"aminoAcidMutations": branch_aa},
-            },
-        ]
-        description = (
-            f"{organism_label} Nextclade clade {clade_name}. "
-            f"Parent clade: {parent_str}. "
-            f"{owned_tag}"
-        )
-        collections.append({
-            "name": clade_name,
-            "organism": organism,
-            "description": description,
-            "variants": variants,
-        })
-    return collections
-
-
-class _RsvNextcladeLineagesBase(Source):
-    owned_tag = "#nextclade-lineage"
-    _tree_url: str
-    _organism_label: str
-
-    def get_collections(self) -> list[Collection]:
-        print(f"Fetching Nextclade tree from {self._tree_url} ...")
-        response = requests.get(self._tree_url, timeout=60)
-        response.raise_for_status()
-        tree_json = response.json()
-        collections = _build_collections(tree_json, self.organism, self._organism_label, self.owned_tag)
-        print(f"  Loaded {len(collections)} clade(s).")
-        return collections
-
-
-class RsvANextcladeLineagesSource(_RsvNextcladeLineagesBase):
-    name = "rsv-a-nextclade-lineages"
-    organism = "rsvA"
-    _tree_url = RSV_A_TREE_URL
-    _organism_label = "RSV-A"
-
-
-class RsvBNextcladeLineagesSource(_RsvNextcladeLineagesBase):
-    name = "rsv-b-nextclade-lineages"
-    organism = "rsvB"
-    _tree_url = RSV_B_TREE_URL
-    _organism_label = "RSV-B"

--- a/collection-seeding/tests/test_rsv_nextclade_lineages.py
+++ b/collection-seeding/tests/test_rsv_nextclade_lineages.py
@@ -82,6 +82,14 @@ def test_apply_nuc_second_mutation_keeps_original_ref_base():
     assert result == {"982": ("A", "T")}
 
 
+def test_apply_nuc_two_hops_ref_base_is_always_original():
+    # Position 100: first branch A→C, second branch C→T.
+    # The accumulated entry should be A100T — reference base A, not the intermediate C.
+    after_first = _apply_nuc_mutations(["A100C"], {})
+    after_second = _apply_nuc_mutations(["C100T"], after_first)
+    assert after_second == {"100": ("A", "T")}
+
+
 def test_apply_nuc_reversion_removes_position():
     # Position 982 was mutated A→C; now reverted C→A.
     # Net effect from reference is zero — position should be removed.

--- a/collection-seeding/tests/test_rsv_nextclade_lineages.py
+++ b/collection-seeding/tests/test_rsv_nextclade_lineages.py
@@ -5,11 +5,22 @@ from sources.rsv_nextclade_lineages import (
     RSV_B_TREE_URL,
     RsvANextcladeLineagesSource,
     RsvBNextcladeLineagesSource,
+    _apply_aa_mutations,
+    _apply_nuc_mutations,
     _build_collections,
     _extract_clades,
 )
 
-# Minimal tree: root → A (clade-introducing) → A.1 (clade-introducing leaf)
+# Minimal tree used by most tests:
+#
+#   root (no clade)
+#   └─ NODE_A  introduces clade "A"  — nuc: T59C, G108A  — aa F: T8A, L20F  G: T4N
+#      ├─ NODE_A1  introduces clade "A.1"  — nuc: C241T  — aa F: K124N
+#      └─ leaf_no_clade  (clade_membership=A, no labels.clade — not yielded)
+#
+# Expected accumulated mutations:
+#   A:    full_nuc=["T59C", "G108A"],   full_aa=["F:T8A", "F:L20F", "G:T4N"]
+#   A.1:  full_nuc=["T59C", "G108A", "C241T"],  full_aa=["F:T8A", "F:L20F", "G:T4N", "F:K124N"]
 SAMPLE_TREE = {
     "tree": {
         "name": "root",
@@ -55,6 +66,70 @@ SAMPLE_TREE = {
 }
 
 
+# --- _apply_nuc_mutations ---
+
+
+def test_apply_nuc_first_mutation_records_ref_base():
+    # Position 982 not previously mutated → parent base C is the reference base.
+    result = _apply_nuc_mutations(["C982T"], {})
+    assert result == {"982": ("C", "T")}
+
+
+def test_apply_nuc_second_mutation_keeps_original_ref_base():
+    # Position 982 was previously mutated A→C; now mutated C→T.
+    # The reference base should remain A (not C).
+    result = _apply_nuc_mutations(["C982T"], {"982": ("A", "C")})
+    assert result == {"982": ("A", "T")}
+
+
+def test_apply_nuc_reversion_removes_position():
+    # Position 982 was mutated A→C; now reverted C→A.
+    # Net effect from reference is zero — position should be removed.
+    result = _apply_nuc_mutations(["C982A"], {"982": ("A", "C")})
+    assert "982" not in result
+
+
+def test_apply_nuc_does_not_mutate_input():
+    accum = {"59": ("T", "C")}
+    _apply_nuc_mutations(["G108A"], accum)
+    assert "108" not in accum  # original dict unchanged
+
+
+def test_apply_nuc_multiple_mutations():
+    result = _apply_nuc_mutations(["T59C", "G108A"], {})
+    assert result == {"59": ("T", "C"), "108": ("G", "A")}
+
+
+# --- _apply_aa_mutations ---
+
+
+def test_apply_aa_first_mutation():
+    result = _apply_aa_mutations({"F": ["T8A"]}, {})
+    assert result == {("F", "8"): ("T", "A")}
+
+
+def test_apply_aa_second_mutation_keeps_original_ref():
+    # F codon 8 was previously mutated T→A; now mutated A→G.
+    result = _apply_aa_mutations({"F": ["A8G"]}, {("F", "8"): ("T", "A")})
+    assert result == {("F", "8"): ("T", "G")}
+
+
+def test_apply_aa_reversion_removes_entry():
+    result = _apply_aa_mutations({"F": ["A8T"]}, {("F", "8"): ("T", "A")})
+    assert ("F", "8") not in result
+
+
+def test_apply_aa_does_not_mutate_input():
+    accum = {("F", "8"): ("T", "A")}
+    _apply_aa_mutations({"G": ["T4N"]}, accum)
+    assert ("G", "4") not in accum
+
+
+def test_apply_aa_multiple_genes():
+    result = _apply_aa_mutations({"F": ["T8A"], "G": ["T4N"]}, {})
+    assert result == {("F", "8"): ("T", "A"), ("G", "4"): ("T", "N")}
+
+
 # --- _extract_clades ---
 
 
@@ -67,9 +142,7 @@ def test_extract_clades_finds_both_clades():
 
 def test_extract_clades_skips_non_clade_nodes():
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    names = [c[0] for c in clades]
-    assert "root" not in names
-    assert len(names) == 2
+    assert len(clades) == 2
 
 
 def test_extract_clades_root_clade_has_no_parent():
@@ -80,34 +153,163 @@ def test_extract_clades_root_clade_has_no_parent():
 
 def test_extract_clades_child_clade_parent():
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    child_clade = next(c for c in clades if c[0] == "A.1")
-    assert child_clade[1] == "A"
+    child = next(c for c in clades if c[0] == "A.1")
+    assert child[1] == "A"
 
 
-def test_extract_clades_nuc_mutations():
+def test_extract_clades_branch_nuc_is_this_branch_only():
+    # branch_nuc (index 2) should contain only the mutations on that specific branch.
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    a_clade = next(c for c in clades if c[0] == "A")
-    assert a_clade[2] == ["T59C", "G108A"]
+    a1 = next(c for c in clades if c[0] == "A.1")
+    assert a1[2] == ["C241T"]  # only what's new in A.1, not A's mutations
 
 
-def test_extract_clades_aa_mutations_prefixed_with_gene():
+def test_extract_clades_branch_aa_is_this_branch_only():
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    a_clade = next(c for c in clades if c[0] == "A")
-    assert "F:T8A" in a_clade[3]
-    assert "F:L20F" in a_clade[3]
-    assert "G:T4N" in a_clade[3]
+    a1 = next(c for c in clades if c[0] == "A.1")
+    assert a1[3] == ["F:K124N"]
 
 
-def test_extract_clades_no_nuc_in_aa_mutations():
+def test_extract_clades_full_nuc_accumulates_from_root():
+    # full_nuc (index 4) for A.1 must include A's mutations as well as A.1's own.
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    for _, _, _, aa_muts in clades:
-        assert not any(m.startswith("nuc:") for m in aa_muts)
+    a1 = next(c for c in clades if c[0] == "A.1")
+    assert set(a1[4]) == {"T59C", "G108A", "C241T"}
 
 
-def test_extract_clades_node_without_clade_label_not_yielded():
+def test_extract_clades_full_nuc_root_clade_equals_branch():
+    # For the root clade (A) there is no ancestor, so full == branch.
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    # leaf_no_clade has no labels.clade, so it should not appear
-    assert len(clades) == 2
+    a = next(c for c in clades if c[0] == "A")
+    assert set(a[4]) == {"T59C", "G108A"}
+
+
+def test_extract_clades_full_aa_accumulates_from_root():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    a1 = next(c for c in clades if c[0] == "A.1")
+    assert set(a1[5]) == {"F:T8A", "F:L20F", "G:T4N", "F:K124N"}
+
+
+def test_extract_clades_sibling_subtrees_do_not_share_state():
+    # Add a second child of A that mutates position 59 again (T59C was A's mutation).
+    # This sibling should not see a "reverted" position 59 from the other sibling.
+    tree = {
+        "tree": {
+            "name": "root",
+            "node_attrs": {},
+            "branch_attrs": {},
+            "children": [
+                {
+                    "name": "NODE_A",
+                    "node_attrs": {"clade_membership": {"value": "A"}},
+                    "branch_attrs": {
+                        "labels": {"clade": "A"},
+                        "mutations": {"nuc": ["T59C"]},
+                    },
+                    "children": [
+                        {
+                            "name": "NODE_A1",
+                            "node_attrs": {"clade_membership": {"value": "A.1"}},
+                            "branch_attrs": {
+                                "labels": {"clade": "A.1"},
+                                "mutations": {"nuc": ["C241T"]},
+                            },
+                            "children": [],
+                        },
+                        {
+                            "name": "NODE_A2",
+                            "node_attrs": {"clade_membership": {"value": "A.2"}},
+                            "branch_attrs": {
+                                "labels": {"clade": "A.2"},
+                                "mutations": {"nuc": ["G300T"]},
+                            },
+                            "children": [],
+                        },
+                    ],
+                }
+            ],
+        }
+    }
+    clades = {c[0]: c for c in _extract_clades(tree["tree"])}
+    # A.1 and A.2 should each independently see T59C from A
+    assert "T59C" in clades["A.1"][4]
+    assert "T59C" in clades["A.2"][4]
+    # A.1 should NOT see A.2's mutation and vice versa
+    assert "G300T" not in clades["A.1"][4]
+    assert "C241T" not in clades["A.2"][4]
+
+
+def test_extract_clades_multi_hop_accumulation():
+    # Position 100: A→C in clade A, then C→G in clade A.1.
+    # full_nuc for A.1 should report it as A100G (from reference A to final G).
+    tree = {
+        "tree": {
+            "name": "root",
+            "node_attrs": {},
+            "branch_attrs": {},
+            "children": [
+                {
+                    "name": "NODE_A",
+                    "node_attrs": {"clade_membership": {"value": "A"}},
+                    "branch_attrs": {
+                        "labels": {"clade": "A"},
+                        "mutations": {"nuc": ["A100C"]},
+                    },
+                    "children": [
+                        {
+                            "name": "NODE_A1",
+                            "node_attrs": {"clade_membership": {"value": "A.1"}},
+                            "branch_attrs": {
+                                "labels": {"clade": "A.1"},
+                                "mutations": {"nuc": ["C100G"]},
+                            },
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+    clades = {c[0]: c for c in _extract_clades(tree["tree"])}
+    assert "A100C" in clades["A"][4]
+    assert "A100G" in clades["A.1"][4]   # reference A, final G
+    assert "A100C" not in clades["A.1"][4]  # A's intermediate step not present
+
+
+def test_extract_clades_reversion_removed_from_full():
+    # Position 100: A→C in clade A, then C→A (reversion) in clade A.1.
+    # A.1's full_nuc should NOT contain position 100 (net effect is zero).
+    tree = {
+        "tree": {
+            "name": "root",
+            "node_attrs": {},
+            "branch_attrs": {},
+            "children": [
+                {
+                    "name": "NODE_A",
+                    "node_attrs": {"clade_membership": {"value": "A"}},
+                    "branch_attrs": {
+                        "labels": {"clade": "A"},
+                        "mutations": {"nuc": ["A100C"]},
+                    },
+                    "children": [
+                        {
+                            "name": "NODE_A1",
+                            "node_attrs": {"clade_membership": {"value": "A.1"}},
+                            "branch_attrs": {
+                                "labels": {"clade": "A.1"},
+                                "mutations": {"nuc": ["C100A"]},
+                            },
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+    clades = {c[0]: c for c in _extract_clades(tree["tree"])}
+    full_nuc_a1 = clades["A.1"][4]
+    assert not any("100" in m for m in full_nuc_a1)
 
 
 # --- _build_collections ---
@@ -125,21 +327,20 @@ def test_build_collections_organism():
 
 def test_build_collections_name_is_clade():
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
-    names = {c["name"] for c in cols}
-    assert names == {"A", "A.1"}
+    assert {c["name"] for c in cols} == {"A", "A.1"}
 
 
 def test_build_collections_description_contains_clade_and_parent():
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
-    a1_col = next(c for c in cols if c["name"] == "A.1")
-    assert "A.1" in a1_col["description"]
-    assert "A" in a1_col["description"]  # parent
+    a1 = next(c for c in cols if c["name"] == "A.1")
+    assert "A.1" in a1["description"]
+    assert "A" in a1["description"]
 
 
 def test_build_collections_description_root_clade_parent_dash():
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
-    a_col = next(c for c in cols if c["name"] == "A")
-    assert "—" in a_col["description"]
+    a = next(c for c in cols if c["name"] == "A")
+    assert "—" in a["description"]
 
 
 def test_build_collections_description_contains_organism_label():
@@ -152,33 +353,52 @@ def test_build_collections_description_contains_owned_tag():
     assert all("#nextclade-lineage" in c["description"] for c in cols)
 
 
-def test_build_collections_two_variants_per_collection():
+def test_build_collections_four_variants_per_collection():
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
-    assert all(len(c["variants"]) == 2 for c in cols)
+    assert all(len(c["variants"]) == 4 for c in cols)
 
 
 def test_build_collections_variant_names():
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
     for col in cols:
         names = [v["name"] for v in col["variants"]]
-        assert names == ["Nucleotide substitutions", "Amino acid substitutions"]
+        assert names == [
+            "Nucleotide substitutions",
+            "Amino acid substitutions",
+            "New nucleotide substitutions",
+            "New amino acid substitutions",
+        ]
 
 
-def test_build_collections_nuc_variant_contents():
+def test_build_collections_full_nuc_variant_contents():
+    # "Nucleotide substitutions" = full set from reference root.
+    # For A.1 this includes A's mutations plus A.1's own.
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
-    a_col = next(c for c in cols if c["name"] == "A")
-    nuc_variant = next(v for v in a_col["variants"] if v["name"] == "Nucleotide substitutions")
-    assert nuc_variant["filterObject"]["nucleotideMutations"] == ["T59C", "G108A"]
+    a1 = next(c for c in cols if c["name"] == "A.1")
+    full_nuc = next(v for v in a1["variants"] if v["name"] == "Nucleotide substitutions")
+    assert set(full_nuc["filterObject"]["nucleotideMutations"]) == {"T59C", "G108A", "C241T"}
 
 
-def test_build_collections_aa_variant_contents():
+def test_build_collections_new_nuc_variant_contents():
+    # "New nucleotide substitutions" = branch-only, just what A.1 introduces.
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
-    a_col = next(c for c in cols if c["name"] == "A")
-    aa_variant = next(v for v in a_col["variants"] if v["name"] == "Amino acid substitutions")
-    aa = aa_variant["filterObject"]["aminoAcidMutations"]
-    assert "F:T8A" in aa
-    assert "F:L20F" in aa
-    assert "G:T4N" in aa
+    a1 = next(c for c in cols if c["name"] == "A.1")
+    new_nuc = next(v for v in a1["variants"] if v["name"] == "New nucleotide substitutions")
+    assert new_nuc["filterObject"]["nucleotideMutations"] == ["C241T"]
+
+
+def test_build_collections_full_aa_variant_contents():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    a1 = next(c for c in cols if c["name"] == "A.1")
+    full_aa = next(v for v in a1["variants"] if v["name"] == "Amino acid substitutions")
+    assert set(full_aa["filterObject"]["aminoAcidMutations"]) == {"F:T8A", "F:L20F", "G:T4N", "F:K124N"}
+
+
+def test_build_collections_new_aa_variant_contents():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    a1 = next(c for c in cols if c["name"] == "A.1")
+    new_aa = next(v for v in a1["variants"] if v["name"] == "New amino acid substitutions")
+    assert new_aa["filterObject"]["aminoAcidMutations"] == ["F:K124N"]
 
 
 # --- source class attributes ---
@@ -215,7 +435,6 @@ def test_rsv_b_owned_tag():
 def test_rsv_a_fetches_correct_url():
     rsps_lib.add(rsps_lib.GET, RSV_A_TREE_URL, json=SAMPLE_TREE, status=200)
     RsvANextcladeLineagesSource().get_collections()
-    assert len(rsps_lib.calls) == 1
     assert rsps_lib.calls[0].request.url == RSV_A_TREE_URL
 
 
@@ -223,7 +442,6 @@ def test_rsv_a_fetches_correct_url():
 def test_rsv_b_fetches_correct_url():
     rsps_lib.add(rsps_lib.GET, RSV_B_TREE_URL, json=SAMPLE_TREE, status=200)
     RsvBNextcladeLineagesSource().get_collections()
-    assert len(rsps_lib.calls) == 1
     assert rsps_lib.calls[0].request.url == RSV_B_TREE_URL
 
 

--- a/collection-seeding/tests/test_rsv_nextclade_lineages.py
+++ b/collection-seeding/tests/test_rsv_nextclade_lineages.py
@@ -1,0 +1,241 @@
+import responses as rsps_lib
+
+from sources.rsv_nextclade_lineages import (
+    RSV_A_TREE_URL,
+    RSV_B_TREE_URL,
+    RsvANextcladeLineagesSource,
+    RsvBNextcladeLineagesSource,
+    _build_collections,
+    _extract_clades,
+)
+
+# Minimal tree: root → A (clade-introducing) → A.1 (clade-introducing leaf)
+SAMPLE_TREE = {
+    "tree": {
+        "name": "root",
+        "node_attrs": {},
+        "branch_attrs": {},
+        "children": [
+            {
+                "name": "NODE_A",
+                "node_attrs": {"clade_membership": {"value": "A"}},
+                "branch_attrs": {
+                    "labels": {"clade": "A"},
+                    "mutations": {
+                        "nuc": ["T59C", "G108A"],
+                        "F": ["T8A", "L20F"],
+                        "G": ["T4N"],
+                    },
+                },
+                "children": [
+                    {
+                        "name": "NODE_A1",
+                        "node_attrs": {"clade_membership": {"value": "A.1"}},
+                        "branch_attrs": {
+                            "labels": {"clade": "A.1"},
+                            "mutations": {
+                                "nuc": ["C241T"],
+                                "F": ["K124N"],
+                            },
+                        },
+                        "children": [],
+                    },
+                    {
+                        "name": "leaf_no_clade",
+                        "node_attrs": {"clade_membership": {"value": "A"}},
+                        "branch_attrs": {
+                            "mutations": {"nuc": ["A100G"]},
+                        },
+                        "children": [],
+                    },
+                ],
+            }
+        ],
+    }
+}
+
+
+# --- _extract_clades ---
+
+
+def test_extract_clades_finds_both_clades():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    names = [c[0] for c in clades]
+    assert "A" in names
+    assert "A.1" in names
+
+
+def test_extract_clades_skips_non_clade_nodes():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    names = [c[0] for c in clades]
+    assert "root" not in names
+    assert len(names) == 2
+
+
+def test_extract_clades_root_clade_has_no_parent():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    root_clade = next(c for c in clades if c[0] == "A")
+    assert root_clade[1] is None
+
+
+def test_extract_clades_child_clade_parent():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    child_clade = next(c for c in clades if c[0] == "A.1")
+    assert child_clade[1] == "A"
+
+
+def test_extract_clades_nuc_mutations():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    a_clade = next(c for c in clades if c[0] == "A")
+    assert a_clade[2] == ["T59C", "G108A"]
+
+
+def test_extract_clades_aa_mutations_prefixed_with_gene():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    a_clade = next(c for c in clades if c[0] == "A")
+    assert "F:T8A" in a_clade[3]
+    assert "F:L20F" in a_clade[3]
+    assert "G:T4N" in a_clade[3]
+
+
+def test_extract_clades_no_nuc_in_aa_mutations():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    for _, _, _, aa_muts in clades:
+        assert not any(m.startswith("nuc:") for m in aa_muts)
+
+
+def test_extract_clades_node_without_clade_label_not_yielded():
+    clades = list(_extract_clades(SAMPLE_TREE["tree"]))
+    # leaf_no_clade has no labels.clade, so it should not appear
+    assert len(clades) == 2
+
+
+# --- _build_collections ---
+
+
+def test_build_collections_count():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    assert len(cols) == 2
+
+
+def test_build_collections_organism():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    assert all(c["organism"] == "rsvA" for c in cols)
+
+
+def test_build_collections_name_is_clade():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    names = {c["name"] for c in cols}
+    assert names == {"A", "A.1"}
+
+
+def test_build_collections_description_contains_clade_and_parent():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    a1_col = next(c for c in cols if c["name"] == "A.1")
+    assert "A.1" in a1_col["description"]
+    assert "A" in a1_col["description"]  # parent
+
+
+def test_build_collections_description_root_clade_parent_dash():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    a_col = next(c for c in cols if c["name"] == "A")
+    assert "—" in a_col["description"]
+
+
+def test_build_collections_description_contains_organism_label():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    assert all("RSV-A" in c["description"] for c in cols)
+
+
+def test_build_collections_description_contains_owned_tag():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    assert all("#nextclade-lineage" in c["description"] for c in cols)
+
+
+def test_build_collections_two_variants_per_collection():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    assert all(len(c["variants"]) == 2 for c in cols)
+
+
+def test_build_collections_variant_names():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    for col in cols:
+        names = [v["name"] for v in col["variants"]]
+        assert names == ["Nucleotide substitutions", "Amino acid substitutions"]
+
+
+def test_build_collections_nuc_variant_contents():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    a_col = next(c for c in cols if c["name"] == "A")
+    nuc_variant = next(v for v in a_col["variants"] if v["name"] == "Nucleotide substitutions")
+    assert nuc_variant["filterObject"]["nucleotideMutations"] == ["T59C", "G108A"]
+
+
+def test_build_collections_aa_variant_contents():
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    a_col = next(c for c in cols if c["name"] == "A")
+    aa_variant = next(v for v in a_col["variants"] if v["name"] == "Amino acid substitutions")
+    aa = aa_variant["filterObject"]["aminoAcidMutations"]
+    assert "F:T8A" in aa
+    assert "F:L20F" in aa
+    assert "G:T4N" in aa
+
+
+# --- source class attributes ---
+
+
+def test_rsv_a_source_name():
+    assert RsvANextcladeLineagesSource.name == "rsv-a-nextclade-lineages"
+
+
+def test_rsv_b_source_name():
+    assert RsvBNextcladeLineagesSource.name == "rsv-b-nextclade-lineages"
+
+
+def test_rsv_a_organism():
+    assert RsvANextcladeLineagesSource.organism == "rsvA"
+
+
+def test_rsv_b_organism():
+    assert RsvBNextcladeLineagesSource.organism == "rsvB"
+
+
+def test_rsv_a_owned_tag():
+    assert RsvANextcladeLineagesSource.owned_tag == "#nextclade-lineage"
+
+
+def test_rsv_b_owned_tag():
+    assert RsvBNextcladeLineagesSource.owned_tag == "#nextclade-lineage"
+
+
+# --- get_collections (HTTP) ---
+
+
+@rsps_lib.activate
+def test_rsv_a_fetches_correct_url():
+    rsps_lib.add(rsps_lib.GET, RSV_A_TREE_URL, json=SAMPLE_TREE, status=200)
+    RsvANextcladeLineagesSource().get_collections()
+    assert len(rsps_lib.calls) == 1
+    assert rsps_lib.calls[0].request.url == RSV_A_TREE_URL
+
+
+@rsps_lib.activate
+def test_rsv_b_fetches_correct_url():
+    rsps_lib.add(rsps_lib.GET, RSV_B_TREE_URL, json=SAMPLE_TREE, status=200)
+    RsvBNextcladeLineagesSource().get_collections()
+    assert len(rsps_lib.calls) == 1
+    assert rsps_lib.calls[0].request.url == RSV_B_TREE_URL
+
+
+@rsps_lib.activate
+def test_rsv_a_get_collections_organism():
+    rsps_lib.add(rsps_lib.GET, RSV_A_TREE_URL, json=SAMPLE_TREE, status=200)
+    cols = RsvANextcladeLineagesSource().get_collections()
+    assert all(c["organism"] == "rsvA" for c in cols)
+
+
+@rsps_lib.activate
+def test_rsv_b_get_collections_organism():
+    rsps_lib.add(rsps_lib.GET, RSV_B_TREE_URL, json=SAMPLE_TREE, status=200)
+    cols = RsvBNextcladeLineagesSource().get_collections()
+    assert all(c["organism"] == "rsvB" for c in cols)

--- a/collection-seeding/tests/test_rsv_nextclade_lineages.py
+++ b/collection-seeding/tests/test_rsv_nextclade_lineages.py
@@ -143,7 +143,7 @@ def test_apply_aa_multiple_genes():
 
 def test_extract_clades_finds_both_clades():
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    names = [c[0] for c in clades]
+    names = [c.clade_name for c in clades]
     assert "A" in names
     assert "A.1" in names
 
@@ -155,47 +155,47 @@ def test_extract_clades_skips_non_clade_nodes():
 
 def test_extract_clades_root_clade_has_no_parent():
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    root_clade = next(c for c in clades if c[0] == "A")
-    assert root_clade[1] is None
+    root_clade = next(c for c in clades if c.clade_name == "A")
+    assert root_clade.parent_clade is None
 
 
 def test_extract_clades_child_clade_parent():
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    child = next(c for c in clades if c[0] == "A.1")
-    assert child[1] == "A"
+    child = next(c for c in clades if c.clade_name == "A.1")
+    assert child.parent_clade == "A"
 
 
 def test_extract_clades_branch_nuc_is_this_branch_only():
-    # branch_nuc (index 2) should contain only the mutations on that specific branch.
+    # branch_nuc should contain only the mutations on that specific branch.
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    a1 = next(c for c in clades if c[0] == "A.1")
-    assert a1[2] == ["C241T"]  # only what's new in A.1, not A's mutations
+    a1 = next(c for c in clades if c.clade_name == "A.1")
+    assert a1.branch_nuc == ["C241T"]  # only what's new in A.1, not A's mutations
 
 
 def test_extract_clades_branch_aa_is_this_branch_only():
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    a1 = next(c for c in clades if c[0] == "A.1")
-    assert a1[3] == ["F:K124N"]
+    a1 = next(c for c in clades if c.clade_name == "A.1")
+    assert a1.branch_aa == ["F:K124N"]
 
 
 def test_extract_clades_full_nuc_accumulates_from_root():
-    # full_nuc (index 4) for A.1 must include A's mutations as well as A.1's own.
+    # full_nuc for A.1 must include A's mutations as well as A.1's own.
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    a1 = next(c for c in clades if c[0] == "A.1")
-    assert set(a1[4]) == {"T59C", "G108A", "C241T"}
+    a1 = next(c for c in clades if c.clade_name == "A.1")
+    assert set(a1.full_nuc) == {"T59C", "G108A", "C241T"}
 
 
 def test_extract_clades_full_nuc_root_clade_equals_branch():
     # For the root clade (A) there is no ancestor, so full == branch.
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    a = next(c for c in clades if c[0] == "A")
-    assert set(a[4]) == {"T59C", "G108A"}
+    a = next(c for c in clades if c.clade_name == "A")
+    assert set(a.full_nuc) == {"T59C", "G108A"}
 
 
 def test_extract_clades_full_aa_accumulates_from_root():
     clades = list(_extract_clades(SAMPLE_TREE["tree"]))
-    a1 = next(c for c in clades if c[0] == "A.1")
-    assert set(a1[5]) == {"F:T8A", "F:L20F", "G:T4N", "F:K124N"}
+    a1 = next(c for c in clades if c.clade_name == "A.1")
+    assert set(a1.full_aa) == {"F:T8A", "F:L20F", "G:T4N", "F:K124N"}
 
 
 def test_extract_clades_sibling_subtrees_do_not_share_state():
@@ -238,13 +238,13 @@ def test_extract_clades_sibling_subtrees_do_not_share_state():
             ],
         }
     }
-    clades = {c[0]: c for c in _extract_clades(tree["tree"])}
+    clades = {c.clade_name: c for c in _extract_clades(tree["tree"])}
     # A.1 and A.2 should each independently see T59C from A
-    assert "T59C" in clades["A.1"][4]
-    assert "T59C" in clades["A.2"][4]
+    assert "T59C" in clades["A.1"].full_nuc
+    assert "T59C" in clades["A.2"].full_nuc
     # A.1 should NOT see A.2's mutation and vice versa
-    assert "G300T" not in clades["A.1"][4]
-    assert "C241T" not in clades["A.2"][4]
+    assert "G300T" not in clades["A.1"].full_nuc
+    assert "C241T" not in clades["A.2"].full_nuc
 
 
 def test_extract_clades_multi_hop_accumulation():
@@ -278,10 +278,10 @@ def test_extract_clades_multi_hop_accumulation():
             ],
         }
     }
-    clades = {c[0]: c for c in _extract_clades(tree["tree"])}
-    assert "A100C" in clades["A"][4]
-    assert "A100G" in clades["A.1"][4]   # reference A, final G
-    assert "A100C" not in clades["A.1"][4]  # A's intermediate step not present
+    clades = {c.clade_name: c for c in _extract_clades(tree["tree"])}
+    assert "A100C" in clades["A"].full_nuc
+    assert "A100G" in clades["A.1"].full_nuc   # reference A, final G
+    assert "A100C" not in clades["A.1"].full_nuc  # A's intermediate step not present
 
 
 def test_extract_clades_reversion_removed_from_full():
@@ -315,9 +315,8 @@ def test_extract_clades_reversion_removed_from_full():
             ],
         }
     }
-    clades = {c[0]: c for c in _extract_clades(tree["tree"])}
-    full_nuc_a1 = clades["A.1"][4]
-    assert not any("100" in m for m in full_nuc_a1)
+    clades = {c.clade_name: c for c in _extract_clades(tree["tree"])}
+    assert not any("100" in m for m in clades["A.1"].full_nuc)
 
 
 # --- _build_collections ---


### PR DESCRIPTION
Closes #1256

## Summary

- Adds `RsvANextcladeLineagesSource` and `RsvBNextcladeLineagesSource` that walk the Nextclade reference tree JSON to produce one collection per RSV clade
- Shared base class `_RsvNextcladeLineagesBase` handles the HTTP fetch; subclasses point at the hardcoded April 2026 snapshots from `nextstrain/nextclade_data`
- Each collection gets four variants, mirroring the COVID Pango lineage shape:
  - **Nucleotide substitutions** — full set accumulated from the reference root (1-based genomic coordinates), expressed as `REF_BASE + POSITION + CURRENT_BASE` (e.g. `A982T`)
  - **Amino acid substitutions** — full AA set from reference root, expressed as `GENE:REF_AA + POSITION + CURRENT_AA` (e.g. `F:T8A`)
  - **New nucleotide substitutions** — branch-only delta, what this clade introduces relative to its parent
  - **New amino acid substitutions** — branch-only AA delta
- Accumulation handles multi-hop mutations (A→C→G collapses to A→G) and reversions (A→C→A is dropped from the accumulated set)
- Both sources registered in `registry.py` and included in the default run
- 45 new tests covering accumulation logic, tree extraction, collection shape, source metadata, and HTTP fetch behaviour

## Test plan

- [x] `pixi run -e test test` — all 95 tests pass
- [x] Seeded against local backend — 45 RSV-A and 30 RSV-B collections created/updated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)