### PR TITLE
feat(dashboards): migrate seeder and frontend from pseudo-tags to real collection tags

### DIFF
--- a/collection-seeding/api.py
+++ b/collection-seeding/api.py
@@ -55,7 +55,7 @@ class ApiClient:
         )
         if not r.ok:
             raise RuntimeError(
-                f"GET /api/collections?tags= failed: {r.status_code} {r.text}"
+                f"GET /api/collections?tags={tag} failed: {r.status_code} {r.text}"
             )
         return r.json()
 

--- a/collection-seeding/api.py
+++ b/collection-seeding/api.py
@@ -44,6 +44,21 @@ class ApiClient:
             raise RuntimeError(f"GET /api/collections failed: {r.status_code} {r.text}")
         return r.json()
 
+    def fetch_existing_collections_by_tag(
+        self, tag: str, organism: str
+    ) -> list[ExistingCollection]:
+        r = requests.get(
+            self._collections_url,
+            params={"tags": tag, "organism": organism},
+            headers=self._auth_headers,
+            timeout=10,
+        )
+        if not r.ok:
+            raise RuntimeError(
+                f"GET /api/collections?tags= failed: {r.status_code} {r.text}"
+            )
+        return r.json()
+
     def create_collection(self, collection: Collection) -> int:
         r = requests.post(
             self._collections_url,

--- a/collection-seeding/models.py
+++ b/collection-seeding/models.py
@@ -1,6 +1,6 @@
 """Shared type definitions for collection seeding."""
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 class FilterObject(TypedDict, total=False):
@@ -19,6 +19,7 @@ class Collection(TypedDict):
     organism: str
     description: str
     variants: list[Variant]
+    tags: NotRequired[list[str]]
 
 
 class ExistingCollection(TypedDict):
@@ -27,3 +28,4 @@ class ExistingCollection(TypedDict):
     id: int
     name: str
     description: str | None
+    tags: NotRequired[list[str]]

--- a/collection-seeding/models.py
+++ b/collection-seeding/models.py
@@ -1,6 +1,6 @@
 """Shared type definitions for collection seeding."""
 
-from typing import NotRequired, TypedDict
+from typing import TypedDict
 
 
 class FilterObject(TypedDict, total=False):
@@ -19,7 +19,7 @@ class Collection(TypedDict):
     organism: str
     description: str
     variants: list[Variant]
-    tags: NotRequired[list[str]]
+    tags: list[str]
 
 
 class ExistingCollection(TypedDict):
@@ -28,4 +28,4 @@ class ExistingCollection(TypedDict):
     id: int
     name: str
     description: str | None
-    tags: NotRequired[list[str]]
+    tags: list[str]

--- a/collection-seeding/seed.py
+++ b/collection-seeding/seed.py
@@ -86,8 +86,9 @@ def seed_source(client: ApiClient, source: Source) -> tuple[int, int, int]:
     by_tag = client.fetch_existing_collections_by_tag(source.owned_tag, source.organism)
     all_existing = client.fetch_existing_collections(source.organism)
     by_description = [
-        c for c in all_existing if source.owned_tag in (c["description"] or "")
+        c for c in all_existing if f"#{source.owned_tag}" in (c["description"] or "")
     ]
+
     all_owned = {c["id"]: c for c in by_tag + by_description}
     existing_by_name = {c["name"]: c for c in all_owned.values()}
 

--- a/collection-seeding/seed.py
+++ b/collection-seeding/seed.py
@@ -80,10 +80,16 @@ def seed_source(client: ApiClient, source: Source) -> tuple[int, int, int]:
     collections = source.get_collections()
     print(f"\n[{source.name}]")
 
-    existing = client.fetch_existing_collections(source.organism)
-    existing_by_name = {
-        c["name"]: c for c in existing if source.owned_tag in (c["description"] or "")
-    }
+    # Lenient orphan detection: find owned collections via real tags (new-style) OR
+    # description pseudo-tags (old-style), so old collections are found and replaced
+    # with properly tagged ones on the first seeder run after migration.
+    by_tag = client.fetch_existing_collections_by_tag(source.owned_tag, source.organism)
+    all_existing = client.fetch_existing_collections(source.organism)
+    by_description = [
+        c for c in all_existing if source.owned_tag in (c["description"] or "")
+    ]
+    all_owned = {c["id"]: c for c in by_tag + by_description}
+    existing_by_name = {c["name"]: c for c in all_owned.values()}
 
     created = 0
     updated = 0

--- a/collection-seeding/sources/__init__.py
+++ b/collection-seeding/sources/__init__.py
@@ -7,9 +7,9 @@ class Source(ABC):
     """A data source that produces collections to be seeded into the backend.
 
     Implement this to add a new source: set a unique `name` (used as the --source flag value),
-    an `organism`, an `owned_tag` (appended to each description and used to identify orphaned
-    collections for deletion), and implement `get_collections` to return the collections to upsert.
-    Then register it in sources/registry.py.
+    an `organism`, an `owned_tag` (added as a real tag to each collection and used to identify
+    orphaned collections for deletion), and implement `get_collections` to return the collections
+    to upsert. Then register it in sources/registry.py.
 
     Set `include_in_default_run = False` for sources that should only be used via --source
     (e.g. demo/sample sources that overlap with a full source).

--- a/collection-seeding/sources/covid_pango_lineages.py
+++ b/collection-seeding/sources/covid_pango_lineages.py
@@ -70,8 +70,7 @@ class CovidPangoLineagesSource(Source):
             f"Pango lineage {lineage}. "
             f"Parent: {parent}. "
             f"Nextstrain clade: {clade}. "
-            f"Designated: {date}. "
-            f"{self.owned_tag}"
+            f"Designated: {date}."
         )
 
         return {
@@ -79,6 +78,7 @@ class CovidPangoLineagesSource(Source):
             "organism": "covid",
             "description": description,
             "variants": variants,
+            "tags": [self.owned_tag],
         }
 
 

--- a/collection-seeding/sources/covid_pango_lineages.py
+++ b/collection-seeding/sources/covid_pango_lineages.py
@@ -17,7 +17,7 @@ class CovidPangoLineagesSource(Source):
 
     name = "covid-pango-lineages"
     organism = "covid"
-    owned_tag = "#pango-lineage"
+    owned_tag = "pango-lineage"
 
     def __init__(self, limit: int | None = None):
         self._limit = limit

--- a/collection-seeding/sources/covid_resistance_mutations.py
+++ b/collection-seeding/sources/covid_resistance_mutations.py
@@ -11,7 +11,7 @@ class CovidResistanceMutationsSource(Source):
 
     name = "covid-resistance-mutations"
     organism = "covid"
-    owned_tag = "#resistance-mutation"
+    owned_tag = "resistance-mutation"
 
     def get_collections(self) -> list[Collection]:
         return [

--- a/collection-seeding/sources/covid_resistance_mutations.py
+++ b/collection-seeding/sources/covid_resistance_mutations.py
@@ -21,9 +21,10 @@ class CovidResistanceMutationsSource(Source):
                 "description": (
                     "SARS-CoV-2 3C-like protease (3CLpro/Mpro) inhibitor resistance mutations "
                     "as per Stanford Coronavirus Antiviral & Resistance database "
-                    f"(last updated 21 August 2024). {self.owned_tag}"
+                    "(last updated 21 August 2024)."
                 ),
                 "variants": _build_variants(CLPRO_MUTATIONS, "3CLpro", -3263),
+                "tags": [self.owned_tag],
             },
             {
                 "name": "RdRp resistance mutations",
@@ -31,9 +32,10 @@ class CovidResistanceMutationsSource(Source):
                 "description": (
                     "SARS-CoV-2 RNA-dependent RNA polymerase (RdRp) inhibitor resistance mutations "
                     "as per Stanford Coronavirus Antiviral & Resistance database "
-                    f"(last updated 21 August 2024). {self.owned_tag}"
+                    "(last updated 21 August 2024)."
                 ),
                 "variants": _build_variants(RDRP_MUTATIONS, "RdRp", 9),
+                "tags": [self.owned_tag],
             },
             {
                 "name": "Spike mAb resistance mutations",
@@ -41,9 +43,10 @@ class CovidResistanceMutationsSource(Source):
                 "description": (
                     "SARS-CoV-2 Spike monoclonal antibody (mAb) resistance mutations "
                     "as per Stanford Coronavirus Antiviral & Resistance database "
-                    f"(last updated 21 August 2024). {self.owned_tag}"
+                    "(last updated 21 August 2024)."
                 ),
                 "variants": _build_variants(SPIKE_MUTATIONS, "Spike", 0),
+                "tags": [self.owned_tag],
             },
         ]
 

--- a/collection-seeding/sources/registry.py
+++ b/collection-seeding/sources/registry.py
@@ -4,10 +4,19 @@ To add a new source, import it here and add it to ALL_SOURCES. This is the only
 place that needs to change — seed.py discovers sources exclusively through this list.
 """
 
-from sources.covid_pango_lineages import CovidPangoLineagesSource, CovidPangoLineagesSampleSource
+from sources.covid_pango_lineages import (
+    CovidPangoLineagesSource,
+    CovidPangoLineagesSampleSource,
+)
 from sources.covid_resistance_mutations import CovidResistanceMutationsSource
-from sources.rsv_resistance_mutations import RsvAResistanceMutationsSource, RsvBResistanceMutationsSource
-from sources.rsv_nextclade_lineages import RsvANextcladeLineagesSource, RsvBNextcladeLineagesSource
+from sources.rsv_resistance_mutations import (
+    RsvAResistanceMutationsSource,
+    RsvBResistanceMutationsSource,
+)
+from sources.rsv_nextclade_lineages import (
+    RsvANextcladeLineagesSource,
+    RsvBNextcladeLineagesSource,
+)
 from sources import Source
 
 ALL_SOURCES: list[type[Source]] = [

--- a/collection-seeding/sources/rsv_nextclade_lineages.py
+++ b/collection-seeding/sources/rsv_nextclade_lineages.py
@@ -28,7 +28,9 @@ class _RsvNextcladeLineagesBase(Source):
         response = requests.get(self._tree_url, timeout=60)
         response.raise_for_status()
         tree_json = response.json()
-        collections = _build_collections(tree_json, self.organism, self._organism_label, self.owned_tag)
+        collections = _build_collections(
+            tree_json, self.organism, self._organism_label, self.owned_tag
+        )
         print(f"  Loaded {len(collections)} clade(s).")
         return collections
 
@@ -56,7 +58,9 @@ class _CladeInfo(NamedTuple):
     full_aa: list[str]
 
 
-def _build_collections(tree_json: dict, organism: str, organism_label: str, owned_tag: str) -> list[Collection]:
+def _build_collections(
+    tree_json: dict, organism: str, organism_label: str, owned_tag: str
+) -> list[Collection]:
     """Build one Collection per clade in the Nextclade reference tree.
 
     Each collection gets four variants, mirroring the shape used for COVID Pango lineages:
@@ -96,15 +100,17 @@ def _build_collections(tree_json: dict, organism: str, organism_label: str, owne
         ]
         description = (
             f"{organism_label} Nextclade clade {clade.clade_name}. "
-            f"Parent clade: {parent_str}. "
-            f"{owned_tag}"
+            f"Parent clade: {parent_str}."
         )
-        collections.append({
-            "name": clade.clade_name,
-            "organism": organism,
-            "description": description,
-            "variants": variants,
-        })
+        collections.append(
+            {
+                "name": clade.clade_name,
+                "organism": organism,
+                "description": description,
+                "variants": variants,
+                "tags": [owned_tag],
+            }
+        )
     return collections
 
 
@@ -208,9 +214,9 @@ def _apply_nuc_mutations(
     """
     result = dict(accum)
     for mut in branch_muts:
-        ref_base = mut[0]        # base in the parent (= reference if first mutation here)
-        pos = mut[1:-1]          # genome position as string, e.g. "982"
-        new_base = mut[-1]       # base introduced by this branch
+        ref_base = mut[0]  # base in the parent (= reference if first mutation here)
+        pos = mut[1:-1]  # genome position as string, e.g. "982"
+        new_base = mut[-1]  # base introduced by this branch
         existing = result.get(pos)
         # If this position was already mutated earlier on the path, keep the original
         # reference base; otherwise the parent base is the reference base.
@@ -248,9 +254,9 @@ def _apply_aa_mutations(
     result = dict(accum)
     for gene, muts in branch_muts_by_gene.items():
         for mut in muts:
-            ref_aa = mut[0]      # amino acid in the parent
-            pos = mut[1:-1]      # codon position within the gene
-            new_aa = mut[-1]     # amino acid introduced by this branch
+            ref_aa = mut[0]  # amino acid in the parent
+            pos = mut[1:-1]  # codon position within the gene
+            new_aa = mut[-1]  # amino acid introduced by this branch
             key = (gene, pos)
             existing = result.get(key)
             orig_ref = existing[0] if existing else ref_aa

--- a/collection-seeding/sources/rsv_nextclade_lineages.py
+++ b/collection-seeding/sources/rsv_nextclade_lineages.py
@@ -19,7 +19,7 @@ RSV_B_TREE_URL = (
 
 
 class _RsvNextcladeLineagesBase(Source):
-    owned_tag = "#nextclade-lineage"
+    owned_tag = "nextclade-lineage"
     _tree_url: str
     _organism_label: str
 

--- a/collection-seeding/sources/rsv_resistance_mutations.py
+++ b/collection-seeding/sources/rsv_resistance_mutations.py
@@ -32,12 +32,16 @@ def _parse_rows(text: str) -> list[tuple[str, list[str], str, str]]:
             antibody = "Palivizumab"
         else:
             continue
-        resistance_type = "Partial resistance" if "Partial resistance" in comment else "Resistance"
+        resistance_type = (
+            "Partial resistance" if "Partial resistance" in comment else "Resistance"
+        )
         rows.append((rsv_type, aa_mutations, antibody, resistance_type))
     return rows
 
 
-def _build_collections(rsv_type: str, organism: str, owned_tag: str) -> list[Collection]:
+def _build_collections(
+    rsv_type: str, organism: str, owned_tag: str
+) -> list[Collection]:
     all_rows = _fetch_rows()
     type_rows = [(aa, ab, res) for (t, aa, ab, res) in all_rows if t == rsv_type]
     collections = []
@@ -51,15 +55,18 @@ def _build_collections(rsv_type: str, organism: str, owned_tag: str) -> list[Col
             for (aa, ab, res_type) in type_rows
             if ab == antibody
         ]
-        collections.append({
-            "name": f"{antibody} resistance mutations",
-            "organism": organism,
-            "description": (
-                f"RSV F protein resistance mutations against {antibody} "
-                f"as per ViralZone (https://viralzone.expasy.org/11605). {owned_tag}"
-            ),
-            "variants": variants,
-        })
+        collections.append(
+            {
+                "name": f"{antibody} resistance mutations",
+                "organism": organism,
+                "description": (
+                    f"RSV F protein resistance mutations against {antibody} "
+                    "as per ViralZone (https://viralzone.expasy.org/11605)."
+                ),
+                "variants": variants,
+                "tags": [owned_tag],
+            }
+        )
     return collections
 
 

--- a/collection-seeding/sources/rsv_resistance_mutations.py
+++ b/collection-seeding/sources/rsv_resistance_mutations.py
@@ -73,7 +73,7 @@ def _build_collections(
 class RsvAResistanceMutationsSource(Source):
     name = "rsv-a-resistance-mutations"
     organism = "rsvA"
-    owned_tag = "#resistance-mutation"
+    owned_tag = "resistance-mutation"
 
     def get_collections(self) -> list[Collection]:
         return _build_collections("A", self.organism, self.owned_tag)
@@ -82,7 +82,7 @@ class RsvAResistanceMutationsSource(Source):
 class RsvBResistanceMutationsSource(Source):
     name = "rsv-b-resistance-mutations"
     organism = "rsvB"
-    owned_tag = "#resistance-mutation"
+    owned_tag = "resistance-mutation"
 
     def get_collections(self) -> list[Collection]:
         return _build_collections("B", self.organism, self.owned_tag)

--- a/collection-seeding/tests/mock_source.py
+++ b/collection-seeding/tests/mock_source.py
@@ -5,7 +5,7 @@ from sources import Source
 class MockSource(Source):
     name = "mock-source"
     organism = "covid"
-    owned_tag = "#mock-tag"
+    owned_tag = "mock-tag"
 
     def __init__(self, collections: list[Collection]):
         self._collections = collections

--- a/collection-seeding/tests/test_pango_lineages.py
+++ b/collection-seeding/tests/test_pango_lineages.py
@@ -58,6 +58,12 @@ def test_build_collection_description_format():
     assert "BA" in col["description"]  # parent
     assert "22C" in col["description"]  # clade
     assert "2022-01-20" in col["description"]
+    assert CovidPangoLineagesSource.owned_tag not in col["description"]
+
+
+def test_build_collection_has_tags():
+    col = CovidPangoLineagesSource()._build_collection(SAMPLE_DATA["BA.2"])
+    assert col["tags"] == [CovidPangoLineagesSource.owned_tag]
 
 
 def test_build_collection_missing_fields_use_defaults():

--- a/collection-seeding/tests/test_resistance_mutations.py
+++ b/collection-seeding/tests/test_resistance_mutations.py
@@ -1,4 +1,7 @@
-from sources.covid_resistance_mutations import CovidResistanceMutationsSource, _mature_name
+from sources.covid_resistance_mutations import (
+    CovidResistanceMutationsSource,
+    _mature_name,
+)
 
 
 def test_name():

--- a/collection-seeding/tests/test_rsv_nextclade_lineages.py
+++ b/collection-seeding/tests/test_rsv_nextclade_lineages.py
@@ -280,7 +280,7 @@ def test_extract_clades_multi_hop_accumulation():
     }
     clades = {c.clade_name: c for c in _extract_clades(tree["tree"])}
     assert "A100C" in clades["A"].full_nuc
-    assert "A100G" in clades["A.1"].full_nuc   # reference A, final G
+    assert "A100G" in clades["A.1"].full_nuc  # reference A, final G
     assert "A100C" not in clades["A.1"].full_nuc  # A's intermediate step not present
 
 
@@ -355,9 +355,10 @@ def test_build_collections_description_contains_organism_label():
     assert all("RSV-A" in c["description"] for c in cols)
 
 
-def test_build_collections_description_contains_owned_tag():
+def test_build_collections_tag_in_tags_not_description():
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
-    assert all("#nextclade-lineage" in c["description"] for c in cols)
+    assert all(c["tags"] == ["#nextclade-lineage"] for c in cols)
+    assert all("#nextclade-lineage" not in c["description"] for c in cols)
 
 
 def test_build_collections_four_variants_per_collection():
@@ -382,15 +383,23 @@ def test_build_collections_full_nuc_variant_contents():
     # For A.1 this includes A's mutations plus A.1's own.
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
-    full_nuc = next(v for v in a1["variants"] if v["name"] == "Nucleotide substitutions")
-    assert set(full_nuc["filterObject"]["nucleotideMutations"]) == {"T59C", "G108A", "C241T"}
+    full_nuc = next(
+        v for v in a1["variants"] if v["name"] == "Nucleotide substitutions"
+    )
+    assert set(full_nuc["filterObject"]["nucleotideMutations"]) == {
+        "T59C",
+        "G108A",
+        "C241T",
+    }
 
 
 def test_build_collections_new_nuc_variant_contents():
     # "New nucleotide substitutions" = branch-only, just what A.1 introduces.
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
-    new_nuc = next(v for v in a1["variants"] if v["name"] == "New nucleotide substitutions")
+    new_nuc = next(
+        v for v in a1["variants"] if v["name"] == "New nucleotide substitutions"
+    )
     assert new_nuc["filterObject"]["nucleotideMutations"] == ["C241T"]
 
 
@@ -398,13 +407,20 @@ def test_build_collections_full_aa_variant_contents():
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
     full_aa = next(v for v in a1["variants"] if v["name"] == "Amino acid substitutions")
-    assert set(full_aa["filterObject"]["aminoAcidMutations"]) == {"F:T8A", "F:L20F", "G:T4N", "F:K124N"}
+    assert set(full_aa["filterObject"]["aminoAcidMutations"]) == {
+        "F:T8A",
+        "F:L20F",
+        "G:T4N",
+        "F:K124N",
+    }
 
 
 def test_build_collections_new_aa_variant_contents():
     cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
-    new_aa = next(v for v in a1["variants"] if v["name"] == "New amino acid substitutions")
+    new_aa = next(
+        v for v in a1["variants"] if v["name"] == "New amino acid substitutions"
+    )
     assert new_aa["filterObject"]["aminoAcidMutations"] == ["F:K124N"]
 
 

--- a/collection-seeding/tests/test_rsv_nextclade_lineages.py
+++ b/collection-seeding/tests/test_rsv_nextclade_lineages.py
@@ -323,51 +323,51 @@ def test_extract_clades_reversion_removed_from_full():
 
 
 def test_build_collections_count():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     assert len(cols) == 2
 
 
 def test_build_collections_organism():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     assert all(c["organism"] == "rsvA" for c in cols)
 
 
 def test_build_collections_name_is_clade():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     assert {c["name"] for c in cols} == {"A", "A.1"}
 
 
 def test_build_collections_description_contains_clade_and_parent():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
     assert "A.1" in a1["description"]
     assert "A" in a1["description"]
 
 
 def test_build_collections_description_root_clade_parent_dash():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     a = next(c for c in cols if c["name"] == "A")
     assert "—" in a["description"]
 
 
 def test_build_collections_description_contains_organism_label():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     assert all("RSV-A" in c["description"] for c in cols)
 
 
 def test_build_collections_tag_in_tags_not_description():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
-    assert all(c["tags"] == ["#nextclade-lineage"] for c in cols)
-    assert all("#nextclade-lineage" not in c["description"] for c in cols)
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
+    assert all(c["tags"] == ["nextclade-lineage"] for c in cols)
+    assert all("nextclade-lineage" not in c["description"] for c in cols)
 
 
 def test_build_collections_four_variants_per_collection():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     assert all(len(c["variants"]) == 4 for c in cols)
 
 
 def test_build_collections_variant_names():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     for col in cols:
         names = [v["name"] for v in col["variants"]]
         assert names == [
@@ -381,7 +381,7 @@ def test_build_collections_variant_names():
 def test_build_collections_full_nuc_variant_contents():
     # "Nucleotide substitutions" = full set from reference root.
     # For A.1 this includes A's mutations plus A.1's own.
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
     full_nuc = next(
         v for v in a1["variants"] if v["name"] == "Nucleotide substitutions"
@@ -395,7 +395,7 @@ def test_build_collections_full_nuc_variant_contents():
 
 def test_build_collections_new_nuc_variant_contents():
     # "New nucleotide substitutions" = branch-only, just what A.1 introduces.
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
     new_nuc = next(
         v for v in a1["variants"] if v["name"] == "New nucleotide substitutions"
@@ -404,7 +404,7 @@ def test_build_collections_new_nuc_variant_contents():
 
 
 def test_build_collections_full_aa_variant_contents():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
     full_aa = next(v for v in a1["variants"] if v["name"] == "Amino acid substitutions")
     assert set(full_aa["filterObject"]["aminoAcidMutations"]) == {
@@ -416,7 +416,7 @@ def test_build_collections_full_aa_variant_contents():
 
 
 def test_build_collections_new_aa_variant_contents():
-    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    cols = _build_collections(SAMPLE_TREE, "rsvA", "RSV-A", "nextclade-lineage")
     a1 = next(c for c in cols if c["name"] == "A.1")
     new_aa = next(
         v for v in a1["variants"] if v["name"] == "New amino acid substitutions"
@@ -444,11 +444,11 @@ def test_rsv_b_organism():
 
 
 def test_rsv_a_owned_tag():
-    assert RsvANextcladeLineagesSource.owned_tag == "#nextclade-lineage"
+    assert RsvANextcladeLineagesSource.owned_tag == "nextclade-lineage"
 
 
 def test_rsv_b_owned_tag():
-    assert RsvBNextcladeLineagesSource.owned_tag == "#nextclade-lineage"
+    assert RsvBNextcladeLineagesSource.owned_tag == "nextclade-lineage"
 
 
 # --- get_collections (HTTP) ---

--- a/collection-seeding/tests/test_rsv_resistance_mutations.py
+++ b/collection-seeding/tests/test_rsv_resistance_mutations.py
@@ -105,7 +105,10 @@ def test_collection_names_are_nirsevimab_and_palivizumab():
     rsps_lib.add(rsps_lib.GET, DATA_URL, body=SAMPLE_TEXT, status=200)
     cols = RsvAResistanceMutationsSource().get_collections()
     names = {c["name"] for c in cols}
-    assert names == {"Nirsevimab resistance mutations", "Palivizumab resistance mutations"}
+    assert names == {
+        "Nirsevimab resistance mutations",
+        "Palivizumab resistance mutations",
+    }
 
 
 @rsps_lib.activate
@@ -133,7 +136,8 @@ def test_combo_mutation_produces_multiple_aa_entries():
     cols = RsvAResistanceMutationsSource().get_collections()
     nirsevimab_col = next(c for c in cols if "Nirsevimab" in c["name"])
     combo_variant = next(
-        v for v in nirsevimab_col["variants"]
+        v
+        for v in nirsevimab_col["variants"]
         if len(v["filterObject"]["aminoAcidMutations"]) > 1
     )
     assert combo_variant["filterObject"]["aminoAcidMutations"] == ["F:N67I", "F:N208Y"]

--- a/collection-seeding/tests/test_seed.py
+++ b/collection-seeding/tests/test_seed.py
@@ -25,9 +25,10 @@ COLLECTIONS = [
 ]
 
 
-def make_client(existing=None):
+def make_client(existing=None, existing_by_tag=None):
     client = MagicMock()
     client.fetch_existing_collections.return_value = existing or []
+    client.fetch_existing_collections_by_tag.return_value = existing_by_tag or []
     client.create_collection.return_value = 99
     return client
 
@@ -147,3 +148,21 @@ def test_current_collections_are_not_deleted():
     created, updated, deleted = seed_source(client, TaggedMockSource([col]))
     assert deleted == 0
     client.delete_collection.assert_not_called()
+
+
+def test_orphan_with_real_tag_is_deleted():
+    existing_by_tag = [
+        {"id": 7, "name": "OldLineage", "description": "No pseudo-tag here."}
+    ]
+    client = make_client(existing=[], existing_by_tag=existing_by_tag)
+    created, updated, deleted = seed_source(client, TaggedMockSource([]))
+    assert deleted == 1
+    client.delete_collection.assert_called_once_with(7)
+
+
+def test_orphan_found_by_both_tag_and_description_deleted_once():
+    entry = {"id": 8, "name": "OldLineage", "description": f"Old. {TAG}"}
+    client = make_client(existing=[entry], existing_by_tag=[entry])
+    created, updated, deleted = seed_source(client, TaggedMockSource([]))
+    assert deleted == 1
+    client.delete_collection.assert_called_once_with(8)

--- a/collection-seeding/tests/test_seed.py
+++ b/collection-seeding/tests/test_seed.py
@@ -50,7 +50,7 @@ def existing_entry(id: int, name: str) -> dict:
     return {
         "id": id,
         "name": name,
-        "description": f"A collection. {MockSource.owned_tag}",
+        "description": f"A collection. #{MockSource.owned_tag}",
     }
 
 
@@ -107,15 +107,15 @@ def tagged(name: str, description: str = "") -> dict:
     return {
         "name": name,
         "organism": "covid",
-        "description": description or f"A collection. {TAG}",
+        "description": description or f"A collection. #{TAG}",
         "variants": [],
     }
 
 
 def test_orphan_with_tag_is_deleted():
     existing = [
-        {"id": 5, "name": "OldLineage", "description": f"Old. {TAG}"},
-        {"id": 6, "name": "CurrentLineage", "description": f"Current. {TAG}"},
+        {"id": 5, "name": "OldLineage", "description": f"Old. #{TAG}"},
+        {"id": 6, "name": "CurrentLineage", "description": f"Current. #{TAG}"},
     ]
     client = make_client(existing=existing)
     created, updated, deleted = seed_source(
@@ -161,7 +161,7 @@ def test_orphan_with_real_tag_is_deleted():
 
 
 def test_orphan_found_by_both_tag_and_description_deleted_once():
-    entry = {"id": 8, "name": "OldLineage", "description": f"Old. {TAG}"}
+    entry = {"id": 8, "name": "OldLineage", "description": f"Old. #{TAG}"}
     client = make_client(existing=[entry], existing_by_tag=[entry])
     created, updated, deleted = seed_source(client, TaggedMockSource([]))
     assert deleted == 1

--- a/collection-seeding/tests/test_seed.py
+++ b/collection-seeding/tests/test_seed.py
@@ -96,7 +96,7 @@ def test_returns_zero_counts_for_empty_collections():
 
 # --- seed_source: orphan deletion ---
 
-TAG = "#test-tag"
+TAG = "test-tag"
 
 
 class TaggedMockSource(MockSource):

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -181,12 +181,14 @@ export class BackendService extends ApiService {
         organism,
         userId,
         excludeSystemCollections,
-    }: { organism?: string; userId?: number; excludeSystemCollections?: boolean } = {}) {
+        tags,
+    }: { organism?: string; userId?: number; excludeSystemCollections?: boolean; tags?: string } = {}) {
         const requestParams: Record<string, string> = {};
         if (organism !== undefined) requestParams.organism = organism;
         if (userId !== undefined) requestParams.userId = String(userId);
         if (excludeSystemCollections !== undefined)
             requestParams.excludeSystemCollections = String(excludeSystemCollections);
+        if (tags !== undefined) requestParams.tags = tags;
         return this.get({
             url: '/collections',
             requestParams: Object.keys(requestParams).length > 0 ? requestParams : undefined,

--- a/website/src/backendApi/backendService.ts
+++ b/website/src/backendApi/backendService.ts
@@ -22,7 +22,7 @@ const X_REQUEST_ID_HEADER = 'x-request-id';
 
 type EndpointParameters<Response> = {
     url: string;
-    requestParams?: Record<string, string | boolean | undefined>;
+    requestParams?: Record<string, string | string[] | boolean | undefined>;
     schema: ZodSchema<Response>;
 };
 
@@ -32,7 +32,7 @@ class ApiService {
     private readonly axiosInstance: AxiosInstance;
 
     constructor(baseURL: string) {
-        this.axiosInstance = axios.create({ baseURL });
+        this.axiosInstance = axios.create({ baseURL, paramsSerializer: { indexes: null } });
     }
 
     public async get<Response>({ url, requestParams, schema }: EndpointParameters<Response>): Promise<Response> {
@@ -182,8 +182,8 @@ export class BackendService extends ApiService {
         userId,
         excludeSystemCollections,
         tags,
-    }: { organism?: string; userId?: number; excludeSystemCollections?: boolean; tags?: string } = {}) {
-        const requestParams: Record<string, string> = {};
+    }: { organism?: string; userId?: number; excludeSystemCollections?: boolean; tags?: string | string[] } = {}) {
+        const requestParams: Record<string, string | string[]> = {};
         if (organism !== undefined) requestParams.organism = organism;
         if (userId !== undefined) requestParams.userId = String(userId);
         if (excludeSystemCollections !== undefined)

--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -112,11 +112,11 @@ export function WasapPageStateSelector({
                 );
             }
             const { collectionsUserId, collectionsTag } = config.predefinedVariantsSource;
-            const collections = await getBackendServiceForClientside().getCollectionSummaries({
+            return getBackendServiceForClientside().getCollectionSummaries({
                 userId: collectionsUserId,
                 organism: config.internalName,
+                tags: collectionsTag,
             });
-            return collections.filter((c) => c.description?.includes(collectionsTag) ?? false);
         },
     });
 

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -72,7 +72,7 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
             locationNameField: 'locationName',
             predefinedVariantsSource: {
                 collectionsUserId: byEnv(env, { prod: 3, staging: 1, local: 1 }),
-                collectionsTag: '#pango-lineage',
+                collectionsTag: 'pango-lineage',
                 variantSourceLabel: 'Nextclade',
             },
             clinicalLapis: {
@@ -139,7 +139,7 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
             locationNameField: 'locationName',
             predefinedVariantsSource: {
                 collectionsUserId: byEnv(env, { prod: 3, staging: 1, local: 1 }),
-                collectionsTag: '#nextclade-lineage',
+                collectionsTag: 'nextclade-lineage',
                 variantSourceLabel: 'Nextclade',
             },
             clinicalLapis: {
@@ -210,7 +210,7 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
             locationNameField: 'locationName',
             predefinedVariantsSource: {
                 collectionsUserId: byEnv(env, { prod: 3, staging: 1, local: 1 }),
-                collectionsTag: '#nextclade-lineage',
+                collectionsTag: 'nextclade-lineage',
                 variantSourceLabel: 'Nextclade',
             },
             clinicalLapis: {


### PR DESCRIPTION
Closes #1299.

### Summary

The seeder used to embed ownership markers like `#pango-lineage` directly in collection descriptions. These markers drove both orphan detection and client-side filtering in the WASAP frontend.

This commit switches to the backend's first-class tag system:

Seeder:
- `Collection` model gains a `tags` field; all sources populate it with `owned_tag` and no longer embed the marker in the description string.
- `ApiClient` gets `fetch_existing_collections_by_tag` to query `GET /collections?tags=<tag>&organism=<organism>`.
- Orphan detection now unions results from the tag query AND the description-based scan, so existing (pre-migration) collections that lack real tags are still found, deleted, and recreated with proper tags on the first seeder run after deployment.

Frontend:
- `Collection.ts` schema gains an optional `tags` field.
- `BackendService.getCollectionSummaries` accepts an optional `tags` parameter forwarded as a query string.
- `WasapPageStateSelector` passes `tags: collectionsTag` to the backend instead of fetching all collections and filtering client-side by description substring.

### Screenshot

n/a

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
