### PR TITLE
feat(website): add RSV-A/B Nextclade lineage selection to W-ASAP variant explorer

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -126,7 +126,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
             samplingDateField: 'samplingDate',
             locationNameField: 'locationName',
             predefinedVariantsSource: {
-                collectionsUserId: 1,
+                collectionsUserId: isStaging ? 1 : 3,
                 collectionsTag: '#nextclade-lineage',
                 variantSourceLabel: 'Nextclade',
             },
@@ -197,7 +197,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
             samplingDateField: 'samplingDate',
             locationNameField: 'locationName',
             predefinedVariantsSource: {
-                collectionsUserId: 1,
+                collectionsUserId: isStaging ? 1 : 3,
                 collectionsTag: '#nextclade-lineage',
                 variantSourceLabel: 'Nextclade',
             },

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -5,8 +5,8 @@ import { VARIANT_TIME_FRAME, type WasapPageConfig } from '../components/views/wa
 
 export const wastewaterOrganisms = {
     covid: 'covid',
-    rsvA: 'rsv-a',
-    rsvB: 'rsv-b',
+    rsvA: 'rsvA',
+    rsvB: 'rsvB',
 } as const;
 
 export type WastewaterOrganismName = (typeof wastewaterOrganisms)[keyof typeof wastewaterOrganisms];
@@ -125,6 +125,11 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
             lapisBaseUrl: 'https://lapis.wasap.genspectrum.org/rsva',
             samplingDateField: 'samplingDate',
             locationNameField: 'locationName',
+            predefinedVariantsSource: {
+                collectionsUserId: 1,
+                collectionsTag: '#nextclade-lineage',
+                variantSourceLabel: 'Nextclade',
+            },
             clinicalLapis: {
                 lapisBaseUrl: 'https://lapis.pathoplexus.org/rsv-a',
                 dateField: 'sampleCollectionDateRangeLower',
@@ -165,6 +170,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                     minCount: 15,
                     minJaccard: 0.75,
                     timeFrame: VARIANT_TIME_FRAME.all,
+                    collectionId: isStaging ? 4997 : undefined,
                 },
                 resistance: {
                     mode: 'resistance',
@@ -190,6 +196,11 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
             lapisBaseUrl: 'https://lapis.wasap.genspectrum.org/rsvb',
             samplingDateField: 'samplingDate',
             locationNameField: 'locationName',
+            predefinedVariantsSource: {
+                collectionsUserId: 1,
+                collectionsTag: '#nextclade-lineage',
+                variantSourceLabel: 'Nextclade',
+            },
             clinicalLapis: {
                 lapisBaseUrl: 'https://lapis.pathoplexus.org/rsv-b',
                 dateField: 'sampleCollectionDateRangeLower',
@@ -230,6 +241,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                     minCount: 15,
                     minJaccard: 0.75,
                     timeFrame: VARIANT_TIME_FRAME.all,
+                    collectionId: isStaging ? 5050 : undefined,
                 },
                 resistance: {
                     mode: 'resistance',


### PR DESCRIPTION
## Summary

- Adds `predefinedVariantsSource` to the RSV-A and RSV-B W-ASAP configs, pointing at the Nextclade lineage collections already seeded into the backend (tagged `#nextclade-lineage`)
- Renames `wastewaterOrganisms.rsvA/rsvB` from `'rsv-a'/'rsv-b'` to `'rsvA'/'rsvB'` so `internalName` matches the backend organism key used by the collections API — removes the need for any organism name override

Users can now select an RSV-A or RSV-B Nextclade lineage from the "Predefined" tab in the Variant Explorer mode, the same way COVID Pango lineages are selectable.

## Test plan

- [x] Open `/swiss-wastewater/rsv-a`, switch to Variant → Predefined — dropdown of Nextclade lineage names (e.g. A.D.3, A.D.5.2) appears
- [x] Select a lineage and confirm the chart updates with the mutation signature
- [x] Same for `/swiss-wastewater/rsv-b`
- [x] `/swiss-wastewater/covid` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)