### PR TITLE
fix(collection-seeding): sort RSV lineage mutations by position

### DIFF
--- a/collection-seeding/sources/rsv_nextclade_lineages.py
+++ b/collection-seeding/sources/rsv_nextclade_lineages.py
@@ -145,7 +145,7 @@ def _extract_clades(node, parent_clade=None, accum_nuc=None, accum_aa=None):
 
     # Separate nucleotide mutations (key "nuc") from amino acid mutations (all other keys
     # are gene names such as "F", "G", "L", etc.).
-    branch_nuc = muts.get("nuc", [])
+    branch_nuc = sorted(muts.get("nuc", []), key=lambda m: int(m[1:-1]))
     branch_aa_by_gene = {k: v for k, v in muts.items() if k != "nuc"}
 
     # Fold this branch's mutations into the running accumulated state.
@@ -155,11 +155,10 @@ def _extract_clades(node, parent_clade=None, accum_nuc=None, accum_aa=None):
 
     if "clade" in labels:
         # Flatten branch-level AA mutations into GENE:MUT strings for the "new" variant.
-        branch_aa_flat = [
-            f"{gene}:{m}"
-            for gene, gene_muts in branch_aa_by_gene.items()
-            for m in gene_muts
-        ]
+        branch_aa_flat = sorted(
+            [f"{gene}:{m}" for gene, gene_muts in branch_aa_by_gene.items() for m in gene_muts],
+            key=lambda s: (s.split(":")[0], int(s.split(":")[1][1:-1])),
+        )
         yield _CladeInfo(
             clade_name=labels["clade"],
             parent_clade=parent_clade,
@@ -267,7 +266,7 @@ def _format_accum_nuc(accum: dict[str, tuple[str, str]]) -> list[str]:
     E.g. {"982": ("A", "T")} → ["A982T"], meaning: at genome position 982 the reference
     has A and this clade (from root) has T.
     """
-    return [f"{ref}{pos}{cur}" for pos, (ref, cur) in accum.items()]
+    return [f"{ref}{pos}{cur}" for pos, (ref, cur) in sorted(accum.items(), key=lambda item: int(item[0]))]
 
 
 def _format_accum_aa(accum: dict[tuple[str, str], tuple[str, str]]) -> list[str]:
@@ -276,4 +275,4 @@ def _format_accum_aa(accum: dict[tuple[str, str], tuple[str, str]]) -> list[str]
     E.g. {("F", "8"): ("T", "G")} → ["F:T8G"], meaning: in gene F at codon 8 the reference
     has T and this clade (from root) has G.
     """
-    return [f"{gene}:{ref}{pos}{cur}" for (gene, pos), (ref, cur) in accum.items()]
+    return [f"{gene}:{ref}{pos}{cur}" for (gene, pos), (ref, cur) in sorted(accum.items(), key=lambda item: (item[0][0], int(item[0][1])))]

--- a/collection-seeding/tests/test_rsv_nextclade_lineages.py
+++ b/collection-seeding/tests/test_rsv_nextclade_lineages.py
@@ -408,6 +408,64 @@ def test_build_collections_new_aa_variant_contents():
     assert new_aa["filterObject"]["aminoAcidMutations"] == ["F:K124N"]
 
 
+# --- mutation sort order ---
+
+# Tree where mutations are given in reverse-position order to expose any ordering bug.
+#
+#   root
+#   └─ NODE_A  clade "A"  — nuc: G300T, C241T, T59C (descending)
+#                         — aa F: K124N, T8A (descending)  G: T4N
+SORT_TREE = {
+    "tree": {
+        "name": "root",
+        "node_attrs": {},
+        "branch_attrs": {},
+        "children": [
+            {
+                "name": "NODE_A",
+                "node_attrs": {"clade_membership": {"value": "A"}},
+                "branch_attrs": {
+                    "labels": {"clade": "A"},
+                    "mutations": {
+                        "nuc": ["G300T", "C241T", "T59C"],
+                        "F": ["K124N", "T8A"],
+                        "G": ["T4N"],
+                    },
+                },
+                "children": [],
+            }
+        ],
+    }
+}
+
+
+def test_branch_nuc_sorted_by_position():
+    clades = list(_extract_clades(SORT_TREE["tree"]))
+    a = next(c for c in clades if c.clade_name == "A")
+    assert a.branch_nuc == ["T59C", "C241T", "G300T"]
+
+
+def test_branch_aa_sorted_by_gene_then_position():
+    clades = list(_extract_clades(SORT_TREE["tree"]))
+    a = next(c for c in clades if c.clade_name == "A")
+    # F gene comes before G; within F, position 8 before 124
+    assert a.branch_aa == ["F:T8A", "F:K124N", "G:T4N"]
+
+
+def test_full_nuc_sorted_by_position():
+    cols = _build_collections(SORT_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    a = next(c for c in cols if c["name"] == "A")
+    full_nuc = next(v for v in a["variants"] if v["name"] == "Nucleotide substitutions")
+    assert full_nuc["filterObject"]["nucleotideMutations"] == ["T59C", "C241T", "G300T"]
+
+
+def test_full_aa_sorted_by_gene_then_position():
+    cols = _build_collections(SORT_TREE, "rsvA", "RSV-A", "#nextclade-lineage")
+    a = next(c for c in cols if c["name"] == "A")
+    full_aa = next(v for v in a["variants"] if v["name"] == "Amino acid substitutions")
+    assert full_aa["filterObject"]["aminoAcidMutations"] == ["F:T8A", "F:K124N", "G:T4N"]
+
+
 # --- source class attributes ---
 
 


### PR DESCRIPTION
resolves #1275 

## Summary

- Mutations in all four variant lists (full nuc, full AA, branch nuc, branch AA) for RSV Nextclade lineage collections were emitted in dict-insertion or source-JSON order rather than numeric genome position order
- Fixed by sorting in `_format_accum_nuc` (by position int), `_format_accum_aa` (by gene then position int), and at the `branch_nuc`/`branch_aa_flat` construction sites in `_extract_clades`
- Added 4 new tests using a `SORT_TREE` fixture with deliberately descending-order mutations to catch regressions

## Test plan

- [x] `pixi run test tests/test_rsv_nextclade_lineages.py -v` — all 50 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)