### PR TITLE
fix(website): set production collection IDs for RSV-A/B variant filter defaults

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -170,7 +170,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                     minCount: 15,
                     minJaccard: 0.75,
                     timeFrame: VARIANT_TIME_FRAME.all,
-                    collectionId: isStaging ? 4997 : undefined,
+                    collectionId: isStaging ? 4997 : 5000,
                 },
                 resistance: {
                     mode: 'resistance',
@@ -241,7 +241,7 @@ function buildWastewaterOrganismConfigs(isStaging: boolean): Record<WastewaterOr
                     minCount: 15,
                     minJaccard: 0.75,
                     timeFrame: VARIANT_TIME_FRAME.all,
-                    collectionId: isStaging ? 5050 : undefined,
+                    collectionId: isStaging ? 5050 : 5053,
                 },
                 resistance: {
                     mode: 'resistance',


### PR DESCRIPTION
## Summary
- RSV-A `filterDefaults.variant.collectionId` was `undefined` in production — set to 5000 (A.D.1 lineage)
- RSV-B `filterDefaults.variant.collectionId` was `undefined` in production — set to 5053 (B.D.E.1 lineage)

I forgot to set these earlier

🤖 Generated with [Claude Code](https://claude.com/claude-code)