### PR TITLE
feat(collections): gridJS table with pagination and column sorting

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -28,5 +28,15 @@ export default defineConfig({
             },
         ],
     },
-    vite: { plugins: [tailwindcss()] },
+    vite: {
+        plugins: [tailwindcss()],
+        resolve: {
+            alias: {
+                // gridjs-react ships both CJS and ESM builds; Vite's package scanner picks up
+                // the CJS entry and then fails to find named exports. Pointing directly at the
+                // ESM dist file bypasses that detection entirely.
+                'gridjs-react': 'gridjs-react/dist/gridjs.production.es.min.js',
+            },
+        },
+    },
 });

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -17,6 +17,8 @@
                 "cookie": "^1.1.1",
                 "dayjs": "^1.11.21",
                 "downshift": "^9.3.3",
+                "gridjs": "^6.2.0",
+                "gridjs-react": "^6.1.1",
                 "katex": "^0.17.0",
                 "patch-package": "^8.0.1",
                 "react": "^19.2.7",
@@ -7930,6 +7932,16 @@
             "license": "MIT",
             "dependencies": {
                 "preact": "^10.11.3"
+            }
+        },
+        "node_modules/gridjs-react": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gridjs-react/-/gridjs-react-6.1.1.tgz",
+            "integrity": "sha512-MOu/t4naXR6vIeLdcE+vUFtyUcYuRn75sThJnShlMntQcrVCSKSBApmNWU1MzLuNrqOH5sbDImqk7pIXYumKxA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "gridjs": "^6.1.0",
+                "react": ">=18.x"
             }
         },
         "node_modules/h3": {

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,8 @@
         "cookie": "^1.1.1",
         "dayjs": "^1.11.21",
         "downshift": "^9.3.3",
+        "gridjs": "^6.2.0",
+        "gridjs-react": "^6.1.1",
         "katex": "^0.17.0",
         "patch-package": "^8.0.1",
         "react": "^19.2.7",

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -41,7 +41,7 @@ describe('CollectionsOverview', () => {
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('Community collection')).toBeVisible();
-        await expect.element(getByRole('table')).toBeVisible();
+        await expect.element(getByRole('grid')).toBeVisible();
     });
 
     it('hides official collections by default', async ({ routeMockers: { astro } }) => {

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -35,7 +35,7 @@ function renderOverview() {
 
 describe('CollectionsOverview', () => {
     it('shows the headline and community collections by default', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries(allCollections, ORGANISM);
+        astro.mockGetCollectionSummaries(allCollections, ORGANISM, 200, true);
 
         const { getByText, getByRole } = renderOverview();
 
@@ -45,7 +45,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('hides official collections by default', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries(allCollections, ORGANISM);
+        astro.mockGetCollectionSummaries(allCollections, ORGANISM, 200, true);
 
         const { getByText } = renderOverview();
 
@@ -54,7 +54,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows only official collections when Official is selected', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries(allCollections, ORGANISM);
+        astro.mockGetCollectionSummaries(allCollections, ORGANISM, 200, true);
 
         const { getByText } = renderOverview();
 
@@ -65,7 +65,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows all collections when All is selected', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries(allCollections, ORGANISM);
+        astro.mockGetCollectionSummaries(allCollections, ORGANISM, 200, true);
 
         const { getByText } = renderOverview();
 
@@ -76,7 +76,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows the headline and empty message when there are no collections', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries([], ORGANISM);
+        astro.mockGetCollectionSummaries([], ORGANISM, 200, true);
 
         const { getByText } = renderOverview();
 
@@ -85,7 +85,7 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows the headline and error message when the fetch fails', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries([], ORGANISM, 500);
+        astro.mockGetCollectionSummaries([], ORGANISM, 500, true);
         astro.mockLog();
 
         const { getByText } = renderOverview();

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -135,7 +135,6 @@ function CollectionFilterSelect({
                 </Fragment>
             ))}
         </div>
-
     );
 }
 

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -38,9 +38,8 @@ function CollectionsOverviewInner({
         error,
     } = useQuery({
         queryKey: ['collections', organism],
-        // TODO: restore excludeSystemCollections: true once done testing with GridJS
         queryFn: () =>
-            getBackendServiceForClientside().getCollectionSummaries({ organism /*, excludeSystemCollections: true*/ }),
+            getBackendServiceForClientside().getCollectionSummaries({ organism, excludeSystemCollections: true }),
     });
 
     if (isError) {

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -135,6 +135,43 @@ function CollectionFilterSelect({
                 </Fragment>
             ))}
         </div>
+
+    );
+}
+
+function CollectionsGridStyles() {
+    return (
+        <style>{`
+            /* Remove the mermaid theme's rounded corners and drop shadow; add outer left/right border to frame the table */
+            .collections-grid .gridjs-wrapper, .collections-grid .gridjs-footer { border-radius: 0; box-shadow: none; border-left: 1px solid var(--color-base-300); border-right: 1px solid var(--color-base-300); }
+
+            /* Mermaid sets inline-block here, which lets the table overflow the viewport instead of squishing */
+            .collections-grid .gridjs-container { display: block; }
+
+            /* Remove horizontal row lines, keeping only the vertical column separators */
+            .collections-grid th.gridjs-th, .collections-grid td.gridjs-td { border-top: none; border-bottom: none; }
+
+            /* Zebra striping using the active DaisyUI theme's base-200 colour */
+            .collections-grid .gridjs-tbody tr:nth-child(even) td.gridjs-td { background-color: var(--color-base-200); }
+
+            /* Tighten up header padding and reduce font slightly from the mermaid default */
+            .collections-grid th.gridjs-th { padding: 10px 16px; font-size: 0.8125rem; }
+
+            /* Tighten up cell padding and reduce font to match the rest of the UI */
+            .collections-grid td.gridjs-td { padding: 6px 16px; font-size: 0.875rem; }
+
+            /* Scale the sort arrow button down to match the smaller header size */
+            .collections-grid button.gridjs-sort { height: 18px; width: 11px; }
+
+            /* Tighten up the pagination footer */
+            .collections-grid .gridjs-footer { padding: 8px 16px; font-size: 0.8125rem; }
+
+            /* Reduce pagination button padding to match the smaller footer */
+            .collections-grid .gridjs-pagination .gridjs-pages button { padding: 3px 10px; }
+
+            /* Truncate long descriptions with an ellipsis — relies on table-layout: fixed from the mermaid theme */
+            .collections-grid td.gridjs-td:nth-child(3) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 0; }
+        `}</style>
     );
 }
 
@@ -143,85 +180,57 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
 
     return (
         <div className='my-6'>
-            <style>{`
-                /* Remove the mermaid theme's rounded corners and drop shadow; add outer left/right border to frame the table */
-                .gridjs-wrapper, .gridjs-footer { border-radius: 0; box-shadow: none; border-left: 1px solid #e5e7eb; border-right: 1px solid #e5e7eb; }
-
-                /* Mermaid sets inline-block here, which lets the table overflow the viewport instead of squishing */
-                .gridjs-container { display: block; }
-
-                /* Remove horizontal row lines, keeping only the vertical column separators */
-                th.gridjs-th, td.gridjs-td { border-top: none; border-bottom: none; }
-
-                /* Zebra striping using the active DaisyUI theme's base-200 colour */
-                .gridjs-tbody tr:nth-child(even) td.gridjs-td { background-color: var(--color-base-200); }
-
-                /* Tighten up header padding and reduce font slightly from the mermaid default */
-                th.gridjs-th { padding: 10px 16px; font-size: 0.8125rem; }
-
-                /* Tighten up cell padding and reduce font to match the rest of the UI */
-                td.gridjs-td { padding: 6px 16px; font-size: 0.875rem; }
-
-                /* Scale the sort arrow button down to match the smaller header size */
-                button.gridjs-sort { height: 18px; width: 11px; }
-
-                /* Tighten up the pagination footer */
-                .gridjs-footer { padding: 8px 16px; font-size: 0.8125rem; }
-
-                /* Reduce pagination button padding to match the smaller footer */
-                .gridjs-pagination .gridjs-pages button { padding: 3px 10px; }
-
-                /* Truncate long descriptions with an ellipsis — relies on table-layout: fixed from the mermaid theme */
-                td.gridjs-td:nth-child(3) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 0; }
-            `}</style>
-            <Grid
-                columns={[
-                    {
-                        id: 'id',
-                        name: 'ID',
-                        width: '7%',
-                        formatter: (cell) =>
-                            h(
-                                'a',
-                                { href: makeHref(cell as number) },
-                                h('span', { className: 'font-mono text-xs text-gray-500' }, String(cell as number)),
-                            ),
-                    },
-                    {
-                        id: 'name',
-                        name: 'Name',
-                        width: '25%',
-                        formatter: (cell, row) =>
-                            h(
-                                'a',
-                                { href: makeHref(row.cell(0).data as number) },
-                                h('span', { className: 'font-medium' }, cell as string),
-                            ),
-                    },
-                    {
-                        id: 'description',
-                        name: 'Description',
-                        formatter: (cell, row) =>
-                            h(
-                                'a',
-                                { href: makeHref(row.cell(0).data as number) },
-                                cell != null
-                                    ? h('span', { className: 'text-gray-500' }, cell as string)
-                                    : h('span', { className: 'text-gray-300' }, '—'),
-                            ),
-                    },
-                    {
-                        id: 'variantCount',
-                        name: 'Variants',
-                        width: '10%',
-                        formatter: (cell, row) =>
-                            h('a', { href: makeHref(row.cell(0).data as number) }, String(cell as number)),
-                    },
-                ]}
-                data={collections.map((c) => [c.id, c.name, c.description, c.variantCount])}
-                pagination={{ limit: 20 }}
-                sort={true}
-            />
+            <CollectionsGridStyles />
+            <div className='collections-grid'>
+                <Grid
+                    columns={[
+                        {
+                            id: 'id',
+                            name: 'ID',
+                            width: '7%',
+                            formatter: (cell) =>
+                                h(
+                                    'a',
+                                    { href: makeHref(cell as number) },
+                                    h('span', { className: 'font-mono text-xs text-gray-500' }, String(cell as number)),
+                                ),
+                        },
+                        {
+                            id: 'name',
+                            name: 'Name',
+                            width: '25%',
+                            formatter: (cell, row) =>
+                                h(
+                                    'a',
+                                    { href: makeHref(row.cell(0).data as number) },
+                                    h('span', { className: 'font-medium' }, cell as string),
+                                ),
+                        },
+                        {
+                            id: 'description',
+                            name: 'Description',
+                            formatter: (cell, row) =>
+                                h(
+                                    'a',
+                                    { href: makeHref(row.cell(0).data as number) },
+                                    cell != null
+                                        ? h('span', { className: 'text-gray-500' }, cell as string)
+                                        : h('span', { className: 'text-gray-300' }, '—'),
+                                ),
+                        },
+                        {
+                            id: 'variantCount',
+                            name: 'Variants',
+                            width: '10%',
+                            formatter: (cell, row) =>
+                                h('a', { href: makeHref(row.cell(0).data as number) }, String(cell as number)),
+                        },
+                    ]}
+                    data={collections.map((c) => [c.id, c.name, c.description, c.variantCount])}
+                    pagination={{ limit: 20 }}
+                    sort={true}
+                />
+            </div>
         </div>
     );
 }

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -144,6 +144,31 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
 
     return (
         <div className='my-6'>
+            <style>{`
+                /* Remove the mermaid theme's rounded corners and drop shadow; add outer left/right border to frame the table */
+                .gridjs-wrapper, .gridjs-footer { border-radius: 0; box-shadow: none; border-left: 1px solid #e5e7eb; border-right: 1px solid #e5e7eb; }
+
+                /* Remove horizontal row lines, keeping only the vertical column separators */
+                th.gridjs-th, td.gridjs-td { border-top: none; border-bottom: none; }
+
+                /* Zebra striping using the active DaisyUI theme's base-200 colour */
+                .gridjs-tbody tr:nth-child(even) td.gridjs-td { background-color: var(--color-base-200); }
+
+                /* Tighten up header padding and reduce font slightly from the mermaid default */
+                th.gridjs-th { padding: 10px 16px; font-size: 0.8125rem; }
+
+                /* Tighten up cell padding and reduce font to match the rest of the UI */
+                td.gridjs-td { padding: 6px 16px; font-size: 0.875rem; }
+
+                /* Scale the sort arrow button down to match the smaller header size */
+                button.gridjs-sort { height: 18px; width: 11px; }
+
+                /* Tighten up the pagination footer */
+                .gridjs-footer { padding: 8px 16px; font-size: 0.8125rem; }
+
+                /* Reduce pagination button padding to match the smaller footer */
+                .gridjs-pagination .gridjs-pages button { padding: 3px 10px; }
+            `}</style>
             <Grid
                 columns={[
                     {

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -171,6 +171,12 @@ function CollectionsGridStyles() {
 
             /* Truncate long descriptions with an ellipsis — relies on table-layout: fixed from the mermaid theme */
             .collections-grid td.gridjs-td:nth-child(3) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 0; }
+
+            /* Make links fill the entire cell so the whole row area is clickable */
+            .collections-grid td.gridjs-td a { display: block; margin: -6px -16px; padding: 6px 16px; }
+
+            /* Right-align the Variants (last) column to match the old table */
+            .collections-grid td.gridjs-td:last-child, .collections-grid th.gridjs-th:last-child { text-align: right; }
         `}</style>
     );
 }
@@ -213,7 +219,7 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                                 h(
                                     'a',
                                     { href: makeHref(row.cell(0).data as number) },
-                                    cell != null
+                                    cell
                                         ? h('span', { className: 'text-gray-500' }, cell as string)
                                         : h('span', { className: 'text-gray-300' }, '—'),
                                 ),

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -219,7 +219,7 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                                 h(
                                     'a',
                                     { href: makeHref(row.cell(0).data as number) },
-                                    cell
+                                    cell !== null
                                         ? h('span', { className: 'text-gray-500' }, cell as string)
                                         : h('span', { className: 'text-gray-300' }, '—'),
                                 ),

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -1,6 +1,6 @@
-import { Grid } from 'gridjs-react';
-import { h } from 'gridjs';
 import { useQuery } from '@tanstack/react-query';
+import { h } from 'gridjs';
+import { Grid } from 'gridjs-react';
 import { Fragment, useId, useState } from 'react';
 
 import 'gridjs/dist/theme/mermaid.css';
@@ -182,8 +182,10 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                         name: 'ID',
                         width: '7%',
                         formatter: (cell) =>
-                            h('a', { href: makeHref(cell as number) },
-                                h('span', { className: 'font-mono text-xs text-gray-500' }, String(cell)),
+                            h(
+                                'a',
+                                { href: makeHref(cell as number) },
+                                h('span', { className: 'font-mono text-xs text-gray-500' }, String(cell as number)),
                             ),
                     },
                     {
@@ -191,17 +193,21 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                         name: 'Name',
                         width: '25%',
                         formatter: (cell, row) =>
-                            h('a', { href: makeHref(row.cell(0).data as number) },
-                                h('span', { className: 'font-medium' }, String(cell)),
+                            h(
+                                'a',
+                                { href: makeHref(row.cell(0).data as number) },
+                                h('span', { className: 'font-medium' }, cell as string),
                             ),
                     },
                     {
                         id: 'description',
                         name: 'Description',
                         formatter: (cell, row) =>
-                            h('a', { href: makeHref(row.cell(0).data as number) },
+                            h(
+                                'a',
+                                { href: makeHref(row.cell(0).data as number) },
                                 cell != null
-                                    ? h('span', { className: 'text-gray-500' }, String(cell))
+                                    ? h('span', { className: 'text-gray-500' }, cell as string)
                                     : h('span', { className: 'text-gray-300' }, '—'),
                             ),
                     },
@@ -210,15 +216,10 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                         name: 'Variants',
                         width: '10%',
                         formatter: (cell, row) =>
-                            h('a', { href: makeHref(row.cell(0).data as number) }, String(cell)),
+                            h('a', { href: makeHref(row.cell(0).data as number) }, String(cell as number)),
                     },
                 ]}
-                data={collections.map((c) => [
-                    c.id,
-                    c.name,
-                    c.description,
-                    c.variantCount,
-                ])}
+                data={collections.map((c) => [c.id, c.name, c.description, c.variantCount])}
                 pagination={{ limit: 20 }}
                 sort={true}
             />

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -1,5 +1,9 @@
+import { Grid } from 'gridjs-react';
+import { h } from 'gridjs';
 import { useQuery } from '@tanstack/react-query';
 import { Fragment, useId, useState } from 'react';
+
+import 'gridjs/dist/theme/mermaid.css';
 
 import { getBackendServiceForClientside } from '../../../backendApi/backendService.ts';
 import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
@@ -34,7 +38,9 @@ function CollectionsOverviewInner({
         error,
     } = useQuery({
         queryKey: ['collections', organism],
-        queryFn: () => getBackendServiceForClientside().getCollectionSummaries({ organism }),
+        // TODO: restore excludeSystemCollections: true once done testing with GridJS
+        queryFn: () =>
+            getBackendServiceForClientside().getCollectionSummaries({ organism /*, excludeSystemCollections: true*/ }),
     });
 
     if (isError) {
@@ -134,55 +140,58 @@ function CollectionFilterSelect({
 }
 
 function CollectionsTable({ collections, organism }: { collections: CollectionSummary[]; organism: Organism }) {
+    const makeHref = (id: number) => Page.viewCollection(organism, String(id));
+
     return (
-        <div className='my-6 overflow-x-auto'>
-            <table className='table-zebra table w-full'>
-                <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Name</th>
-                        <th>Description</th>
-                        <th className='text-right'>Variants</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {collections.map((collection) => {
-                        const href = Page.viewCollection(organism, String(collection.id));
-                        return (
-                            <tr key={collection.id} className='hover:bg-base-300'>
-                                <td className='p-0'>
-                                    <a href={href} className='block px-4 py-3 font-mono text-xs text-gray-500'>
-                                        {collection.id}
-                                    </a>
-                                </td>
-                                <td className='p-0'>
-                                    <a href={href} className='block px-4 py-3 font-medium'>
-                                        {collection.name}
-                                    </a>
-                                </td>
-                                <td className='max-w-sm p-0'>
-                                    <a href={href} className='block px-4 py-3 text-gray-500'>
-                                        {collection.description ? (
-                                            collection.description.length > 80 ? (
-                                                collection.description.slice(0, 80) + '…'
-                                            ) : (
-                                                collection.description
-                                            )
-                                        ) : (
-                                            <span className='text-gray-300'>—</span>
-                                        )}
-                                    </a>
-                                </td>
-                                <td className='p-0'>
-                                    <a href={href} className='block px-4 py-3 text-right'>
-                                        {collection.variantCount}
-                                    </a>
-                                </td>
-                            </tr>
-                        );
-                    })}
-                </tbody>
-            </table>
+        <div className='my-6'>
+            <Grid
+                columns={[
+                    {
+                        id: 'id',
+                        name: 'ID',
+                        formatter: (cell) =>
+                            h('a', { href: makeHref(cell as number) },
+                                h('span', { className: 'font-mono text-xs text-gray-500' }, String(cell)),
+                            ),
+                    },
+                    {
+                        id: 'name',
+                        name: 'Name',
+                        formatter: (cell, row) =>
+                            h('a', { href: makeHref(row.cell(0).data as number) },
+                                h('span', { className: 'font-medium' }, String(cell)),
+                            ),
+                    },
+                    {
+                        id: 'description',
+                        name: 'Description',
+                        formatter: (cell, row) =>
+                            h('a', { href: makeHref(row.cell(0).data as number) },
+                                cell != null
+                                    ? h('span', { className: 'text-gray-500' }, String(cell))
+                                    : h('span', { className: 'text-gray-300' }, '—'),
+                            ),
+                    },
+                    {
+                        id: 'variantCount',
+                        name: 'Variants',
+                        formatter: (cell, row) =>
+                            h('a', { href: makeHref(row.cell(0).data as number) }, String(cell)),
+                    },
+                ]}
+                data={collections.map((c) => [
+                    c.id,
+                    c.name,
+                    c.description != null
+                        ? c.description.length > 80
+                            ? c.description.slice(0, 80) + '…'
+                            : c.description
+                        : null,
+                    c.variantCount,
+                ])}
+                pagination={{ limit: 20 }}
+                sort={true}
+            />
         </div>
     );
 }

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -148,6 +148,9 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                 /* Remove the mermaid theme's rounded corners and drop shadow; add outer left/right border to frame the table */
                 .gridjs-wrapper, .gridjs-footer { border-radius: 0; box-shadow: none; border-left: 1px solid #e5e7eb; border-right: 1px solid #e5e7eb; }
 
+                /* Mermaid sets inline-block here, which lets the table overflow the viewport instead of squishing */
+                .gridjs-container { display: block; }
+
                 /* Remove horizontal row lines, keeping only the vertical column separators */
                 th.gridjs-th, td.gridjs-td { border-top: none; border-bottom: none; }
 
@@ -168,12 +171,16 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
 
                 /* Reduce pagination button padding to match the smaller footer */
                 .gridjs-pagination .gridjs-pages button { padding: 3px 10px; }
+
+                /* Truncate long descriptions with an ellipsis — relies on table-layout: fixed from the mermaid theme */
+                td.gridjs-td:nth-child(3) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 0; }
             `}</style>
             <Grid
                 columns={[
                     {
                         id: 'id',
                         name: 'ID',
+                        width: '7%',
                         formatter: (cell) =>
                             h('a', { href: makeHref(cell as number) },
                                 h('span', { className: 'font-mono text-xs text-gray-500' }, String(cell)),
@@ -182,6 +189,7 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                     {
                         id: 'name',
                         name: 'Name',
+                        width: '25%',
                         formatter: (cell, row) =>
                             h('a', { href: makeHref(row.cell(0).data as number) },
                                 h('span', { className: 'font-medium' }, String(cell)),
@@ -200,6 +208,7 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                     {
                         id: 'variantCount',
                         name: 'Variants',
+                        width: '10%',
                         formatter: (cell, row) =>
                             h('a', { href: makeHref(row.cell(0).data as number) }, String(cell)),
                     },
@@ -207,11 +216,7 @@ function CollectionsTable({ collections, organism }: { collections: CollectionSu
                 data={collections.map((c) => [
                     c.id,
                     c.name,
-                    c.description != null
-                        ? c.description.length > 80
-                            ? c.description.slice(0, 80) + '…'
-                            : c.description
-                        : null,
+                    c.description,
                     c.variantCount,
                 ])}
                 pagination={{ limit: 20 }}


### PR DESCRIPTION
Closes #1269

## Summary

- Replaces the hand-rolled DaisyUI table in `CollectionsOverview.tsx` with a GridJS `<Grid>` component
- All four columns (ID, Name, Description, Variants) are sortable client-side
- Pagination at 20 rows per page
- Cells wrapped in `<a>` tags via GridJS `h()` formatter, preserving proper link behaviour (hover cursor, right-click, middle-click)
- Adds a Vite alias pointing `gridjs-react` at its ESM dist file directly, working around Vite's CJS package scanner misidentifying the named exports

## Styling

Overrides the mermaid theme via an inline `<style>` block to match the site's design language:
- No rounded corners or drop shadow
- Outer left/right border frames the table
- No horizontal row lines — vertical column separators only
- Zebra striping using DaisyUI's `--color-base-200` (theme-aware, works in dark mode)
- Tighter padding and font sizes
- `display: block` on `.gridjs-container` so the table squishes on narrow screens instead of scrolling

Column widths: ID 7%, Name 25%, Variants 10%, Description takes the rest. Long descriptions are truncated with a CSS ellipsis.

## Screenshot

<img width="1512" height="858" alt="image" src="https://github.com/user-attachments/assets/3fe6e1c7-79a3-4899-ad22-e1971d0f4aad" />

## Test plan

- [ ] Verify sorting works on all columns
- [ ] Verify pagination appears when there are more than 20 rows
- [ ] Verify clicking a row navigates to the collection detail page
- [ ] Verify description truncation with ellipsis on long descriptions
- [ ] Verify table squishes (no horizontal scroll) on narrow screens (~1000px)
- [ ] Run browser spec tests: `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
