### PR TITLE
feat(website): add community/official/all filter to collections overview

### DIFF
--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -7,46 +7,80 @@ import { Organisms } from '../../../types/Organism';
 
 const ORGANISM = Organisms.covid;
 const HEADLINE = 'SARS-CoV-2 Collections';
+const SYSTEM_USER_ID = 1;
 
-const mockCollections = [
-    {
-        id: 1,
-        name: 'My first collection',
-        ownedBy: 1,
-        organism: ORGANISM,
-        description: 'A test collection',
-        variantCount: 3,
-    },
-    {
-        id: 2,
-        name: 'Another collection',
-        ownedBy: 1,
-        organism: ORGANISM,
-        description: null,
-        variantCount: 0,
-    },
-];
+const communityCollection = {
+    id: 1,
+    name: 'Community collection',
+    ownedBy: 2,
+    organism: ORGANISM,
+    description: 'A user-submitted collection',
+    variantCount: 3,
+};
+
+const officialCollection = {
+    id: 2,
+    name: 'Official collection',
+    ownedBy: SYSTEM_USER_ID,
+    organism: ORGANISM,
+    description: null,
+    variantCount: 0,
+};
+
+const allCollections = [communityCollection, officialCollection];
+
+function renderOverview(collections: typeof allCollections) {
+    return render(
+        <CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={SYSTEM_USER_ID} />,
+    );
+}
 
 describe('CollectionsOverview', () => {
-    it('shows the headline and collections table on success', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries(mockCollections, ORGANISM);
+    it('shows the headline and community collections by default', async ({ routeMockers: { astro } }) => {
+        astro.mockGetCollectionSummaries(allCollections, ORGANISM);
 
-        const { getByText, getByRole } = render(
-            <CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={1} />,
-        );
+        const { getByText, getByRole } = renderOverview(allCollections);
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
-        await expect.element(getByText('My first collection')).toBeVisible();
-        await expect.element(getByText('Another collection')).toBeVisible();
+        await expect.element(getByText('Community collection')).toBeVisible();
         await expect.element(getByRole('table')).toBeVisible();
-        await expect.element(getByText('3')).toBeVisible(); // variant count for first collection
-        await expect.element(getByText('0')).toBeVisible(); // variant count for second collection
+    });
+
+    it('hides official collections by default', async ({ routeMockers: { astro } }) => {
+        astro.mockGetCollectionSummaries(allCollections, ORGANISM);
+
+        const { getByText } = renderOverview(allCollections);
+
+        await expect.element(getByText('Community collection')).toBeVisible();
+        await expect.element(getByText('Official collection')).not.toBeInTheDocument();
+    });
+
+    it('shows only official collections when Official is selected', async ({ routeMockers: { astro } }) => {
+        astro.mockGetCollectionSummaries(allCollections, ORGANISM);
+
+        const { getByText } = renderOverview(allCollections);
+
+        await getByText('Official').click();
+
+        await expect.element(getByText('Official collection')).toBeVisible();
+        await expect.element(getByText('Community collection')).not.toBeInTheDocument();
+    });
+
+    it('shows all collections when All is selected', async ({ routeMockers: { astro } }) => {
+        astro.mockGetCollectionSummaries(allCollections, ORGANISM);
+
+        const { getByText } = renderOverview(allCollections);
+
+        await getByText('All').click();
+
+        await expect.element(getByText('Community collection')).toBeVisible();
+        await expect.element(getByText('Official collection')).toBeVisible();
     });
 
     it('shows the headline and empty message when there are no collections', async ({ routeMockers: { astro } }) => {
         astro.mockGetCollectionSummaries([], ORGANISM);
 
-        const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={1} />);
+        const { getByText } = renderOverview([]);
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('No collections yet.')).toBeVisible();
@@ -56,7 +90,7 @@ describe('CollectionsOverview', () => {
         astro.mockGetCollectionSummaries([], ORGANISM, 500);
         astro.mockLog();
 
-        const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={1} />);
+        const { getByText } = renderOverview([]);
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('Failed to load collections. Please try reloading the page.')).toBeVisible();

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -29,17 +29,15 @@ const officialCollection = {
 
 const allCollections = [communityCollection, officialCollection];
 
-function renderOverview(collections: typeof allCollections) {
-    return render(
-        <CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={SYSTEM_USER_ID} />,
-    );
+function renderOverview() {
+    return render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={SYSTEM_USER_ID} />);
 }
 
 describe('CollectionsOverview', () => {
     it('shows the headline and community collections by default', async ({ routeMockers: { astro } }) => {
         astro.mockGetCollectionSummaries(allCollections, ORGANISM);
 
-        const { getByText, getByRole } = renderOverview(allCollections);
+        const { getByText, getByRole } = renderOverview();
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('Community collection')).toBeVisible();
@@ -49,7 +47,7 @@ describe('CollectionsOverview', () => {
     it('hides official collections by default', async ({ routeMockers: { astro } }) => {
         astro.mockGetCollectionSummaries(allCollections, ORGANISM);
 
-        const { getByText } = renderOverview(allCollections);
+        const { getByText } = renderOverview();
 
         await expect.element(getByText('Community collection')).toBeVisible();
         await expect.element(getByText('Official collection')).not.toBeInTheDocument();
@@ -58,7 +56,7 @@ describe('CollectionsOverview', () => {
     it('shows only official collections when Official is selected', async ({ routeMockers: { astro } }) => {
         astro.mockGetCollectionSummaries(allCollections, ORGANISM);
 
-        const { getByText } = renderOverview(allCollections);
+        const { getByText } = renderOverview();
 
         await getByText('Official').click();
 
@@ -69,7 +67,7 @@ describe('CollectionsOverview', () => {
     it('shows all collections when All is selected', async ({ routeMockers: { astro } }) => {
         astro.mockGetCollectionSummaries(allCollections, ORGANISM);
 
-        const { getByText } = renderOverview(allCollections);
+        const { getByText } = renderOverview();
 
         await getByText('All').click();
 
@@ -80,7 +78,7 @@ describe('CollectionsOverview', () => {
     it('shows the headline and empty message when there are no collections', async ({ routeMockers: { astro } }) => {
         astro.mockGetCollectionSummaries([], ORGANISM);
 
-        const { getByText } = renderOverview([]);
+        const { getByText } = renderOverview();
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('No collections yet.')).toBeVisible();
@@ -90,7 +88,7 @@ describe('CollectionsOverview', () => {
         astro.mockGetCollectionSummaries([], ORGANISM, 500);
         astro.mockLog();
 
-        const { getByText } = renderOverview([]);
+        const { getByText } = renderOverview();
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('Failed to load collections. Please try reloading the page.')).toBeVisible();

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -31,7 +31,9 @@ describe('CollectionsOverview', () => {
     it('shows the headline and collections table on success', async ({ routeMockers: { astro } }) => {
         astro.mockGetCollectionSummaries(mockCollections, ORGANISM);
 
-        const { getByText, getByRole } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={1} />);
+        const { getByText, getByRole } = render(
+            <CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={1} />,
+        );
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('My first collection')).toBeVisible();

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -29,9 +29,9 @@ const mockCollections = [
 
 describe('CollectionsOverview', () => {
     it('shows the headline and collections table on success', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries(mockCollections, ORGANISM, 200, true);
+        astro.mockGetCollectionSummaries(mockCollections, ORGANISM);
 
-        const { getByText, getByRole } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);
+        const { getByText, getByRole } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={1} />);
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('My first collection')).toBeVisible();
@@ -42,19 +42,19 @@ describe('CollectionsOverview', () => {
     });
 
     it('shows the headline and empty message when there are no collections', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries([], ORGANISM, 200, true);
+        astro.mockGetCollectionSummaries([], ORGANISM);
 
-        const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);
+        const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={1} />);
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('No collections yet.')).toBeVisible();
     });
 
     it('shows the headline and error message when the fetch fails', async ({ routeMockers: { astro } }) => {
-        astro.mockGetCollectionSummaries([], ORGANISM, 500, true);
+        astro.mockGetCollectionSummaries([], ORGANISM, 500);
         astro.mockLog();
 
-        const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} />);
+        const { getByText } = render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={1} />);
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('Failed to load collections. Please try reloading the page.')).toBeVisible();

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -1,5 +1,5 @@
-import { Fragment, useId, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Fragment, useId, useState } from 'react';
 
 import { getBackendServiceForClientside } from '../../../backendApi/backendService.ts';
 import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { getBackendServiceForClientside } from '../../../backendApi/backendService.ts';
@@ -13,7 +14,19 @@ export const CollectionsOverview = withQueryProvider(CollectionsOverviewInner);
 
 const logger = getClientLogger('CollectionsOverview');
 
-function CollectionsOverviewInner({ organism, isLoggedIn }: { organism: Organism; isLoggedIn: boolean }) {
+type CollectionFilter = 'community' | 'official' | 'all';
+
+function CollectionsOverviewInner({
+    organism,
+    isLoggedIn,
+    systemUserId,
+}: {
+    organism: Organism;
+    isLoggedIn: boolean;
+    systemUserId: number;
+}) {
+    const [filter, setFilter] = useState<CollectionFilter>('community');
+
     const {
         isLoading,
         isError,
@@ -21,13 +34,14 @@ function CollectionsOverviewInner({ organism, isLoggedIn }: { organism: Organism
         error,
     } = useQuery({
         queryKey: ['collections', organism],
-        queryFn: () =>
-            getBackendServiceForClientside().getCollectionSummaries({ organism, excludeSystemCollections: true }),
+        queryFn: () => getBackendServiceForClientside().getCollectionSummaries({ organism }),
     });
 
     if (isError) {
         logger.error(`Failed to fetch collections: ${getErrorLogMessage(error)}`);
     }
+
+    const filteredCollections = filterCollections(collections, filter, systemUserId);
 
     return (
         <div>
@@ -39,11 +53,24 @@ function CollectionsOverviewInner({ organism, isLoggedIn }: { organism: Organism
                     </a>
                 )}
             </div>
+            <div className='join'>
+                {(['community', 'official', 'all'] as CollectionFilter[]).map((option) => (
+                    <input
+                        key={option}
+                        className='join-item btn btn-sm'
+                        type='radio'
+                        name='collection-filter'
+                        aria-label={option.charAt(0).toUpperCase() + option.slice(1)}
+                        checked={filter === option}
+                        onChange={() => setFilter(option)}
+                    />
+                ))}
+            </div>
             {isLoading ? (
                 <span className='loading loading-spinner loading-sm' />
             ) : isError ? (
                 <div className='text-error'>Failed to load collections. Please try reloading the page.</div>
-            ) : collections === undefined || collections.length === 0 ? (
+            ) : filteredCollections.length === 0 ? (
                 <div className='mt-6 text-gray-500'>
                     No collections yet.
                     {isLoggedIn && (
@@ -57,10 +84,26 @@ function CollectionsOverviewInner({ organism, isLoggedIn }: { organism: Organism
                     )}
                 </div>
             ) : (
-                <CollectionsTable collections={collections} organism={organism} />
+                        <CollectionsTable collections={filteredCollections} organism={organism} />
             )}
         </div>
     );
+}
+
+function filterCollections(
+    collections: CollectionSummary[] | undefined,
+    filter: CollectionFilter,
+    systemUserId: number,
+): CollectionSummary[] {
+    if (!collections) return [];
+    switch (filter) {
+        case 'community':
+            return collections.filter((c) => c.ownedBy !== systemUserId);
+        case 'official':
+            return collections.filter((c) => c.ownedBy === systemUserId);
+        case 'all':
+            return collections;
+    }
 }
 
 function CollectionsTable({ collections, organism }: { collections: CollectionSummary[]; organism: Organism }) {

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -116,7 +116,7 @@ function CollectionFilterSelect({
                         type='radio'
                         id={`${id}-${opt.value}`}
                         name={id}
-                        className='hidden'
+                        className='sr-only'
                         checked={filter === opt.value}
                         onChange={() => onChange(opt.value)}
                     />

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Fragment, useId, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { getBackendServiceForClientside } from '../../../backendApi/backendService.ts';
@@ -53,19 +53,7 @@ function CollectionsOverviewInner({
                     </a>
                 )}
             </div>
-            <div className='join'>
-                {(['community', 'official', 'all'] as CollectionFilter[]).map((option) => (
-                    <input
-                        key={option}
-                        className='join-item btn btn-sm'
-                        type='radio'
-                        name='collection-filter'
-                        aria-label={option.charAt(0).toUpperCase() + option.slice(1)}
-                        checked={filter === option}
-                        onChange={() => setFilter(option)}
-                    />
-                ))}
-            </div>
+            <CollectionFilterSelect filter={filter} onChange={setFilter} />
             {isLoading ? (
                 <span className='loading loading-spinner loading-sm' />
             ) : isError ? (
@@ -84,7 +72,7 @@ function CollectionsOverviewInner({
                     )}
                 </div>
             ) : (
-                        <CollectionsTable collections={filteredCollections} organism={organism} />
+                <CollectionsTable collections={filteredCollections} organism={organism} />
             )}
         </div>
     );
@@ -104,6 +92,45 @@ function filterCollections(
         case 'all':
             return collections;
     }
+}
+
+const FILTER_OPTIONS: { value: CollectionFilter; label: string; tooltip: string }[] = [
+    { value: 'community', label: 'Community', tooltip: 'User submissions' },
+    { value: 'official', label: 'Official', tooltip: 'GenSpectrum curated' },
+    { value: 'all', label: 'All', tooltip: 'Show everything' },
+];
+
+function CollectionFilterSelect({
+    filter,
+    onChange,
+}: {
+    filter: CollectionFilter;
+    onChange: (f: CollectionFilter) => void;
+}) {
+    const id = useId();
+    return (
+        <div className='flex text-sm'>
+            {FILTER_OPTIONS.map((opt, i) => (
+                <Fragment key={opt.value}>
+                    <input
+                        type='radio'
+                        id={`${id}-${opt.value}`}
+                        name={id}
+                        className='hidden'
+                        checked={filter === opt.value}
+                        onChange={() => onChange(opt.value)}
+                    />
+                    <label
+                        htmlFor={`${id}-${opt.value}`}
+                        className={`tooltip w-24 cursor-pointer border p-2 text-center ${i === 0 ? 'rounded-l-md' : '-ml-px rounded-none'} ${i === FILTER_OPTIONS.length - 1 ? 'rounded-r-md' : ''} ${filter === opt.value ? 'border-primary relative z-10' : 'border-gray-300'}`}
+                        data-tip={opt.tooltip}
+                    >
+                        {opt.label}
+                    </label>
+                </Fragment>
+            ))}
+        </div>
+    );
 }
 
 function CollectionsTable({ collections, organism }: { collections: CollectionSummary[]; organism: Organism }) {

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -108,6 +108,10 @@ export function isStaging() {
     return getEnvironment() === 'dashboards-staging';
 }
 
+export function getSystemUserId(): number {
+    return isStaging() ? 1 : 3;
+}
+
 function getEnvironment() {
     return processEnvOrMetaEnv('DASHBOARDS_ENVIRONMENT', environmentSchema);
 }

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -108,6 +108,8 @@ export function isStaging() {
     return getEnvironment() === 'dashboards-staging';
 }
 
+/* The system user gets created first by the backend, so if we ever re-create the staging DB, it will be 1
+ * (and is 1 at the moment as well). On prod, the system user is ID 3. */
 export function getSystemUserId(): number {
     return isStaging() ? 1 : 3;
 }

--- a/website/src/pages/collections/[pathFragment]/index.astro
+++ b/website/src/pages/collections/[pathFragment]/index.astro
@@ -1,5 +1,6 @@
 ---
 import { CollectionsOverview } from '../../../components/collections/overview/CollectionsOverview';
+import { getSystemUserId } from '../../../config';
 import { defaultBreadcrumbs } from '../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { organismConfig, organismFromPathFragment } from '../../../types/Organism';
@@ -24,5 +25,5 @@ const isLoggedIn = Astro.locals.user !== undefined;
         { name: orgConfig.label, href: Page.collectionsForOrganism(organism) },
     ]}
 >
-    <CollectionsOverview client:load organism={organism} isLoggedIn={isLoggedIn} />
+    <CollectionsOverview client:load organism={organism} isLoggedIn={isLoggedIn} systemUserId={getSystemUserId()} />
 </ContaineredPageLayout>


### PR DESCRIPTION
Closes #1271

## Summary

- Adds a segmented control (`[ Community ] [ Official ] [ All ]`) to the collections overview page
- Filtering is done client-side based on `ownedBy`; "Community" is the default, preserving current behavior
- Adds `getSystemUserId()` to `config.ts` (returns `1` on staging, `3` on prod); called server-side in the Astro page and passed as a prop so it doesn't reach the browser

## Screenshot

https://github.com/user-attachments/assets/39cd0d35-3f16-43e7-b4b1-8a410834da90

## Test plan

- [x] Community filter shows only non-system-user collections
- [x] Official filter shows only system-user collections
- [x] All filter shows everything
- [x] Default on page load is Community
- [x] Browser spec passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)