### PR TITLE
feat(collections): persist filter and tag state in URL

### DIFF
--- a/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.browser.spec.tsx
@@ -1,5 +1,5 @@
 import { userEvent } from '@vitest/browser/context';
-import { describe, expect } from 'vitest';
+import { beforeEach, describe, expect } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { CollectionsOverview } from './CollectionsOverview';
@@ -90,6 +90,10 @@ function renderOverview() {
 }
 
 describe('CollectionsOverview', () => {
+    beforeEach(() => {
+        window.history.replaceState(null, '', '/');
+    });
+
     it('shows the headline and community collections by default', async ({ routeMockers: { astro } }) => {
         astro.mockGetCollectionSummaries(allCollections, ORGANISM, 200);
 

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -14,6 +14,7 @@ import { organismConfig, type Organism } from '../../../types/Organism.ts';
 import { Page } from '../../../types/pages.ts';
 import { getErrorLogMessage } from '../../../util/getErrorLogMessage.ts';
 import {
+    CollectionFilters,
     CollectionsOverviewPageStateHandler,
     type CollectionFilter,
 } from '../../../views/pageStateHandlers/CollectionsOverviewPageStateHandler.ts';
@@ -113,13 +114,13 @@ function filterCollections(
     if (!collections) return [];
     let result: CollectionSummary[];
     switch (filter) {
-        case 'community':
+        case CollectionFilters.community:
             result = collections.filter((c) => c.ownedBy !== systemUserId);
             break;
-        case 'official':
+        case CollectionFilters.official:
             result = collections.filter((c) => c.ownedBy === systemUserId);
             break;
-        case 'all':
+        case CollectionFilters.all:
             result = collections;
             break;
     }
@@ -130,9 +131,9 @@ function filterCollections(
 }
 
 const FILTER_OPTIONS: { value: CollectionFilter; label: string; tooltip: string }[] = [
-    { value: 'community', label: 'Community', tooltip: 'User submissions' },
-    { value: 'official', label: 'Official', tooltip: 'GenSpectrum curated' },
-    { value: 'all', label: 'All', tooltip: 'Show everything' },
+    { value: CollectionFilters.community, label: 'Community', tooltip: 'User submissions' },
+    { value: CollectionFilters.official, label: 'Official', tooltip: 'GenSpectrum curated' },
+    { value: CollectionFilters.all, label: 'All', tooltip: 'Show everything' },
 ];
 
 function CollectionFilterSelect({

--- a/website/src/components/collections/overview/CollectionsOverview.tsx
+++ b/website/src/components/collections/overview/CollectionsOverview.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { h } from 'gridjs';
 import { Grid } from 'gridjs-react';
-import { Fragment, useId, useState } from 'react';
+import { Fragment, useId, useMemo } from 'react';
 
 import 'gridjs/dist/theme/mermaid.css';
 
@@ -13,13 +13,16 @@ import type { CollectionSummary } from '../../../types/Collection.ts';
 import { organismConfig, type Organism } from '../../../types/Organism.ts';
 import { Page } from '../../../types/pages.ts';
 import { getErrorLogMessage } from '../../../util/getErrorLogMessage.ts';
+import {
+    CollectionsOverviewPageStateHandler,
+    type CollectionFilter,
+} from '../../../views/pageStateHandlers/CollectionsOverviewPageStateHandler.ts';
+import { usePageState } from '../../views/usePageState.ts';
 import { TagInput } from '../form/TagInput.tsx';
 
 export const CollectionsOverview = withQueryProvider(CollectionsOverviewInner);
 
 const logger = getClientLogger('CollectionsOverview');
-
-type CollectionFilter = 'community' | 'official' | 'all';
 
 function CollectionsOverviewInner({
     organism,
@@ -30,8 +33,12 @@ function CollectionsOverviewInner({
     isLoggedIn: boolean;
     systemUserId: number;
 }) {
-    const [filter, setFilter] = useState<CollectionFilter>('community');
-    const [tagFilter, setTagFilter] = useState<string[]>([]);
+    const pageStateHandler = useMemo(
+        () => new CollectionsOverviewPageStateHandler(Page.collectionsForOrganism(organism)),
+        [organism],
+    );
+    const { pageState, setPageState } = usePageState(pageStateHandler);
+    const { filter, tagFilter } = pageState;
 
     const {
         isLoading,
@@ -60,9 +67,15 @@ function CollectionsOverviewInner({
                 )}
             </div>
             <div className='mt-4 flex flex-wrap items-start gap-4'>
-                <CollectionFilterSelect filter={filter} onChange={setFilter} />
+                <CollectionFilterSelect
+                    filter={filter}
+                    onChange={(f) => setPageState((prev) => ({ ...prev, filter: f }))}
+                />
                 <div className='flex-1'>
-                    <TagInput tags={tagFilter} onChange={setTagFilter} />
+                    <TagInput
+                        tags={tagFilter}
+                        onChange={(tags) => setPageState((prev) => ({ ...prev, tagFilter: tags }))}
+                    />
                 </div>
             </div>
             {isLoading ? (

--- a/website/src/pages/collections/[pathFragment]/index.astro
+++ b/website/src/pages/collections/[pathFragment]/index.astro
@@ -25,5 +25,5 @@ const isLoggedIn = Astro.locals.user !== undefined;
         { name: orgConfig.label, href: Page.collectionsForOrganism(organism) },
     ]}
 >
-    <CollectionsOverview client:load organism={organism} isLoggedIn={isLoggedIn} systemUserId={getSystemUserId()} />
+    <CollectionsOverview client:only='react' organism={organism} isLoggedIn={isLoggedIn} systemUserId={getSystemUserId()} />
 </ContaineredPageLayout>

--- a/website/src/pages/collections/[pathFragment]/index.astro
+++ b/website/src/pages/collections/[pathFragment]/index.astro
@@ -25,5 +25,10 @@ const isLoggedIn = Astro.locals.user !== undefined;
         { name: orgConfig.label, href: Page.collectionsForOrganism(organism) },
     ]}
 >
-    <CollectionsOverview client:only='react' organism={organism} isLoggedIn={isLoggedIn} systemUserId={getSystemUserId()} />
+    <CollectionsOverview
+        client:only='react'
+        organism={organism}
+        isLoggedIn={isLoggedIn}
+        systemUserId={getSystemUserId()}
+    />
 </ContaineredPageLayout>

--- a/website/src/views/pageStateHandlers/CollectionsOverviewPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/CollectionsOverviewPageStateHandler.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { CollectionFilters, CollectionsOverviewPageStateHandler } from './CollectionsOverviewPageStateHandler';
+
+const PATH = '/collections/covid';
+
+describe('CollectionsOverviewPageStateHandler', () => {
+    const handler = new CollectionsOverviewPageStateHandler(PATH);
+
+    describe('parsePageStateFromUrl', () => {
+        it('defaults to community filter and no tags when URL has no params', () => {
+            const url = new URL('http://example.com/collections/covid');
+            expect(handler.parsePageStateFromUrl(url)).toEqual({
+                filter: CollectionFilters.community,
+                tagFilter: [],
+            });
+        });
+
+        it('parses a non-default filter', () => {
+            const url = new URL('http://example.com/collections/covid?filter=official');
+            expect(handler.parsePageStateFromUrl(url)).toEqual({
+                filter: CollectionFilters.official,
+                tagFilter: [],
+            });
+        });
+
+        it('parses multiple tags', () => {
+            const url = new URL('http://example.com/collections/covid?tag=ebola&tag=mpox');
+            expect(handler.parsePageStateFromUrl(url)).toEqual({
+                filter: CollectionFilters.community,
+                tagFilter: ['ebola', 'mpox'],
+            });
+        });
+
+        it('parses filter and tags together', () => {
+            const url = new URL('http://example.com/collections/covid?filter=all&tag=ebola&tag=mpox');
+            expect(handler.parsePageStateFromUrl(url)).toEqual({
+                filter: CollectionFilters.all,
+                tagFilter: ['ebola', 'mpox'],
+            });
+        });
+
+        it('falls back to default filter for an unrecognised filter value', () => {
+            const url = new URL('http://example.com/collections/covid?filter=invalid');
+            expect(handler.parsePageStateFromUrl(url)).toEqual({
+                filter: CollectionFilters.community,
+                tagFilter: [],
+            });
+        });
+    });
+
+    describe('toUrl', () => {
+        it('produces a clean URL for the default state', () => {
+            expect(handler.toUrl({ filter: CollectionFilters.community, tagFilter: [] })).toBe(PATH);
+        });
+
+        it('includes filter param when non-default', () => {
+            expect(handler.toUrl({ filter: CollectionFilters.official, tagFilter: [] })).toBe(
+                `${PATH}?filter=official&`,
+            );
+        });
+
+        it('includes tag params', () => {
+            expect(handler.toUrl({ filter: CollectionFilters.community, tagFilter: ['ebola', 'mpox'] })).toBe(
+                `${PATH}?tag=ebola&tag=mpox&`,
+            );
+        });
+
+        it('includes both filter and tag params', () => {
+            expect(handler.toUrl({ filter: CollectionFilters.all, tagFilter: ['ebola'] })).toBe(
+                `${PATH}?filter=all&tag=ebola&`,
+            );
+        });
+    });
+
+    describe('getDefaultPageUrl', () => {
+        it('returns the bare path', () => {
+            expect(handler.getDefaultPageUrl()).toBe(PATH);
+        });
+    });
+});

--- a/website/src/views/pageStateHandlers/CollectionsOverviewPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CollectionsOverviewPageStateHandler.ts
@@ -1,0 +1,41 @@
+import type { PageStateHandler } from './PageStateHandler';
+import { formatUrl } from '../../util/formatUrl';
+
+export type CollectionFilter = 'community' | 'official' | 'all';
+
+export type CollectionsOverviewPageState = {
+    filter: CollectionFilter;
+    tagFilter: string[];
+};
+
+const COLLECTION_FILTER_VALUES: CollectionFilter[] = ['community', 'official', 'all'];
+const DEFAULT_FILTER: CollectionFilter = 'community';
+
+export class CollectionsOverviewPageStateHandler implements PageStateHandler<CollectionsOverviewPageState> {
+    constructor(private readonly path: string) {}
+
+    parsePageStateFromUrl(url: URL): CollectionsOverviewPageState {
+        const filterParam = url.searchParams.get('filter');
+        const filter: CollectionFilter =
+            filterParam !== null && (COLLECTION_FILTER_VALUES as string[]).includes(filterParam)
+                ? (filterParam as CollectionFilter)
+                : DEFAULT_FILTER;
+        const tagFilter = url.searchParams.getAll('tag');
+        return { filter, tagFilter };
+    }
+
+    toUrl(pageState: CollectionsOverviewPageState): string {
+        const search = new URLSearchParams();
+        if (pageState.filter !== DEFAULT_FILTER) {
+            search.set('filter', pageState.filter);
+        }
+        for (const tag of pageState.tagFilter) {
+            search.append('tag', tag);
+        }
+        return formatUrl(this.path, search);
+    }
+
+    getDefaultPageUrl(): string {
+        return this.path;
+    }
+}

--- a/website/src/views/pageStateHandlers/CollectionsOverviewPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CollectionsOverviewPageStateHandler.ts
@@ -1,15 +1,20 @@
 import type { PageStateHandler } from './PageStateHandler';
 import { formatUrl } from '../../util/formatUrl';
 
-export type CollectionFilter = 'community' | 'official' | 'all';
+export const CollectionFilters = {
+    community: 'community' as const,
+    official: 'official' as const,
+    all: 'all' as const,
+};
+
+export type CollectionFilter = keyof typeof CollectionFilters;
 
 export type CollectionsOverviewPageState = {
     filter: CollectionFilter;
     tagFilter: string[];
 };
 
-const COLLECTION_FILTER_VALUES: CollectionFilter[] = ['community', 'official', 'all'];
-const DEFAULT_FILTER: CollectionFilter = 'community';
+const DEFAULT_FILTER: CollectionFilter = CollectionFilters.community;
 
 export class CollectionsOverviewPageStateHandler implements PageStateHandler<CollectionsOverviewPageState> {
     constructor(private readonly path: string) {}
@@ -17,7 +22,7 @@ export class CollectionsOverviewPageStateHandler implements PageStateHandler<Col
     parsePageStateFromUrl(url: URL): CollectionsOverviewPageState {
         const filterParam = url.searchParams.get('filter');
         const filter: CollectionFilter =
-            filterParam !== null && (COLLECTION_FILTER_VALUES as string[]).includes(filterParam)
+            filterParam !== null && filterParam in CollectionFilters
                 ? (filterParam as CollectionFilter)
                 : DEFAULT_FILTER;
         const tagFilter = url.searchParams.getAll('tag');

--- a/website/src/views/pageStateHandlers/CollectionsOverviewPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/CollectionsOverviewPageStateHandler.ts
@@ -21,8 +21,9 @@ export class CollectionsOverviewPageStateHandler implements PageStateHandler<Col
 
     parsePageStateFromUrl(url: URL): CollectionsOverviewPageState {
         const filterParam = url.searchParams.get('filter');
+        const filterValues = Object.values(CollectionFilters) as string[];
         const filter: CollectionFilter =
-            filterParam !== null && filterParam in CollectionFilters
+            filterParam !== null && filterValues.includes(filterParam)
                 ? (filterParam as CollectionFilter)
                 : DEFAULT_FILTER;
         const tagFilter = url.searchParams.getAll('tag');


### PR DESCRIPTION
Closes #1302

### Summary

Implements CollectionsOverviewPageStateHandler following the existing PageStateHandler pattern, and wires it into CollectionsOverview via usePageState so that filter and tag selections are reflected in the URL and survive page refreshes and back/forward navigation.

URL format: `?filter=official&tag=ebola&tag=mpox`

Default filter ('community') and empty tag list produce a clean URL with no search params.

### Screenshot


https://github.com/user-attachments/assets/20fde4d1-6bd3-4773-9a8b-85d89c2e2e73



## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
