### PR TITLE
docs(agents): add PR creation guidelines with conventional commits and template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,13 @@ chore: update dependencies
 
 ---
 
+## Pull Requests
+
+- PR titles must follow the conventional commits pattern (e.g. `feat(website): add user dashboard`, `fix(backend): correct auth token expiry`).
+- Use the PR template at `.github/pull_request_template.md` when creating PRs.
+
+---
+
 ## Architecture Notes
 
 - **State in URL**: View state (filters, selected variants) is stored as query parameters so pages are bookmarkable and shareable.


### PR DESCRIPTION
### Summary

Adds a Pull Requests section to `AGENTS.md` instructing agents to follow the conventional commits pattern for PR titles and to use the repository's PR template at `.github/pull_request_template.md`.

## PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.