### PR TITLE
fix(website): show 403 error instead of 404 when editing unowned collection

### DIFF
--- a/website/src/components/auth/NotAuthorized.astro
+++ b/website/src/components/auth/NotAuthorized.astro
@@ -1,0 +1,9 @@
+---
+import { PageContainer } from '../../styles/containers/PageContainer';
+import { PageHeadline } from '../../styles/containers/PageHeadline';
+---
+
+<PageContainer>
+    <PageHeadline>Not authorized</PageHeadline>
+    <div class='mb-2'>You do not have permission to edit this collection.</div>
+</PageContainer>

--- a/website/src/components/auth/NotAuthorized.astro
+++ b/website/src/components/auth/NotAuthorized.astro
@@ -1,9 +1,0 @@
----
-import { PageContainer } from '../../styles/containers/PageContainer';
-import { PageHeadline } from '../../styles/containers/PageHeadline';
----
-
-<PageContainer>
-    <PageHeadline>Not authorized</PageHeadline>
-    <div class='mb-2'>You do not have permission to edit this collection.</div>
-</PageContainer>

--- a/website/src/pages/collections/[pathFragment]/[id]/edit.astro
+++ b/website/src/pages/collections/[pathFragment]/[id]/edit.astro
@@ -2,12 +2,12 @@
 import { BackendError, BackendService } from '../../../../backendApi/backendService.ts';
 import NotLoggedIn from '../../../../components/auth/NotLoggedIn.astro';
 import { CollectionEdit } from '../../../../components/collections/edit/CollectionEdit';
-import { PageContainer } from '../../../../styles/containers/PageContainer';
-import { PageHeadline } from '../../../../styles/containers/PageHeadline';
 import { getDashboardsConfig, getBackendHost } from '../../../../config';
 import { defaultBreadcrumbs } from '../../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
 import { getInstanceLogger } from '../../../../logger.ts';
+import { PageContainer } from '../../../../styles/containers/PageContainer';
+import { PageHeadline } from '../../../../styles/containers/PageHeadline';
 import { organismConfig, organismFromPathFragment } from '../../../../types/Organism';
 import { Page } from '../../../../types/pages';
 import { getErrorLogMessage } from '../../../../util/getErrorLogMessage.ts';

--- a/website/src/pages/collections/[pathFragment]/[id]/edit.astro
+++ b/website/src/pages/collections/[pathFragment]/[id]/edit.astro
@@ -1,5 +1,6 @@
 ---
 import { BackendError, BackendService } from '../../../../backendApi/backendService.ts';
+import NotAuthorized from '../../../../components/auth/NotAuthorized.astro';
 import NotLoggedIn from '../../../../components/auth/NotLoggedIn.astro';
 import { CollectionEdit } from '../../../../components/collections/edit/CollectionEdit';
 import { getDashboardsConfig, getBackendHost } from '../../../../config';
@@ -28,11 +29,13 @@ const currentUserId = Astro.locals.gsUserId;
 const config = getDashboardsConfig();
 
 let collection;
+let isNotOwner = false;
 if (currentUserId !== undefined) {
     try {
         collection = await new BackendService(getBackendHost()).getCollection({ id });
         if (currentUserId !== collection.ownedBy) {
-            return Astro.redirect('/404');
+            isNotOwner = true;
+            Astro.response.status = 403;
         }
     } catch (error) {
         if (error instanceof BackendError && error.status === 404) {
@@ -57,7 +60,11 @@ const collectionTitle = collection !== undefined ? `#${id} ${collection.name}` :
     ]}
 >
     {
-        currentUserId !== undefined ? (
+        currentUserId === undefined ? (
+            <NotLoggedIn />
+        ) : isNotOwner ? (
+            <NotAuthorized />
+        ) : (
             <CollectionEdit
                 client:only='react'
                 organism={organism}
@@ -68,8 +75,6 @@ const collectionTitle = collection !== undefined ? `#${id} ${collection.name}` :
                     collection!
                 }
             />
-        ) : (
-            <NotLoggedIn />
         )
     }
 </ContaineredPageLayout>

--- a/website/src/pages/collections/[pathFragment]/[id]/edit.astro
+++ b/website/src/pages/collections/[pathFragment]/[id]/edit.astro
@@ -1,8 +1,9 @@
 ---
 import { BackendError, BackendService } from '../../../../backendApi/backendService.ts';
-import NotAuthorized from '../../../../components/auth/NotAuthorized.astro';
 import NotLoggedIn from '../../../../components/auth/NotLoggedIn.astro';
 import { CollectionEdit } from '../../../../components/collections/edit/CollectionEdit';
+import { PageContainer } from '../../../../styles/containers/PageContainer';
+import { PageHeadline } from '../../../../styles/containers/PageHeadline';
 import { getDashboardsConfig, getBackendHost } from '../../../../config';
 import { defaultBreadcrumbs } from '../../../../layouts/Breadcrumbs';
 import ContaineredPageLayout from '../../../../layouts/ContaineredPage/ContaineredPageLayout.astro';
@@ -63,7 +64,10 @@ const collectionTitle = collection !== undefined ? `#${id} ${collection.name}` :
         currentUserId === undefined ? (
             <NotLoggedIn />
         ) : isNotOwner ? (
-            <NotAuthorized />
+            <PageContainer>
+                <PageHeadline>Not authorized</PageHeadline>
+                <div>You do not have permission to edit this collection.</div>
+            </PageContainer>
         ) : (
             <CollectionEdit
                 client:only='react'

--- a/website/tests/collections/collectionForm.spec.ts
+++ b/website/tests/collections/collectionForm.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 import { test } from '../e2e.fixture.ts';
-import { E2E_GITHUB_ID } from '../helpers/auth.ts';
+import { E2E_GITHUB_ID, setupAuthCookie } from '../helpers/auth.ts';
 import { createCollection, deleteCollection, syncUser } from '../helpers/backendClient.ts';
 
 const ORGANISM = 'covid';
@@ -157,6 +157,19 @@ test.describe('Edit collection page', () => {
         await authenticatedCollectionFormPage.gotoEdit(ORGANISM, getCollectionId());
 
         await expect(authenticatedCollectionFormPage.collectionDescriptionTextarea()).toHaveValue('');
+    });
+
+    test('shows "Not authorized" with 403 when editing a collection owned by another user', async ({
+        page,
+        request,
+    }) => {
+        const otherUserId = await syncUser(request, 'e2e-other-99999');
+        await setupAuthCookie(page, 'e2e-other', otherUserId);
+
+        const response = await page.goto(`/collections/${ORGANISM}/${getCollectionId()}/edit`);
+
+        expect(response?.status()).toBe(403);
+        await expect(page.getByRole('heading', { name: 'Not authorized' })).toBeVisible();
     });
 
     test('"Delete collection" shows confirmation dialog; Cancel dismisses it', async ({


### PR DESCRIPTION
resolves #1160 

## Summary

- Visiting `collections/<id>/edit` for a collection you don't own previously returned a generic 404 redirect
- Now returns a proper 403 HTTP status and renders a friendly "Not authorized" error page

