### PR TITLE
fix(seeder): filter collections by system user ID

### DIFF
--- a/collection-seeding/api.py
+++ b/collection-seeding/api.py
@@ -33,10 +33,22 @@ class ApiClient:
             f"API at {self.base_url} did not become ready after {attempts} attempts."
         )
 
-    def fetch_existing_collections(self, organism: str) -> list[ExistingCollection]:
+    def get_my_user_id(self) -> int:
+        r = requests.get(
+            f"{self.base_url}/api/users/me",
+            headers=self._auth_headers,
+            timeout=10,
+        )
+        if not r.ok:
+            raise RuntimeError(f"GET /api/users/me failed: {r.status_code} {r.text}")
+        return r.json()["id"]
+
+    def fetch_existing_collections(
+        self, organism: str, user_id: int
+    ) -> list[ExistingCollection]:
         r = requests.get(
             self._collections_url,
-            params={"organism": organism},
+            params={"organism": organism, "userId": user_id},
             headers=self._auth_headers,
             timeout=10,
         )
@@ -45,11 +57,11 @@ class ApiClient:
         return r.json()
 
     def fetch_existing_collections_by_tag(
-        self, tag: str, organism: str
+        self, tag: str, organism: str, user_id: int
     ) -> list[ExistingCollection]:
         r = requests.get(
             self._collections_url,
-            params={"tags": tag, "organism": organism},
+            params={"tags": tag, "organism": organism, "userId": user_id},
             headers=self._auth_headers,
             timeout=10,
         )

--- a/collection-seeding/seed.py
+++ b/collection-seeding/seed.py
@@ -52,12 +52,15 @@ def main():
         if args.wait:
             client.wait_for_api()
 
+        user_id = client.get_my_user_id()
+        print(f"Authenticated as user ID {user_id}.")
+
         while True:
             total_created = 0
             total_updated = 0
             total_deleted = 0
             for source in active:
-                c, u, d = seed_source(client, source)
+                c, u, d = seed_source(client, source, user_id)
                 total_created += c
                 total_updated += u
                 total_deleted += d
@@ -74,7 +77,9 @@ def main():
         sys.exit(1)
 
 
-def seed_source(client: ApiClient, source: Source) -> tuple[int, int, int]:
+def seed_source(
+    client: ApiClient, source: Source, user_id: int
+) -> tuple[int, int, int]:
     """Upsert collections for one source. Returns (created, updated, deleted) counts.
     Matching is by name — if a collection's name changes in the source, the old entry is orphaned and a new one is created."""
     collections = source.get_collections()
@@ -83,8 +88,10 @@ def seed_source(client: ApiClient, source: Source) -> tuple[int, int, int]:
     # Lenient orphan detection: find owned collections via real tags (new-style) OR
     # description pseudo-tags (old-style), so old collections are found and replaced
     # with properly tagged ones on the first seeder run after migration.
-    by_tag = client.fetch_existing_collections_by_tag(source.owned_tag, source.organism)
-    all_existing = client.fetch_existing_collections(source.organism)
+    by_tag = client.fetch_existing_collections_by_tag(
+        source.owned_tag, source.organism, user_id
+    )
+    all_existing = client.fetch_existing_collections(source.organism, user_id)
     by_description = [
         c for c in all_existing if f"#{source.owned_tag}" in (c["description"] or "")
     ]

--- a/collection-seeding/tests/test_seed.py
+++ b/collection-seeding/tests/test_seed.py
@@ -25,6 +25,9 @@ COLLECTIONS = [
 ]
 
 
+USER_ID = 1
+
+
 def make_client(existing=None, existing_by_tag=None):
     client = MagicMock()
     client.fetch_existing_collections.return_value = existing or []
@@ -38,7 +41,7 @@ def make_client(existing=None, existing_by_tag=None):
 
 def test_all_new_creates_all():
     client = make_client(existing=[])
-    created, updated, deleted = seed_source(client, MockSource(COLLECTIONS))
+    created, updated, deleted = seed_source(client, MockSource(COLLECTIONS), USER_ID)
     assert created == len(COLLECTIONS)
     assert updated == 0
     assert deleted == 0
@@ -57,7 +60,7 @@ def existing_entry(id: int, name: str) -> dict:
 def test_all_existing_updates_all():
     existing = [existing_entry(i + 1, c["name"]) for i, c in enumerate(COLLECTIONS)]
     client = make_client(existing=existing)
-    created, updated, deleted = seed_source(client, MockSource(COLLECTIONS))
+    created, updated, deleted = seed_source(client, MockSource(COLLECTIONS), USER_ID)
     assert created == 0
     assert updated == len(COLLECTIONS)
     assert deleted == 0
@@ -68,7 +71,7 @@ def test_all_existing_updates_all():
 def test_mixed_creates_and_updates():
     existing = [existing_entry(10, COLLECTIONS[0]["name"])]
     client = make_client(existing=existing)
-    created, updated, deleted = seed_source(client, MockSource(COLLECTIONS))
+    created, updated, deleted = seed_source(client, MockSource(COLLECTIONS), USER_ID)
     assert created == len(COLLECTIONS) - 1
     assert updated == 1
 
@@ -76,19 +79,19 @@ def test_mixed_creates_and_updates():
 def test_update_uses_correct_id():
     existing = [existing_entry(42, COLLECTIONS[0]["name"])]
     client = make_client(existing=existing)
-    seed_source(client, MockSource([COLLECTIONS[0]]))
+    seed_source(client, MockSource([COLLECTIONS[0]]), USER_ID)
     client.update_collection.assert_called_once_with(42, COLLECTIONS[0])
 
 
 def test_create_passes_full_collection():
     client = make_client(existing=[])
-    seed_source(client, MockSource([COLLECTIONS[0]]))
+    seed_source(client, MockSource([COLLECTIONS[0]]), USER_ID)
     client.create_collection.assert_called_once_with(COLLECTIONS[0])
 
 
 def test_returns_zero_counts_for_empty_collections():
     client = make_client(existing=[])
-    created, updated, deleted = seed_source(client, MockSource([]))
+    created, updated, deleted = seed_source(client, MockSource([]), USER_ID)
     assert created == 0
     assert updated == 0
     assert deleted == 0
@@ -119,7 +122,7 @@ def test_orphan_with_tag_is_deleted():
     ]
     client = make_client(existing=existing)
     created, updated, deleted = seed_source(
-        client, TaggedMockSource([tagged("CurrentLineage")])
+        client, TaggedMockSource([tagged("CurrentLineage")]), USER_ID
     )
     assert deleted == 1
     client.delete_collection.assert_called_once_with(5)
@@ -128,7 +131,7 @@ def test_orphan_with_tag_is_deleted():
 def test_orphan_without_tag_is_not_deleted():
     existing = [{"id": 5, "name": "ManualCollection", "description": "No tag here."}]
     client = make_client(existing=existing)
-    created, updated, deleted = seed_source(client, TaggedMockSource([]))
+    created, updated, deleted = seed_source(client, TaggedMockSource([]), USER_ID)
     assert deleted == 0
     client.delete_collection.assert_not_called()
 
@@ -136,7 +139,7 @@ def test_orphan_without_tag_is_not_deleted():
 def test_no_deletion_when_owned_tag_is_none():
     existing = [{"id": 5, "name": "OldLineage", "description": f"Old. {TAG}"}]
     client = make_client(existing=existing)
-    created, updated, deleted = seed_source(client, MockSource([]))
+    created, updated, deleted = seed_source(client, MockSource([]), USER_ID)
     assert deleted == 0
     client.delete_collection.assert_not_called()
 
@@ -145,7 +148,7 @@ def test_current_collections_are_not_deleted():
     col = tagged("ExistingLineage")
     existing = [{"id": 5, "name": "ExistingLineage", "description": col["description"]}]
     client = make_client(existing=existing)
-    created, updated, deleted = seed_source(client, TaggedMockSource([col]))
+    created, updated, deleted = seed_source(client, TaggedMockSource([col]), USER_ID)
     assert deleted == 0
     client.delete_collection.assert_not_called()
 
@@ -155,7 +158,7 @@ def test_orphan_with_real_tag_is_deleted():
         {"id": 7, "name": "OldLineage", "description": "No pseudo-tag here."}
     ]
     client = make_client(existing=[], existing_by_tag=existing_by_tag)
-    created, updated, deleted = seed_source(client, TaggedMockSource([]))
+    created, updated, deleted = seed_source(client, TaggedMockSource([]), USER_ID)
     assert deleted == 1
     client.delete_collection.assert_called_once_with(7)
 
@@ -163,6 +166,6 @@ def test_orphan_with_real_tag_is_deleted():
 def test_orphan_found_by_both_tag_and_description_deleted_once():
     entry = {"id": 8, "name": "OldLineage", "description": f"Old. #{TAG}"}
     client = make_client(existing=[entry], existing_by_tag=[entry])
-    created, updated, deleted = seed_source(client, TaggedMockSource([]))
+    created, updated, deleted = seed_source(client, TaggedMockSource([]), USER_ID)
     assert deleted == 1
     client.delete_collection.assert_called_once_with(8)

--- a/website/tests/auth/usersMe.spec.ts
+++ b/website/tests/auth/usersMe.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from '@playwright/test';
 
 import { test } from '../e2e.fixture.ts';
+import { E2E_GITHUB_ID } from '../helpers/auth.ts';
+import { generateApiKey, revokeApiKey, syncUser } from '../helpers/backendClient.ts';
 
 test('GET /api/users/me returns 401 when not authenticated', async ({ request }) => {
     const response = await request.get('/api/users/me');
@@ -15,4 +17,22 @@ test('GET /api/users/me returns user data when authenticated', async ({ authenti
     const body = (await response.json()) as { id: number; name: string };
     expect(typeof body.id).toBe('number');
     expect(body.name).toBe('e2e-test');
+});
+
+test('GET /api/users/me returns user data when authenticated via Bearer token', async ({ request }) => {
+    const userId = await syncUser(request, E2E_GITHUB_ID);
+    const apiKey = await generateApiKey(request, userId);
+
+    try {
+        const response = await request.get('/api/users/me', {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            headers: { Authorization: `Bearer ${apiKey}` },
+        });
+
+        expect(response.status()).toBe(200);
+        const body = (await response.json()) as { id: number; name: string };
+        expect(body.id).toBe(userId);
+    } finally {
+        await revokeApiKey(request, userId);
+    }
 });

--- a/website/tests/helpers/backendClient.ts
+++ b/website/tests/helpers/backendClient.ts
@@ -27,3 +27,14 @@ export async function deleteCollection(
     const response = await request.delete(`${BACKEND_URL}/collections/${collectionId}?userId=${userId}`);
     expect(response.status()).toBe(204);
 }
+
+export async function generateApiKey(request: APIRequestContext, userId: number): Promise<string> {
+    const response = await request.post(`${BACKEND_URL}/api-keys?userId=${userId}`);
+    expect(response.status()).toBe(201);
+    const body = (await response.json()) as { key: string };
+    return body.key;
+}
+
+export async function revokeApiKey(request: APIRequestContext, userId: number): Promise<void> {
+    await request.delete(`${BACKEND_URL}/api-keys?userId=${userId}`);
+}


### PR DESCRIPTION
resolves #1307 

### Summary

The seeder was fetching all collections matching organism/tags without a userId filter, which could cause it to delete collections belonging to other users if their descriptions contained the owned-tag string.

The fix calls GET /api/users/me at startup (which supports Bearer token auth) to resolve the API key to a userId, then passes that userId to all fetch_existing_collections calls so only the seeder's own collections are considered for update or deletion.

Also adds an e2e test verifying that /api/users/me works with Bearer token authentication, and adds generateApiKey/revokeApiKey helpers to backendClient.

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
