### PR TITLE
docs: document FC<Props> React component pattern in website AGENTS.md

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -57,6 +57,21 @@ HTTP header names (e.g. `Content-Type`, `Authorization`) must keep their origina
 { 'Content-Type': 'application/json' }
 ```
 
+### React Component Definition
+
+Define React components with a named `type` for props and `FC<Props>`:
+
+```typescript
+type MyComponentProps = {
+    value: string;
+    onChange: (value: string) => void;
+};
+
+export const MyComponent: FC<MyComponentProps> = ({ value, onChange }) => {
+    // ...
+};
+```
+
 ### React & Astro
 
 - Use **Astro** for static/server-rendered pages; use **React** for interactive components.


### PR DESCRIPTION
## Summary

- Adds a "React Component Definition" section to `website/AGENTS.md` documenting the convention of using a named `type` for props and `FC<Props>` for React components
- Follows up on review feedback in #1294

## Test plan

- [ ] No code changes — docs only