### PR TITLE
fix(collection-seeding): seed placeholder collections to fix CI collection IDs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,14 +79,16 @@ jobs:
           docker compose -f ../docker-compose.yml logs --no-color "$service" > "/tmp/container-logs/${service}.log" || true
         done
 
-    - uses: actions/upload-artifact@v7
+    - name: Upload container logs
+      uses: actions/upload-artifact@v7
       if: ${{ always() && !cancelled() }}
       with:
         name: container-logs
         path: /tmp/container-logs/
         retention-days: 7
 
-    - uses: actions/upload-artifact@v7
+    - name: Upload Playwright report
+      uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: playwright-report

--- a/collection-seeding/sources/placeholder.py
+++ b/collection-seeding/sources/placeholder.py
@@ -1,0 +1,17 @@
+from models import Collection
+from sources import Source
+
+
+class PlaceholderSource(Source):
+    """Three placeholder collections that occupy IDs 1-3 so that subsequently seeded
+    collections receive the IDs expected by hardcoded config (e.g. wastewaterConfig.ts)."""
+
+    name = "placeholder"
+    organism = "covid"
+    owned_tag = "#placeholder"
+
+    def get_collections(self) -> list[Collection]:
+        return [
+            {"name": f"Placeholder {i} #placeholder", "organism": "covid", "description": "", "variants": []}
+            for i in range(1, 4)
+        ]

--- a/collection-seeding/sources/registry.py
+++ b/collection-seeding/sources/registry.py
@@ -6,10 +6,12 @@ place that needs to change — seed.py discovers sources exclusively through thi
 
 from sources.covid_pango_lineages import CovidPangoLineagesSource, CovidPangoLineagesSampleSource
 from sources.covid_resistance_mutations import CovidResistanceMutationsSource
+from sources.placeholder import PlaceholderSource
 from sources.rsv_resistance_mutations import RsvAResistanceMutationsSource, RsvBResistanceMutationsSource
 from sources import Source
 
 ALL_SOURCES: list[type[Source]] = [
+    PlaceholderSource,
     CovidResistanceMutationsSource,
     RsvAResistanceMutationsSource,
     RsvBResistanceMutationsSource,


### PR DESCRIPTION
On fresh DBs, the IDs for the covid resistance mutations are not right, they'd be 1, 2, 3, but on staging and prod they are 4, 5, 6. This causes issues when running E2E tests in CI:

<img width="765" height="437" alt="image" src="https://github.com/user-attachments/assets/bbf3c2c8-bb18-4873-9aa0-0be75230d049" />


We can't change the staging IDs now, and we don't want to introduce yet another switch for different IDs when deploying locally to a fresh, empty DB. My idea is thus, to simply cause the same offset as we have on staging, by inserting placeholder collections.

It's a bit stupid, but it works.

Alternatively, I guess we _could_ wipe the staging DB once, and adjust the IDs in the config accordingly. Maybe that's the better option, actually.

## Summary

- COVID resistance mutation collections are hardcoded as IDs 4, 5, 6 in `wastewaterConfig.ts`
- On a fresh DB (e.g. CI), the seeder assigned them IDs 1, 2, 3 instead, causing the wrong collections to be referenced
- Adds a `PlaceholderSource` that seeds 3 dummy collections first, reserving IDs 1–3 so COVID resistance mutations land on 4, 5, 6 as expected

## Test plan

- [ ] Run collection seeder against a fresh DB and verify COVID resistance mutation collections receive IDs 4, 5, 6
- [ ] Verify CI wastewater dashboard shows correct resistance mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)