### PR TITLE
fix(website): replace isStaging conditionals with byEnv in RSV-A/B wastewater config

### DIFF
--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -138,7 +138,7 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
             samplingDateField: 'samplingDate',
             locationNameField: 'locationName',
             predefinedVariantsSource: {
-                collectionsUserId: isStaging ? 1 : 3,
+                collectionsUserId: byEnv(env, { prod: 3, staging: 1, local: 1 }),
                 collectionsTag: '#nextclade-lineage',
                 variantSourceLabel: 'Nextclade',
             },
@@ -182,7 +182,7 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
                     minCount: 15,
                     minJaccard: 0.75,
                     timeFrame: VARIANT_TIME_FRAME.all,
-                    collectionId: isStaging ? 4997 : 5000,
+                    collectionId: byEnv(env, { prod: 5000, staging: 4997, local: 21 }),
                 },
                 resistance: {
                     mode: 'resistance',
@@ -209,7 +209,7 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
             samplingDateField: 'samplingDate',
             locationNameField: 'locationName',
             predefinedVariantsSource: {
-                collectionsUserId: isStaging ? 1 : 3,
+                collectionsUserId: byEnv(env, { prod: 3, staging: 1, local: 1 }),
                 collectionsTag: '#nextclade-lineage',
                 variantSourceLabel: 'Nextclade',
             },
@@ -253,7 +253,7 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
                     minCount: 15,
                     minJaccard: 0.75,
                     timeFrame: VARIANT_TIME_FRAME.all,
-                    collectionId: isStaging ? 5050 : 5053,
+                    collectionId: byEnv(env, { prod: 5053, staging: 5050, local: 74 }),
                 },
                 resistance: {
                     mode: 'resistance',


### PR DESCRIPTION
## Summary

- Replaces leftover `isStaging ? X : Y` conditionals in `wastewaterConfig.ts` that were introduced as a rebase artifact
- Converts them to `byEnv(env, { prod, staging, local })` calls consistent with the rest of the file
- Affects `collectionsUserId` (RSV-A, RSV-B) and variant filter `collectionId` (RSV-A: local=21, RSV-B: local=74)

## Test plan

- [ ] TypeScript build passes without `Cannot find name 'isStaging'` errors
- [ ] RSV-A and RSV-B wastewater pages load correctly on staging and production

🤖 Generated with [Claude Code](https://claude.com/claude-code)