### PR TITLE
chore(ci): name E2E upload artifact steps for clarity

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,14 +79,16 @@ jobs:
           docker compose -f ../docker-compose.yml logs --no-color "$service" > "/tmp/container-logs/${service}.log" || true
         done
 
-    - uses: actions/upload-artifact@v7
+    - name: Upload container logs
+      uses: actions/upload-artifact@v7
       if: ${{ always() && !cancelled() }}
       with:
         name: container-logs
         path: /tmp/container-logs/
         retention-days: 7
 
-    - uses: actions/upload-artifact@v7
+    - name: Upload Playwright report
+      uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: playwright-report


### PR DESCRIPTION
## Summary
- Adds `name:` fields to both `actions/upload-artifact` steps in the E2E workflow so they show up as "Upload container logs" and "Upload Playwright report" in the Actions UI instead of being unlabeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)