### PR TITLE
feat(dashboards): tags on collections

### DIFF
--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -231,6 +231,12 @@ export class BackendRouteMocker {
             }),
         );
     }
+
+    mockGetCollectionTags(tags: string[] = [], statusCode = 200) {
+        this.workerOrServer.use(
+            http.get(`${DUMMY_BACKEND_URL}/collections/tags`, resolver([{ statusCode, response: { tags } }])),
+        );
+    }
 }
 
 function resolver(cases: MockCase[]) {

--- a/website/routeMocker.ts
+++ b/website/routeMocker.ts
@@ -30,6 +30,12 @@ export class AstroApiRouteMocker {
         this.workerOrServer.use(http.post(`${ASTRO_SERVER_URL}/log`, () => Response.json({})));
     }
 
+    mockGetCollectionTags(tags: string[] = [], statusCode = 200) {
+        this.workerOrServer.use(
+            http.get(`${ASTRO_SERVER_URL}/collections/tags`, resolver([{ statusCode, response: { tags } }])),
+        );
+    }
+
     mockGetCollectionSummaries(
         response: CollectionSummary[],
         organism?: string,

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -244,6 +244,13 @@ export class BackendService extends ApiService {
             schema: z.literal('').refine((_input): _input is never => true),
         });
     }
+
+    public async getCollectionTags() {
+        return this.get({
+            url: '/collections/tags',
+            schema: z.object({ tags: z.array(z.string()) }),
+        });
+    }
 }
 
 let backendServiceForClientside: BackendService | null = null;

--- a/website/src/components/collections/TagChip.tsx
+++ b/website/src/components/collections/TagChip.tsx
@@ -1,0 +1,20 @@
+export function TagChip({ tag, onRemove }: { tag: string; onRemove?: (tag: string) => void }) {
+    return (
+        <span className='border-l-primary flex items-center gap-1 rounded border border-l-4 border-gray-300 bg-gray-100 px-2 py-0.5 text-xs text-gray-700'>
+            {tag}
+            {onRemove !== undefined && (
+                <button
+                    type='button'
+                    aria-label={`Remove tag ${tag}`}
+                    className='hover:text-gray-500'
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onRemove(tag);
+                    }}
+                >
+                    ×
+                </button>
+            )}
+        </span>
+    );
+}

--- a/website/src/components/collections/create/CollectionCreate.tsx
+++ b/website/src/components/collections/create/CollectionCreate.tsx
@@ -21,6 +21,7 @@ function CollectionCreateInner({ organism, config }: { organism: Organism; confi
                     name: values.name,
                     organism,
                     description: values.description || undefined,
+                    tags: values.tags,
                     variants: values.variants,
                 },
             }),

--- a/website/src/components/collections/detail/CollectionDetail.tsx
+++ b/website/src/components/collections/detail/CollectionDetail.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../types/Collection.ts';
 import { organismConfig, type Organism } from '../../../types/Organism.ts';
 import { Page } from '../../../types/pages.ts';
+import { TagChip } from '../TagChip.tsx';
 
 type LapisConfig = {
     url: string;
@@ -57,7 +58,14 @@ function CollectionDetailInner({
                     )}
                 </div>
                 {collection.description !== null && <p className='mt-1 text-gray-500'>{collection.description}</p>}
-                <p className='mt-1 text-sm text-gray-500'>
+                {collection.tags.length > 0 && (
+                    <div className='mt-2 flex flex-wrap gap-1'>
+                        {collection.tags.map((tag) => (
+                            <TagChip key={tag} tag={tag} />
+                        ))}
+                    </div>
+                )}
+                <p className='mt-2 text-sm text-gray-500'>
                     {organismName} collection owned by {ownerName}
                 </p>
             </div>

--- a/website/src/components/collections/edit/CollectionEdit.tsx
+++ b/website/src/components/collections/edit/CollectionEdit.tsx
@@ -33,6 +33,7 @@ function CollectionEditInner({
                 collection: {
                     name: values.name,
                     description: values.description,
+                    tags: values.tags,
                     variants: values.variants,
                 },
             }),
@@ -47,6 +48,7 @@ function CollectionEditInner({
     const initialValues: CollectionFormValues = {
         name: collection.name,
         description: collection.description ?? '',
+        tags: collection.tags,
         variants: collection.variants.map((v): VariantUpdate => {
             if (v.type === 'query') {
                 return {

--- a/website/src/components/collections/form/CollectionForm.browser.spec.tsx
+++ b/website/src/components/collections/form/CollectionForm.browser.spec.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
@@ -30,6 +31,7 @@ const DEFAULT_PROPS = {
 const INITIAL_VALUES = {
     name: 'My collection',
     description: 'A description',
+    tags: ['flu', 'europe'],
     variants: [{ type: 'filterObject' as const, name: 'Variant 1', filterObject: {} } satisfies VariantUpdate],
 };
 
@@ -69,6 +71,36 @@ describe('CollectionForm', () => {
         await expect.element(getByRole('checkbox', { name: 'Use advanced query instead' })).not.toBeChecked();
     });
 
+    it('shows existing tags as chips when initialValues has tags', async ({ routeMockers: { lapis } }) => {
+        lapis.mockLapisDown();
+
+        const { getByText } = render(<CollectionForm {...DEFAULT_PROPS} initialValues={INITIAL_VALUES} />);
+
+        await expect.element(getByText('flu')).toBeVisible();
+        await expect.element(getByText('europe')).toBeVisible();
+    });
+
+    it('adds a tag on Enter and includes it in onSubmit', async ({ routeMockers: { lapis } }) => {
+        lapis.mockLapisDown();
+
+        const onSubmit = vi.fn();
+
+        const { getByRole, getByPlaceholder } = render(
+            <CollectionForm {...DEFAULT_PROPS} onSubmit={onSubmit} submitLabel='Create collection' />,
+        );
+
+        await getByPlaceholder('A name to identify this collection.').fill('Test name');
+        await getByPlaceholder('Add tags (Enter, comma, or space to confirm)').fill('influenza');
+        await userEvent.keyboard('{Enter}');
+        await getByRole('button', { name: 'Create collection' }).click();
+
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tags: ['influenza'],
+            }),
+        );
+    });
+
     it('calls onSubmit with the correct values when the form is submitted', async ({ routeMockers: { lapis } }) => {
         lapis.mockLapisDown();
 
@@ -85,6 +117,7 @@ describe('CollectionForm', () => {
             expect.objectContaining({
                 name: 'Test name',
                 description: '',
+                tags: [],
             }),
         );
     });

--- a/website/src/components/collections/form/CollectionForm.browser.spec.tsx
+++ b/website/src/components/collections/form/CollectionForm.browser.spec.tsx
@@ -4,7 +4,7 @@ import { render } from 'vitest-browser-react';
 
 import { CollectionForm } from './CollectionForm.tsx';
 import { testOrganismsConfig } from '../../../../routeMocker.ts';
-import { backendRouteMocker, it } from '../../../../test-extend.ts';
+import { astroApiRouteMocker, it } from '../../../../test-extend.ts';
 import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
 import type { DashboardsConfig } from '../../../config.ts';
 import type { VariantUpdate } from '../../../types/Collection.ts';
@@ -39,7 +39,7 @@ const INITIAL_VALUES = {
 };
 
 beforeEach(() => {
-    backendRouteMocker.mockGetCollectionTags();
+    astroApiRouteMocker.mockGetCollectionTags();
 });
 
 describe('CollectionForm', () => {

--- a/website/src/components/collections/form/CollectionForm.browser.spec.tsx
+++ b/website/src/components/collections/form/CollectionForm.browser.spec.tsx
@@ -1,10 +1,10 @@
 import { userEvent } from '@vitest/browser/context';
-import { describe, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { CollectionForm } from './CollectionForm.tsx';
 import { testOrganismsConfig } from '../../../../routeMocker.ts';
-import { it } from '../../../../test-extend.ts';
+import { backendRouteMocker, it } from '../../../../test-extend.ts';
 import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
 import type { DashboardsConfig } from '../../../config.ts';
 import type { VariantUpdate } from '../../../types/Collection.ts';
@@ -37,6 +37,10 @@ const INITIAL_VALUES = {
     tags: ['flu', 'europe'],
     variants: [{ type: 'filterObject' as const, name: 'Variant 1', filterObject: {} } satisfies VariantUpdate],
 };
+
+beforeEach(() => {
+    backendRouteMocker.mockGetCollectionTags();
+});
 
 describe('CollectionForm', () => {
     it('shows "New collection" heading when no initialValues are provided', async ({ routeMockers: { lapis } }) => {

--- a/website/src/components/collections/form/CollectionForm.browser.spec.tsx
+++ b/website/src/components/collections/form/CollectionForm.browser.spec.tsx
@@ -5,9 +5,12 @@ import { render } from 'vitest-browser-react';
 import { CollectionForm } from './CollectionForm.tsx';
 import { testOrganismsConfig } from '../../../../routeMocker.ts';
 import { it } from '../../../../test-extend.ts';
+import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
 import type { DashboardsConfig } from '../../../config.ts';
 import type { VariantUpdate } from '../../../types/Collection.ts';
 import { Organisms } from '../../../types/Organism.ts';
+
+const CollectionFormWithProvider = withQueryProvider(CollectionForm);
 
 const ORGANISM = Organisms.covid;
 
@@ -39,7 +42,7 @@ describe('CollectionForm', () => {
     it('shows "New collection" heading when no initialValues are provided', async ({ routeMockers: { lapis } }) => {
         lapis.mockLapisDown();
 
-        const { getByRole } = render(<CollectionForm {...DEFAULT_PROPS} />);
+        const { getByRole } = render(<CollectionFormWithProvider {...DEFAULT_PROPS} />);
 
         await expect.element(getByRole('heading', { level: 1 })).toHaveTextContent('New collection');
     });
@@ -47,7 +50,7 @@ describe('CollectionForm', () => {
     it('shows "Edit collection" heading when initialValues are provided', async ({ routeMockers: { lapis } }) => {
         lapis.mockLapisDown();
 
-        const { getByRole } = render(<CollectionForm {...DEFAULT_PROPS} initialValues={INITIAL_VALUES} />);
+        const { getByRole } = render(<CollectionFormWithProvider {...DEFAULT_PROPS} initialValues={INITIAL_VALUES} />);
 
         await expect.element(getByRole('heading', { level: 1 })).toHaveTextContent('Edit collection');
     });
@@ -55,7 +58,7 @@ describe('CollectionForm', () => {
     it('"Add variant" button adds a new variant row', async ({ routeMockers: { lapis } }) => {
         lapis.mockLapisDown();
 
-        const { getByRole } = render(<CollectionForm {...DEFAULT_PROPS} />);
+        const { getByRole } = render(<CollectionFormWithProvider {...DEFAULT_PROPS} />);
 
         await getByRole('button', { name: 'Add variant' }).click();
 
@@ -66,7 +69,7 @@ describe('CollectionForm', () => {
     it('default variant has "Use advanced query" unchecked', async ({ routeMockers: { lapis } }) => {
         lapis.mockLapisDown();
 
-        const { getByRole } = render(<CollectionForm {...DEFAULT_PROPS} />);
+        const { getByRole } = render(<CollectionFormWithProvider {...DEFAULT_PROPS} />);
 
         await expect.element(getByRole('checkbox', { name: 'Use advanced query instead' })).not.toBeChecked();
     });
@@ -74,7 +77,7 @@ describe('CollectionForm', () => {
     it('shows existing tags as chips when initialValues has tags', async ({ routeMockers: { lapis } }) => {
         lapis.mockLapisDown();
 
-        const { getByText } = render(<CollectionForm {...DEFAULT_PROPS} initialValues={INITIAL_VALUES} />);
+        const { getByText } = render(<CollectionFormWithProvider {...DEFAULT_PROPS} initialValues={INITIAL_VALUES} />);
 
         await expect.element(getByText('flu')).toBeVisible();
         await expect.element(getByText('europe')).toBeVisible();
@@ -86,7 +89,7 @@ describe('CollectionForm', () => {
         const onSubmit = vi.fn();
 
         const { getByRole, getByPlaceholder } = render(
-            <CollectionForm {...DEFAULT_PROPS} onSubmit={onSubmit} submitLabel='Create collection' />,
+            <CollectionFormWithProvider {...DEFAULT_PROPS} onSubmit={onSubmit} submitLabel='Create collection' />,
         );
 
         await getByPlaceholder('A name to identify this collection.').fill('Test name');
@@ -107,7 +110,7 @@ describe('CollectionForm', () => {
         const onSubmit = vi.fn();
 
         const { getByRole, getByPlaceholder } = render(
-            <CollectionForm {...DEFAULT_PROPS} onSubmit={onSubmit} submitLabel='Create collection' />,
+            <CollectionFormWithProvider {...DEFAULT_PROPS} onSubmit={onSubmit} submitLabel='Create collection' />,
         );
 
         await getByPlaceholder('A name to identify this collection.').fill('Test name');

--- a/website/src/components/collections/form/CollectionForm.browser.spec.tsx
+++ b/website/src/components/collections/form/CollectionForm.browser.spec.tsx
@@ -108,6 +108,25 @@ describe('CollectionForm', () => {
         );
     });
 
+    it('removes a tag and excludes it from onSubmit', async ({ routeMockers: { lapis } }) => {
+        lapis.mockLapisDown();
+
+        const onSubmit = vi.fn();
+
+        const { getByRole } = render(
+            <CollectionFormWithProvider {...DEFAULT_PROPS} onSubmit={onSubmit} initialValues={INITIAL_VALUES} />,
+        );
+
+        await getByRole('button', { name: 'Remove tag flu' }).click();
+        await getByRole('button', { name: 'Create collection' }).click();
+
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tags: ['europe'],
+            }),
+        );
+    });
+
     it('calls onSubmit with the correct values when the form is submitted', async ({ routeMockers: { lapis } }) => {
         lapis.mockLapisDown();
 

--- a/website/src/components/collections/form/CollectionForm.tsx
+++ b/website/src/components/collections/form/CollectionForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { TagInput } from './TagInput.tsx';
 import { VariantEditor } from './VariantEditor.tsx';
 import type { DashboardsConfig } from '../../../config.ts';
 import type { VariantUpdate } from '../../../types/Collection.ts';
@@ -9,6 +10,7 @@ import { GsApp } from '../../genspectrum/GsApp.tsx';
 export type CollectionFormValues = {
     name: string;
     description: string;
+    tags: string[];
     variants: VariantUpdate[];
 };
 
@@ -44,6 +46,7 @@ export function CollectionForm({
     const lineageFields = config.dashboards.organisms[organism].lapis.lineageFields ?? [];
     const [name, setName] = useState(initialValues?.name ?? '');
     const [description, setDescription] = useState(initialValues?.description ?? '');
+    const [tags, setTags] = useState<string[]>(initialValues?.tags ?? []);
     const [variants, setVariants] = useState<VariantWithKey[]>(() =>
         (initialValues?.variants ?? [{ type: 'filterObject' as const, name: 'Variant 1', filterObject: {} }]).map(
             withKey,
@@ -94,6 +97,10 @@ export function CollectionForm({
                                 onChange={(e) => setDescription(e.currentTarget.value)}
                             />
                         </div>
+                        <div>
+                            <label className='label'>Tags</label>
+                            <TagInput tags={tags} onChange={setTags} />
+                        </div>
                     </div>
                 </div>
 
@@ -134,6 +141,7 @@ export function CollectionForm({
                         onSubmit({
                             name,
                             description,
+                            tags,
                             variants: variants.map(({ clientKey: _key, ...v }) => v),
                         })
                     }

--- a/website/src/components/collections/form/TagInput.browser.spec.tsx
+++ b/website/src/components/collections/form/TagInput.browser.spec.tsx
@@ -1,9 +1,10 @@
 import { userEvent } from '@vitest/browser/context';
+import { useState } from 'react';
 import { beforeEach, describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { TagInput } from './TagInput.tsx';
-import { backendRouteMocker, it } from '../../../../test-extend.ts';
+import { astroApiRouteMocker, backendRouteMocker, it } from '../../../../test-extend.ts';
 import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
 
 const TagInputWithProvider = withQueryProvider(TagInput);
@@ -99,5 +100,45 @@ describe('TagInput', () => {
         await userEvent.keyboard('{Backspace}');
 
         expect(onChange).toHaveBeenCalledWith(['flu']);
+    });
+
+    it('can re-add a tag after removing it', async () => {
+        function StatefulTagInput() {
+            const [tags, setTags] = useState<string[]>([]);
+            return <TagInputWithProvider tags={tags} onChange={setTags} />;
+        }
+
+        const { getByPlaceholder, getByRole } = render(<StatefulTagInput />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('foo');
+        await userEvent.keyboard('{Enter}');
+
+        await getByRole('button', { name: 'Remove tag foo' }).click();
+
+        await getByPlaceholder(PLACEHOLDER).fill('foo');
+        await userEvent.keyboard('{Enter}');
+
+        await expect.element(getByRole('button', { name: 'Remove tag foo' })).toBeVisible();
+    });
+
+    it('can re-add a tag that was selected via autocomplete after removing it', async () => {
+        astroApiRouteMocker.mockGetCollectionTags(['flu']);
+
+        function StatefulTagInput() {
+            const [tags, setTags] = useState<string[]>([]);
+            return <TagInputWithProvider tags={tags} onChange={setTags} />;
+        }
+
+        const { getByPlaceholder, getByRole } = render(<StatefulTagInput />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('flu');
+        await getByRole('option', { name: 'flu' }).click();
+
+        await getByRole('button', { name: 'Remove tag flu' }).click();
+
+        await getByPlaceholder(PLACEHOLDER).fill('flu');
+        await getByRole('option', { name: 'flu' }).click();
+
+        await expect.element(getByRole('button', { name: 'Remove tag flu' })).toBeVisible();
     });
 });

--- a/website/src/components/collections/form/TagInput.browser.spec.tsx
+++ b/website/src/components/collections/form/TagInput.browser.spec.tsx
@@ -1,14 +1,18 @@
 import { userEvent } from '@vitest/browser/context';
-import { describe, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { TagInput } from './TagInput.tsx';
-import { it } from '../../../../test-extend.ts';
+import { backendRouteMocker, it } from '../../../../test-extend.ts';
 import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
 
 const TagInputWithProvider = withQueryProvider(TagInput);
 
 const PLACEHOLDER = 'Add tags (Enter, comma, or space to confirm)';
+
+beforeEach(() => {
+    backendRouteMocker.mockGetCollectionTags();
+});
 
 describe('TagInput', () => {
     it('renders existing tags', async () => {

--- a/website/src/components/collections/form/TagInput.browser.spec.tsx
+++ b/website/src/components/collections/form/TagInput.browser.spec.tsx
@@ -102,6 +102,24 @@ describe('TagInput', () => {
         expect(onChange).toHaveBeenCalledWith(['flu']);
     });
 
+    it('adds multiple tags from a comma-separated fill', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={[]} onChange={onChange} />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('a,b,c');
+
+        expect(onChange).toHaveBeenCalledWith(['a', 'b', 'c']);
+    });
+
+    it('deduplicates tags within a single fill', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={[]} onChange={onChange} />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('flu flu');
+
+        expect(onChange).toHaveBeenCalledWith(['flu']);
+    });
+
     it('can re-add a tag after removing it', async () => {
         function StatefulTagInput() {
             const [tags, setTags] = useState<string[]>([]);

--- a/website/src/components/collections/form/TagInput.browser.spec.tsx
+++ b/website/src/components/collections/form/TagInput.browser.spec.tsx
@@ -75,26 +75,6 @@ describe('TagInput', () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
-    it('splits pasted text on whitespace into multiple tags', async () => {
-        const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
-
-        await userEvent.click(getByPlaceholder(PLACEHOLDER));
-        await userEvent.paste('flu covid rsv');
-
-        expect(onChange).toHaveBeenCalledWith(['flu', 'covid', 'rsv']);
-    });
-
-    it('splits pasted text on commas into multiple tags', async () => {
-        const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
-
-        await userEvent.click(getByPlaceholder(PLACEHOLDER));
-        await userEvent.paste('flu,covid,rsv');
-
-        expect(onChange).toHaveBeenCalledWith(['flu', 'covid', 'rsv']);
-    });
-
     it('removes a tag when the remove button is clicked', async () => {
         const onChange = vi.fn();
         const { getByRole } = render(<TagInput tags={['flu', 'covid']} onChange={onChange} />);

--- a/website/src/components/collections/form/TagInput.browser.spec.tsx
+++ b/website/src/components/collections/form/TagInput.browser.spec.tsx
@@ -1,0 +1,116 @@
+import { userEvent } from '@vitest/browser/context';
+import { describe, expect, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+import { TagInput } from './TagInput.tsx';
+import { it } from '../../../../test-extend.ts';
+
+const PLACEHOLDER = 'Add tags (Enter, comma, or space to confirm)';
+
+describe('TagInput', () => {
+    it('renders existing tags', async () => {
+        const { getByText } = render(<TagInput tags={['flu', 'europe']} onChange={vi.fn()} />);
+
+        await expect.element(getByText('flu')).toBeVisible();
+        await expect.element(getByText('europe')).toBeVisible();
+    });
+
+    it('adds a tag on Enter', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('influenza');
+        await userEvent.keyboard('{Enter}');
+
+        expect(onChange).toHaveBeenCalledWith(['influenza']);
+    });
+
+    it('adds a tag on comma', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('influenza');
+        await userEvent.keyboard(',');
+
+        expect(onChange).toHaveBeenCalledWith(['influenza']);
+    });
+
+    it('adds a tag on space', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('influenza');
+        await userEvent.keyboard(' ');
+
+        expect(onChange).toHaveBeenCalledWith(['influenza']);
+    });
+
+    it('adds a tag on blur', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('influenza');
+        await userEvent.tab();
+
+        expect(onChange).toHaveBeenCalledWith(['influenza']);
+    });
+
+    it('lowercases tags', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+
+        await getByPlaceholder(PLACEHOLDER).fill('Influenza');
+        await userEvent.keyboard('{Enter}');
+
+        expect(onChange).toHaveBeenCalledWith(['influenza']);
+    });
+
+    it('does not add duplicate tags', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={['flu']} onChange={onChange} />);
+
+        await getByPlaceholder('').fill('flu');
+        await userEvent.keyboard('{Enter}');
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('splits pasted text on whitespace into multiple tags', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+
+        await userEvent.click(getByPlaceholder(PLACEHOLDER));
+        await userEvent.paste('flu covid rsv');
+
+        expect(onChange).toHaveBeenCalledWith(['flu', 'covid', 'rsv']);
+    });
+
+    it('splits pasted text on commas into multiple tags', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+
+        await userEvent.click(getByPlaceholder(PLACEHOLDER));
+        await userEvent.paste('flu,covid,rsv');
+
+        expect(onChange).toHaveBeenCalledWith(['flu', 'covid', 'rsv']);
+    });
+
+    it('removes a tag when the remove button is clicked', async () => {
+        const onChange = vi.fn();
+        const { getByRole } = render(<TagInput tags={['flu', 'covid']} onChange={onChange} />);
+
+        await getByRole('button', { name: 'Remove tag flu' }).click();
+
+        expect(onChange).toHaveBeenCalledWith(['covid']);
+    });
+
+    it('removes the last tag on Backspace when the input is empty', async () => {
+        const onChange = vi.fn();
+        const { getByPlaceholder } = render(<TagInput tags={['flu', 'covid']} onChange={onChange} />);
+
+        await userEvent.click(getByPlaceholder(''));
+        await userEvent.keyboard('{Backspace}');
+
+        expect(onChange).toHaveBeenCalledWith(['flu']);
+    });
+});

--- a/website/src/components/collections/form/TagInput.browser.spec.tsx
+++ b/website/src/components/collections/form/TagInput.browser.spec.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { TagInput } from './TagInput.tsx';
-import { astroApiRouteMocker, backendRouteMocker, it } from '../../../../test-extend.ts';
+import { astroApiRouteMocker, it } from '../../../../test-extend.ts';
 import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
 
 const TagInputWithProvider = withQueryProvider(TagInput);
@@ -12,7 +12,7 @@ const TagInputWithProvider = withQueryProvider(TagInput);
 const PLACEHOLDER = 'Add tags (Enter, comma, or space to confirm)';
 
 beforeEach(() => {
-    backendRouteMocker.mockGetCollectionTags();
+    astroApiRouteMocker.mockGetCollectionTags();
 });
 
 describe('TagInput', () => {

--- a/website/src/components/collections/form/TagInput.browser.spec.tsx
+++ b/website/src/components/collections/form/TagInput.browser.spec.tsx
@@ -4,12 +4,15 @@ import { render } from 'vitest-browser-react';
 
 import { TagInput } from './TagInput.tsx';
 import { it } from '../../../../test-extend.ts';
+import { withQueryProvider } from '../../../backendApi/withQueryProvider.tsx';
+
+const TagInputWithProvider = withQueryProvider(TagInput);
 
 const PLACEHOLDER = 'Add tags (Enter, comma, or space to confirm)';
 
 describe('TagInput', () => {
     it('renders existing tags', async () => {
-        const { getByText } = render(<TagInput tags={['flu', 'europe']} onChange={vi.fn()} />);
+        const { getByText } = render(<TagInputWithProvider tags={['flu', 'europe']} onChange={vi.fn()} />);
 
         await expect.element(getByText('flu')).toBeVisible();
         await expect.element(getByText('europe')).toBeVisible();
@@ -17,7 +20,7 @@ describe('TagInput', () => {
 
     it('adds a tag on Enter', async () => {
         const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={[]} onChange={onChange} />);
 
         await getByPlaceholder(PLACEHOLDER).fill('influenza');
         await userEvent.keyboard('{Enter}');
@@ -27,7 +30,7 @@ describe('TagInput', () => {
 
     it('adds a tag on comma', async () => {
         const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={[]} onChange={onChange} />);
 
         await getByPlaceholder(PLACEHOLDER).fill('influenza');
         await userEvent.keyboard(',');
@@ -37,7 +40,7 @@ describe('TagInput', () => {
 
     it('adds a tag on space', async () => {
         const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={[]} onChange={onChange} />);
 
         await getByPlaceholder(PLACEHOLDER).fill('influenza');
         await userEvent.keyboard(' ');
@@ -47,7 +50,7 @@ describe('TagInput', () => {
 
     it('adds a tag on blur', async () => {
         const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={[]} onChange={onChange} />);
 
         await getByPlaceholder(PLACEHOLDER).fill('influenza');
         await userEvent.tab();
@@ -57,7 +60,7 @@ describe('TagInput', () => {
 
     it('lowercases tags', async () => {
         const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={[]} onChange={onChange} />);
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={[]} onChange={onChange} />);
 
         await getByPlaceholder(PLACEHOLDER).fill('Influenza');
         await userEvent.keyboard('{Enter}');
@@ -67,7 +70,7 @@ describe('TagInput', () => {
 
     it('does not add duplicate tags', async () => {
         const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={['flu']} onChange={onChange} />);
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={['flu']} onChange={onChange} />);
 
         await getByPlaceholder('').fill('flu');
         await userEvent.keyboard('{Enter}');
@@ -77,7 +80,7 @@ describe('TagInput', () => {
 
     it('removes a tag when the remove button is clicked', async () => {
         const onChange = vi.fn();
-        const { getByRole } = render(<TagInput tags={['flu', 'covid']} onChange={onChange} />);
+        const { getByRole } = render(<TagInputWithProvider tags={['flu', 'covid']} onChange={onChange} />);
 
         await getByRole('button', { name: 'Remove tag flu' }).click();
 
@@ -86,7 +89,7 @@ describe('TagInput', () => {
 
     it('removes the last tag on Backspace when the input is empty', async () => {
         const onChange = vi.fn();
-        const { getByPlaceholder } = render(<TagInput tags={['flu', 'covid']} onChange={onChange} />);
+        const { getByPlaceholder } = render(<TagInputWithProvider tags={['flu', 'covid']} onChange={onChange} />);
 
         await userEvent.click(getByPlaceholder(''));
         await userEvent.keyboard('{Backspace}');

--- a/website/src/components/collections/form/TagInput.tsx
+++ b/website/src/components/collections/form/TagInput.tsx
@@ -33,10 +33,6 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
 
     const addTag = (raw: string) => addTags(raw);
 
-    const removeTag = (tag: string) => {
-        onChange(tags.filter((t) => t !== tag));
-    };
-
     const filteredSuggestions = useMemo(
         () =>
             allTags.filter(
@@ -45,7 +41,7 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
         [allTags, tags, inputValue],
     );
 
-    const { isOpen, getMenuProps, getInputProps, getItemProps, highlightedIndex, closeMenu } = useCombobox({
+    const { isOpen, getMenuProps, getInputProps, getItemProps, highlightedIndex, closeMenu, selectItem } = useCombobox({
         items: filteredSuggestions,
         itemToString: (item) => item ?? '',
         inputValue,
@@ -72,6 +68,11 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
             }
         },
     });
+
+    const removeTag = (tag: string) => {
+        onChange(tags.filter((t) => t !== tag));
+        selectItem(null);
+    };
 
     const inputRef = useRef<HTMLInputElement>(null);
     const {

--- a/website/src/components/collections/form/TagInput.tsx
+++ b/website/src/components/collections/form/TagInput.tsx
@@ -1,12 +1,22 @@
-import { useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useCombobox } from 'downshift';
+import { useMemo, useRef, useState } from 'react';
 
+import { getBackendServiceForClientside } from '../../../backendApi/backendService.ts';
 import { TagChip } from '../TagChip.tsx';
 
 export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: string[]) => void }) {
-    const [inputValue, setInputValue] = useState('');
-    const inputRef = useRef<HTMLInputElement>(null);
+    const { data: allTags = [] } = useQuery({
+        queryKey: ['collection-tags'],
+        queryFn: async () => {
+            const result = await getBackendServiceForClientside().getCollectionTags();
+            return result.tags;
+        },
+    });
 
-    function addTags(raw: string) {
+    const [inputValue, setInputValue] = useState('');
+
+    const addTags = (raw: string) => {
         const newTags = raw
             .split(/[\s,]+/)
             .map((t) => t.toLowerCase().trim())
@@ -15,54 +25,127 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
             onChange([...tags, ...newTags]);
         }
         setInputValue('');
-    }
+    };
 
-    function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-        if (e.key === 'Enter' || e.key === ',' || e.key === ' ') {
+    const addTag = (raw: string) => addTags(raw);
+
+    const removeTag = (tag: string) => {
+        onChange(tags.filter((t) => t !== tag));
+    };
+
+    const filteredSuggestions = useMemo(
+        () =>
+            allTags.filter(
+                (t) => !tags.includes(t) && (inputValue === '' || t.toLowerCase().includes(inputValue.toLowerCase())),
+            ),
+        [allTags, tags, inputValue],
+    );
+
+    const { isOpen, getMenuProps, getInputProps, getItemProps, highlightedIndex, closeMenu } = useCombobox({
+        items: filteredSuggestions,
+        itemToString: (item) => item ?? '',
+        inputValue,
+        onStateChange({ type, selectedItem: newSelectedItem }) {
+            switch (type) {
+                case useCombobox.stateChangeTypes.InputKeyDownEnter:
+                case useCombobox.stateChangeTypes.ItemClick:
+                    if (newSelectedItem) {
+                        addTag(newSelectedItem);
+                    }
+                    setInputValue('');
+                    break;
+                default:
+                    break;
+            }
+        },
+        stateReducer(_state, { changes, type }) {
+            switch (type) {
+                case useCombobox.stateChangeTypes.InputKeyDownEnter:
+                case useCombobox.stateChangeTypes.ItemClick:
+                    return { ...changes, isOpen: true, inputValue: '' };
+                default:
+                    return changes;
+            }
+        },
+    });
+
+    const inputRef = useRef<HTMLInputElement>(null);
+    const {
+        onKeyDown: downshiftKeyDown,
+        onChange: downshiftOnChange,
+        ...restInputProps
+    } = getInputProps({
+        ref: inputRef,
+    });
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === ',' || e.key === ' ') {
             e.preventDefault();
-            addTags(inputValue);
+            if (inputValue.trim()) {
+                addTag(inputValue);
+            }
+        } else if (e.key === 'Enter' && highlightedIndex < 0) {
+            e.preventDefault();
+            if (inputValue.trim()) {
+                addTag(inputValue);
+            }
         } else if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
-            onChange(tags.slice(0, -1));
+            removeTag(tags[tags.length - 1]);
+        } else {
+            downshiftKeyDown?.(e);
         }
-    }
+    };
 
-    function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.currentTarget.value;
         if (/[\s,]/.test(value)) {
             addTags(value);
+            closeMenu();
         } else {
             setInputValue(value);
+            downshiftOnChange?.(e);
         }
-    }
+    };
 
-    function handleBlur() {
+    const handleBlur = () => {
         if (inputValue.trim()) {
-            addTags(inputValue);
+            addTag(inputValue);
         }
-    }
-
-    function removeTag(tag: string) {
-        onChange(tags.filter((t) => t !== tag));
-    }
+    };
 
     return (
-        <div
-            className='input input-bordered flex min-h-10 w-full flex-wrap items-center gap-1 p-1.5'
-            onClick={() => inputRef.current?.focus()}
-        >
-            {tags.map((tag) => (
-                <TagChip key={tag} tag={tag} onRemove={removeTag} />
-            ))}
-            <input
-                ref={inputRef}
-                type='text'
-                className='min-w-20 flex-1 bg-transparent text-sm outline-none'
-                placeholder={tags.length === 0 ? 'Add tags (Enter, comma, or space to confirm)' : ''}
-                value={inputValue}
-                onChange={handleChange}
-                onKeyDown={handleKeyDown}
-                onBlur={handleBlur}
-            />
+        <div className='relative w-full'>
+            <div
+                className='input input-bordered flex h-auto min-h-10 w-full flex-wrap items-center gap-1 p-1.5'
+                onClick={() => inputRef.current?.focus()}
+            >
+                {tags.map((tag) => (
+                    <TagChip key={tag} tag={tag} onRemove={removeTag} />
+                ))}
+                <input
+                    className='min-w-20 flex-1 bg-transparent text-sm outline-none'
+                    placeholder={tags.length === 0 ? 'Add tags (Enter, comma, or space to confirm)' : ''}
+                    {...restInputProps}
+                    onKeyDown={handleKeyDown}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                />
+            </div>
+            <ul
+                {...getMenuProps()}
+                onMouseDown={(e) => e.preventDefault()}
+                className={`bg-base-100 border-base-300 absolute z-10 mt-1 max-h-60 w-full overflow-y-auto border shadow-md ${isOpen && filteredSuggestions.length > 0 ? '' : 'hidden'}`}
+            >
+                {filteredSuggestions.map((item, index) => (
+                    <li
+                        key={item}
+                        className={`cursor-pointer px-3 py-2 text-sm ${highlightedIndex === index ? 'bg-base-200' : ''}`}
+                        {...getItemProps({ item, index })}
+                    >
+                        {item}
+                    </li>
+                ))}
+            </ul>
         </div>
     );
 }

--- a/website/src/components/collections/form/TagInput.tsx
+++ b/website/src/components/collections/form/TagInput.tsx
@@ -17,10 +17,14 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
     const [inputValue, setInputValue] = useState('');
 
     const addTags = (raw: string) => {
-        const newTags = raw
-            .split(/[\s,]+/)
-            .map((t) => t.toLowerCase().trim())
-            .filter((t) => t && !tags.includes(t));
+        const newTags = [
+            ...new Set(
+                raw
+                    .split(/[\s,]+/)
+                    .map((t) => t.toLowerCase().trim())
+                    .filter((t) => t && !tags.includes(t)),
+            ),
+        ];
         if (newTags.length > 0) {
             onChange([...tags, ...newTags]);
         }

--- a/website/src/components/collections/form/TagInput.tsx
+++ b/website/src/components/collections/form/TagInput.tsx
@@ -1,11 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { useCombobox } from 'downshift';
-import { useMemo, useRef, useState } from 'react';
+import { type FC, useMemo, useRef, useState } from 'react';
 
 import { getBackendServiceForClientside } from '../../../backendApi/backendService.ts';
 import { TagChip } from '../TagChip.tsx';
 
-export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: string[]) => void }) {
+type TagInputProps = {
+    tags: string[];
+    onChange: (tags: string[]) => void;
+};
+
+export const TagInput: FC<TagInputProps> = ({ tags, onChange }) => {
     const { data: allTags = [] } = useQuery({
         queryKey: ['collection-tags'],
         queryFn: async () => {
@@ -31,8 +36,6 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
         setInputValue('');
     };
 
-    const addTag = (raw: string) => addTags(raw);
-
     const filteredSuggestions = useMemo(
         () =>
             allTags.filter(
@@ -50,7 +53,7 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
                 case useCombobox.stateChangeTypes.InputKeyDownEnter:
                 case useCombobox.stateChangeTypes.ItemClick:
                     if (newSelectedItem) {
-                        addTag(newSelectedItem);
+                        addTags(newSelectedItem);
                     }
                     setInputValue('');
                     break;
@@ -87,12 +90,12 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
         if (e.key === ',' || e.key === ' ') {
             e.preventDefault();
             if (inputValue.trim()) {
-                addTag(inputValue);
+                addTags(inputValue);
             }
         } else if (e.key === 'Enter' && highlightedIndex < 0) {
             e.preventDefault();
             if (inputValue.trim()) {
-                addTag(inputValue);
+                addTags(inputValue);
             }
         } else if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
             removeTag(tags[tags.length - 1]);
@@ -114,7 +117,7 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
 
     const handleBlur = () => {
         if (inputValue.trim()) {
-            addTag(inputValue);
+            addTags(inputValue);
         }
     };
 
@@ -153,4 +156,4 @@ export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: 
             </ul>
         </div>
     );
-}
+};

--- a/website/src/components/collections/form/TagInput.tsx
+++ b/website/src/components/collections/form/TagInput.tsx
@@ -1,0 +1,68 @@
+import { useRef, useState } from 'react';
+
+import { TagChip } from '../TagChip.tsx';
+
+export function TagInput({ tags, onChange }: { tags: string[]; onChange: (tags: string[]) => void }) {
+    const [inputValue, setInputValue] = useState('');
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    function addTags(raw: string) {
+        const newTags = raw
+            .split(/[\s,]+/)
+            .map((t) => t.toLowerCase().trim())
+            .filter((t) => t && !tags.includes(t));
+        if (newTags.length > 0) {
+            onChange([...tags, ...newTags]);
+        }
+        setInputValue('');
+    }
+
+    function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+        if (e.key === 'Enter' || e.key === ',' || e.key === ' ') {
+            e.preventDefault();
+            addTags(inputValue);
+        } else if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
+            onChange(tags.slice(0, -1));
+        }
+    }
+
+    function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+        const value = e.currentTarget.value;
+        if (/[\s,]/.test(value)) {
+            addTags(value);
+        } else {
+            setInputValue(value);
+        }
+    }
+
+    function handleBlur() {
+        if (inputValue.trim()) {
+            addTags(inputValue);
+        }
+    }
+
+    function removeTag(tag: string) {
+        onChange(tags.filter((t) => t !== tag));
+    }
+
+    return (
+        <div
+            className='input input-bordered flex min-h-10 w-full flex-wrap items-center gap-1 p-1.5'
+            onClick={() => inputRef.current?.focus()}
+        >
+            {tags.map((tag) => (
+                <TagChip key={tag} tag={tag} onRemove={removeTag} />
+            ))}
+            <input
+                ref={inputRef}
+                type='text'
+                className='min-w-20 flex-1 bg-transparent text-sm outline-none'
+                placeholder={tags.length === 0 ? 'Add tags (Enter, comma, or space to confirm)' : ''}
+                value={inputValue}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+            />
+        </div>
+    );
+}

--- a/website/src/components/collections/form/TagInput.tsx
+++ b/website/src/components/collections/form/TagInput.tsx
@@ -133,6 +133,7 @@ export const TagInput: FC<TagInputProps> = ({ tags, onChange }) => {
                 <input
                     className='min-w-20 flex-1 bg-transparent text-sm outline-none'
                     placeholder={tags.length === 0 ? 'Add tags (Enter, comma, or space to confirm)' : ''}
+                    aria-label='Add tags'
                     {...restInputProps}
                     onKeyDown={handleKeyDown}
                     onChange={handleChange}

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -196,5 +196,31 @@ describe('CollectionsOverview', () => {
             await expect.element(getByText('Asia Community')).not.toBeInTheDocument();
             await expect.element(getByText('NoTags Official')).not.toBeInTheDocument();
         });
+
+        it('shows filter-empty message when tag filter excludes all collections', async ({
+            routeMockers: { astro },
+        }) => {
+            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200, true);
+            const { getByText, getByPlaceholder } = renderOverview();
+
+            await getByText('All').click();
+            await getByPlaceholder(TAG_INPUT_PLACEHOLDER).fill('nonexistent');
+            await userEvent.keyboard('{Enter}');
+
+            await expect.element(getByText('No collections match the selected filters.')).toBeVisible();
+            await expect.element(getByText('No collections yet.')).not.toBeInTheDocument();
+        });
+
+        it('shows filter-empty message when community/official filter excludes all collections', async ({
+            routeMockers: { astro },
+        }) => {
+            astro.mockGetCollectionSummaries([communityCollection], ORGANISM, 200, true);
+            const { getByText } = renderOverview();
+
+            await getByText('Official').click();
+
+            await expect.element(getByText('No collections match the selected filters.')).toBeVisible();
+            await expect.element(getByText('No collections yet.')).not.toBeInTheDocument();
+        });
     });
 });

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -16,6 +16,7 @@ const communityCollection = {
     organism: ORGANISM,
     description: 'A user-submitted collection',
     variantCount: 3,
+    tags: ['europe', 'flu'],
 };
 
 const officialCollection = {
@@ -25,6 +26,7 @@ const officialCollection = {
     organism: ORGANISM,
     description: null,
     variantCount: 0,
+    tags: [],
 };
 
 const allCollections = [communityCollection, officialCollection];

--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { describe, expect } from 'vitest';
 import { render } from 'vitest-browser-react';
 
@@ -8,6 +9,7 @@ import { Organisms } from '../../../types/Organism';
 const ORGANISM = Organisms.covid;
 const HEADLINE = 'SARS-CoV-2 Collections';
 const SYSTEM_USER_ID = 1;
+const TAG_INPUT_PLACEHOLDER = 'Add tags (Enter, comma, or space to confirm)';
 
 const communityCollection = {
     id: 1,
@@ -30,6 +32,58 @@ const officialCollection = {
 };
 
 const allCollections = [communityCollection, officialCollection];
+
+const taggedComEuropeFlu = {
+    id: 3,
+    name: 'Euro-Flu Community',
+    ownedBy: 2,
+    organism: ORGANISM,
+    description: null,
+    variantCount: 2,
+    tags: ['europe', 'flu'],
+};
+
+const taggedComAsia = {
+    id: 4,
+    name: 'Asia Community',
+    ownedBy: 2,
+    organism: ORGANISM,
+    description: null,
+    variantCount: 1,
+    tags: ['asia', 'flu'],
+};
+
+const taggedComEurope = {
+    id: 5,
+    name: 'Europe-Only Community',
+    ownedBy: 2,
+    organism: ORGANISM,
+    description: null,
+    variantCount: 1,
+    tags: ['europe'],
+};
+
+const taggedOffEurope = {
+    id: 6,
+    name: 'Europe Official',
+    ownedBy: SYSTEM_USER_ID,
+    organism: ORGANISM,
+    description: null,
+    variantCount: 0,
+    tags: ['europe'],
+};
+
+const taggedOffNone = {
+    id: 7,
+    name: 'NoTags Official',
+    ownedBy: SYSTEM_USER_ID,
+    organism: ORGANISM,
+    description: null,
+    variantCount: 0,
+    tags: [],
+};
+
+const taggedCollections = [taggedComEuropeFlu, taggedComAsia, taggedComEurope, taggedOffEurope, taggedOffNone];
 
 function renderOverview() {
     return render(<CollectionsOverview organism={ORGANISM} isLoggedIn={false} systemUserId={SYSTEM_USER_ID} />);
@@ -94,5 +148,53 @@ describe('CollectionsOverview', () => {
 
         await expect.element(getByText(HEADLINE)).toBeVisible();
         await expect.element(getByText('Failed to load collections. Please try reloading the page.')).toBeVisible();
+    });
+
+    describe('tag filter', () => {
+        it('filters by a single tag in All mode', async ({ routeMockers: { astro } }) => {
+            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200, true);
+            const { getByText, getByPlaceholder } = renderOverview();
+
+            await getByText('All').click();
+            await getByPlaceholder(TAG_INPUT_PLACEHOLDER).fill('europe');
+            await userEvent.keyboard('{Enter}');
+
+            await expect.element(getByText('Euro-Flu Community')).toBeVisible();
+            await expect.element(getByText('Europe-Only Community')).toBeVisible();
+            await expect.element(getByText('Europe Official')).toBeVisible();
+            await expect.element(getByText('Asia Community')).not.toBeInTheDocument();
+            await expect.element(getByText('NoTags Official')).not.toBeInTheDocument();
+        });
+
+        it('filters by multiple tags in All mode', async ({ routeMockers: { astro } }) => {
+            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200, true);
+            const { getByText, getByPlaceholder } = renderOverview();
+
+            await getByText('All').click();
+            await getByPlaceholder(TAG_INPUT_PLACEHOLDER).fill('europe');
+            await userEvent.keyboard('{Enter}');
+            await getByPlaceholder('').fill('flu');
+            await userEvent.keyboard('{Enter}');
+
+            await expect.element(getByText('Euro-Flu Community')).toBeVisible();
+            await expect.element(getByText('Europe-Only Community')).not.toBeInTheDocument();
+            await expect.element(getByText('Europe Official')).not.toBeInTheDocument();
+            await expect.element(getByText('Asia Community')).not.toBeInTheDocument();
+            await expect.element(getByText('NoTags Official')).not.toBeInTheDocument();
+        });
+
+        it('applies tag filter within Community mode', async ({ routeMockers: { astro } }) => {
+            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200, true);
+            const { getByText, getByPlaceholder } = renderOverview();
+
+            await getByPlaceholder(TAG_INPUT_PLACEHOLDER).fill('europe');
+            await userEvent.keyboard('{Enter}');
+
+            await expect.element(getByText('Euro-Flu Community')).toBeVisible();
+            await expect.element(getByText('Europe-Only Community')).toBeVisible();
+            await expect.element(getByText('Europe Official')).not.toBeInTheDocument();
+            await expect.element(getByText('Asia Community')).not.toBeInTheDocument();
+            await expect.element(getByText('NoTags Official')).not.toBeInTheDocument();
+        });
     });
 });

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -70,7 +70,7 @@ function CollectionsOverviewInner({
                 <span className='loading loading-spinner loading-sm' />
             ) : isError ? (
                 <div className='text-error'>Failed to load collections. Please try reloading the page.</div>
-            ) : filteredCollections.length === 0 ? (
+            ) : collections?.length === 0 ? (
                 <div className='mt-6 text-gray-500'>
                     No collections yet.
                     {isLoggedIn && (
@@ -83,6 +83,8 @@ function CollectionsOverviewInner({
                         </>
                     )}
                 </div>
+            ) : filteredCollections.length === 0 ? (
+                <div className='mt-6 text-gray-500'>No collections match the selected filters.</div>
             ) : (
                 <CollectionsTable collections={filteredCollections} organism={organism} />
             )}

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -13,6 +13,7 @@ import type { CollectionSummary } from '../../../types/Collection.ts';
 import { organismConfig, type Organism } from '../../../types/Organism.ts';
 import { Page } from '../../../types/pages.ts';
 import { getErrorLogMessage } from '../../../util/getErrorLogMessage.ts';
+import { TagInput } from '../form/TagInput.tsx';
 
 export const CollectionsOverview = withQueryProvider(CollectionsOverviewInner);
 
@@ -30,6 +31,7 @@ function CollectionsOverviewInner({
     systemUserId: number;
 }) {
     const [filter, setFilter] = useState<CollectionFilter>('community');
+    const [tagFilter, setTagFilter] = useState<string[]>([]);
 
     const {
         isLoading,
@@ -46,7 +48,7 @@ function CollectionsOverviewInner({
         logger.error(`Failed to fetch collections: ${getErrorLogMessage(error)}`);
     }
 
-    const filteredCollections = filterCollections(collections, filter, systemUserId);
+    const filteredCollections = filterCollections(collections, filter, systemUserId, tagFilter);
 
     return (
         <div>
@@ -58,7 +60,12 @@ function CollectionsOverviewInner({
                     </a>
                 )}
             </div>
-            <CollectionFilterSelect filter={filter} onChange={setFilter} />
+            <div className='mt-4 flex flex-wrap items-start gap-4'>
+                <CollectionFilterSelect filter={filter} onChange={setFilter} />
+                <div className='flex-1'>
+                    <TagInput tags={tagFilter} onChange={setTagFilter} />
+                </div>
+            </div>
             {isLoading ? (
                 <span className='loading loading-spinner loading-sm' />
             ) : isError ? (
@@ -87,16 +94,25 @@ function filterCollections(
     collections: CollectionSummary[] | undefined,
     filter: CollectionFilter,
     systemUserId: number,
+    tagFilter: string[],
 ): CollectionSummary[] {
     if (!collections) return [];
+    let result: CollectionSummary[];
     switch (filter) {
         case 'community':
-            return collections.filter((c) => c.ownedBy !== systemUserId);
+            result = collections.filter((c) => c.ownedBy !== systemUserId);
+            break;
         case 'official':
-            return collections.filter((c) => c.ownedBy === systemUserId);
+            result = collections.filter((c) => c.ownedBy === systemUserId);
+            break;
         case 'all':
-            return collections;
+            result = collections;
+            break;
     }
+    if (tagFilter.length > 0) {
+        result = result.filter((c) => tagFilter.every((tag) => c.tags.includes(tag)));
+    }
+    return result;
 }
 
 const FILTER_OPTIONS: { value: CollectionFilter; label: string; tooltip: string }[] = [
@@ -127,7 +143,7 @@ function CollectionFilterSelect({
                     />
                     <label
                         htmlFor={`${id}-${opt.value}`}
-                        className={`tooltip w-24 cursor-pointer border p-2 text-center ${i === 0 ? 'rounded-l-md' : '-ml-px rounded-none'} ${i === FILTER_OPTIONS.length - 1 ? 'rounded-r-md' : ''} ${filter === opt.value ? 'border-primary relative z-10' : 'border-gray-300'}`}
+                        className={`tooltip flex h-10 w-24 cursor-pointer items-center justify-center border px-2 ${i === 0 ? 'rounded-l-sm' : '-ml-px rounded-none'} ${i === FILTER_OPTIONS.length - 1 ? 'rounded-r-sm' : ''} ${filter === opt.value ? 'border-primary relative z-10' : 'border-base-content/20'}`}
                         data-tip={opt.tooltip}
                     >
                         {opt.label}
@@ -141,8 +157,10 @@ function CollectionFilterSelect({
 function CollectionsGridStyles() {
     return (
         <style>{`
-            /* Remove the mermaid theme's rounded corners and drop shadow; add outer left/right border to frame the table */
-            .collections-grid .gridjs-wrapper, .collections-grid .gridjs-footer { border-radius: 0; box-shadow: none; border-left: 1px solid var(--color-base-300); border-right: 1px solid var(--color-base-300); }
+            /* Remove the mermaid theme's drop shadow; add outer left/right border to frame the table; round outer corners to match the filter controls */
+            .collections-grid .gridjs-wrapper, .collections-grid .gridjs-footer { box-shadow: none; border-left: 1px solid var(--color-base-300); border-right: 1px solid var(--color-base-300); }
+            .collections-grid .gridjs-wrapper { border-radius: var(--radius-sm) var(--radius-sm) 0 0; overflow: hidden; }
+            .collections-grid .gridjs-footer { border-radius: 0 0 var(--radius-sm) var(--radius-sm); }
 
             /* Mermaid sets inline-block here, which lets the table overflow the viewport instead of squishing */
             .collections-grid .gridjs-container { display: block; }

--- a/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/VariantExplorerFilter.browser.spec.tsx
@@ -12,8 +12,8 @@ import type { WasapVariantFilter } from '../../../views/wasap/wasapPageConfig';
 const DUMMY_LAPIS_URL_2 = 'http://lapis2.dummy';
 
 const DUMMY_COLLECTIONS: CollectionSummary[] = [
-    { id: 1, name: 'XBB.1.5', ownedBy: 1, organism: 'SARS-CoV-2', description: null, variantCount: 5 },
-    { id: 2, name: 'JN.1', ownedBy: 1, organism: 'SARS-CoV-2', description: null, variantCount: 3 },
+    { id: 1, name: 'XBB.1.5', ownedBy: 1, organism: 'SARS-CoV-2', description: null, variantCount: 5, tags: [] },
+    { id: 2, name: 'JN.1', ownedBy: 1, organism: 'SARS-CoV-2', description: null, variantCount: 3, tags: [] },
 ];
 const mockPredefinedQueryResult = { data: DUMMY_COLLECTIONS } as unknown as UseQueryResult<CollectionSummary[]>;
 

--- a/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/wasap/utils/CollectionCombobox.browser.spec.tsx
@@ -13,6 +13,7 @@ const makeCollection = (id: number, name: string): CollectionSummary => ({
     organism: 'test',
     description: null,
     variantCount: 0,
+    tags: [],
 });
 
 const collections = [makeCollection(1, 'Alpha'), makeCollection(2, 'Beta'), makeCollection(3, 'Gamma')];

--- a/website/src/types/Collection.ts
+++ b/website/src/types/Collection.ts
@@ -37,6 +37,7 @@ const collectionBaseSchema = z.object({
     organism: z.string(),
     description: z.string().nullable(),
     variantCount: z.number().int().nonnegative(),
+    tags: z.array(z.string()),
 });
 
 export const collectionSummarySchema = collectionBaseSchema;
@@ -95,6 +96,7 @@ export const collectionRequestSchema = z.object({
     name: z.string(),
     organism: z.string(),
     description: z.string().optional(),
+    tags: z.array(z.string()),
     variants: z.array(variantRequestSchema),
 });
 
@@ -111,6 +113,7 @@ export const collectionUpdateSchema = collectionRequestSchema
     .omit({ organism: true })
     .partial()
     .extend({
+        tags: z.array(z.string()).optional(),
         variants: z.array(variantUpdateSchema).optional(),
     });
 


### PR DESCRIPTION
resolves #1266 

### Summary

- Adds a new form field to enter tags
- Adds tag badges on collections
- Adds search field in collections overview to filter by tag
- Adds all the plumbing related to tags

### Screenshot

https://github.com/user-attachments/assets/1b5edb9b-17d1-4e79-b1f3-e7263a56178c

(recording doesn't show autocomplete dropdown feature, but it's there)

#### Search


https://github.com/user-attachments/assets/cbfadaf4-f61f-4681-a479-49bb45fee5c2



## PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
