### PR TITLE
fix(website): correct staging collection IDs in wastewater config

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -34,7 +34,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
             defaultAnalysisMode: 'resistance',
             resistanceMutationCollections: [
                 {
-                    collectionId: 4,
+                    collectionId: isStaging ? 1 : 4,
                     name: '3CLpro',
                     annotationSymbol: 'c',
                     annotationMode: annotationMode.perVariant,
@@ -42,7 +42,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                         'SARS-CoV-2 3C-like protease (3CLpro, or Mpro for Main protease) inhibitor resistance mutation as per <a class="link" href="https://covdb.stanford.edu/drms">Stanford Coronavirus Antiviral & Resistance database</a> (last updated on 21 August 2024).',
                 },
                 {
-                    collectionId: 5,
+                    collectionId: isStaging ? 2 : 5,
                     name: 'RdRp',
                     annotationSymbol: 'r',
                     annotationMode: annotationMode.perVariant,
@@ -50,7 +50,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                         'SARS-CoV-2 RNA-dependent RNA polymerase (RdRP) inhibitor resistance mutation as per <a class="link" href="https://covdb.stanford.edu/drms">Stanford Coronavirus Antiviral & Resistance database</a> (last updated on 21 August 2024).',
                 },
                 {
-                    collectionId: 6,
+                    collectionId: isStaging ? 3 : 6,
                     name: 'Spike',
                     annotationSymbol: 's',
                     annotationMode: annotationMode.perVariant,
@@ -93,7 +93,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                     minCount: 15,
                     minJaccard: 0.75,
                     timeFrame: VARIANT_TIME_FRAME.all,
-                    collectionId: isStaging ? 4961 : 4943, // XFG lineage
+                    collectionId: isStaging ? 4944 : 4943, // XFG lineage
                 },
                 resistance: {
                     mode: 'resistance',
@@ -139,7 +139,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
             clinicalSequenceCountWarningThreshold: 50,
             resistanceMutationCollections: [
                 {
-                    collectionId: isStaging ? 5001 : 4983,
+                    collectionId: isStaging ? 4 : 4983,
                     name: 'Nirsevimab',
                     annotationSymbol: 'n',
                     annotationMode: annotationMode.perCollection,
@@ -147,7 +147,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                         'RSV-A F protein resistance mutations against Nirsevimab as per <a class="link" href="https://viralzone.expasy.org/11605">ViralZone</a>.',
                 },
                 {
-                    collectionId: isStaging ? 5002 : 4984,
+                    collectionId: isStaging ? 5 : 4984,
                     name: 'Palivizumab',
                     annotationSymbol: 'p',
                     annotationMode: annotationMode.perCollection,
@@ -206,7 +206,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
             clinicalSequenceCountWarningThreshold: 50,
             resistanceMutationCollections: [
                 {
-                    collectionId: isStaging ? 5003 : 4985,
+                    collectionId: isStaging ? 6 : 4985,
                     name: 'Nirsevimab',
                     annotationSymbol: 'n',
                     annotationMode: annotationMode.perCollection,
@@ -214,7 +214,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                         'RSV-B F protein resistance mutations against Nirsevimab as per <a class="link" href="https://viralzone.expasy.org/11605">ViralZone</a>.',
                 },
                 {
-                    collectionId: isStaging ? 5004 : 4986,
+                    collectionId: isStaging ? 7 : 4986,
                     name: 'Palivizumab',
                     annotationSymbol: 'p',
                     annotationMode: annotationMode.perCollection,


### PR DESCRIPTION
## Summary

The staging DB was recently reset, which caused all collection IDs to shift. RSV resistance mutation collections ended up with low IDs (4–7, owned by user 1), while COVID resistance collections landed at 1–3. The previous config assumed staging mirrored prod's high RSV IDs (5001–5004, which now return 404) and that IDs 4/5/6 were COVID — both were wrong, causing staging to load the wrong collections entirely.

Also fixes the XFG variant filter default: `4961` was pointing to "XFK" on staging — the correct XFG ID on staging is `4944`.

## Collection ID changes

| Purpose | Prod ID | Staging ID (old) | Staging ID (new) |
|---|---|---|---|
| COVID 3CLpro | [4](https://genspectrum.org/api/collections/4) | `4` (was RSV-A Nirsevimab!) | [1](https://staging.genspectrum.org/api/collections/1) |
| COVID RdRp | [5](https://genspectrum.org/api/collections/5) | `5` (was RSV-A Palivizumab!) | [2](https://staging.genspectrum.org/api/collections/2) |
| COVID Spike mAb | [6](https://genspectrum.org/api/collections/6) | `6` (was RSV-B Nirsevimab!) | [3](https://staging.genspectrum.org/api/collections/3) |
| RSV-A Nirsevimab | [4983](https://genspectrum.org/api/collections/4983) | `5001` (404) | [4](https://staging.genspectrum.org/api/collections/4) |
| RSV-A Palivizumab | [4984](https://genspectrum.org/api/collections/4984) | `5002` (404) | [5](https://staging.genspectrum.org/api/collections/5) |
| RSV-B Nirsevimab | [4985](https://genspectrum.org/api/collections/4985) | `5003` (404) | [6](https://staging.genspectrum.org/api/collections/6) |
| RSV-B Palivizumab | [4986](https://genspectrum.org/api/collections/4986) | `5004` (404) | [7](https://staging.genspectrum.org/api/collections/7) |
| COVID variant filter (XFG) | [4943](https://genspectrum.org/api/collections/4943) | `4961` (was XFK!) | [4944](https://staging.genspectrum.org/api/collections/4944) |

## Test plan

- [ ] E2E test action passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)