### PR TITLE
fix(website): remove incorrect excludeSystemCollections param from tag filter test mocks

### DIFF
--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -152,7 +152,7 @@ describe('CollectionsOverview', () => {
 
     describe('tag filter', () => {
         it('filters by a single tag in All mode', async ({ routeMockers: { astro } }) => {
-            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200, true);
+            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200);
             const { getByText, getByPlaceholder } = renderOverview();
 
             await getByText('All').click();
@@ -167,7 +167,7 @@ describe('CollectionsOverview', () => {
         });
 
         it('filters by multiple tags in All mode', async ({ routeMockers: { astro } }) => {
-            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200, true);
+            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200);
             const { getByText, getByPlaceholder } = renderOverview();
 
             await getByText('All').click();
@@ -184,7 +184,7 @@ describe('CollectionsOverview', () => {
         });
 
         it('applies tag filter within Community mode', async ({ routeMockers: { astro } }) => {
-            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200, true);
+            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200);
             const { getByText, getByPlaceholder } = renderOverview();
 
             await getByPlaceholder(TAG_INPUT_PLACEHOLDER).fill('europe');
@@ -200,7 +200,7 @@ describe('CollectionsOverview', () => {
         it('shows filter-empty message when tag filter excludes all collections', async ({
             routeMockers: { astro },
         }) => {
-            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200, true);
+            astro.mockGetCollectionSummaries(taggedCollections, ORGANISM, 200);
             const { getByText, getByPlaceholder } = renderOverview();
 
             await getByText('All').click();
@@ -214,7 +214,7 @@ describe('CollectionsOverview', () => {
         it('shows filter-empty message when community/official filter excludes all collections', async ({
             routeMockers: { astro },
         }) => {
-            astro.mockGetCollectionSummaries([communityCollection], ORGANISM, 200, true);
+            astro.mockGetCollectionSummaries([communityCollection], ORGANISM, 200);
             const { getByText } = renderOverview();
 
             await getByText('Official').click();


### PR DESCRIPTION
## Summary

- The 5 new `tag filter` tests in `CollectionsOverview.browser.spec.tsx` were all timing out because their mocks were set up with `excludeSystemCollections: true` as a required request param
- The component does all community/official/all filtering client-side and never sends `excludeSystemCollections` in its API request
- The `resolver` in `routeMocker.ts` does strict param matching, so the mock never matched → returned 400 → component had no data
- Fix: remove the spurious `true` 4th argument from all 5 `mockGetCollectionSummaries` calls in the tag filter describe block

## Test plan

- [x] All 11 `CollectionsOverview` browser tests now pass locally (previously 5 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)