### PR TITLE
refactor(website): rename wasap 'collection' mode to 'covSpectrumCollection'

### DIFF
--- a/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
+++ b/website/src/components/pageStateSelectors/wasap/WasapPageStateSelector.tsx
@@ -6,7 +6,7 @@ import { ApplyFilterButton } from '../ApplyFilterButton';
 import { DynamicDateFilter } from '../DynamicDateFilter';
 import { SelectorHeadline } from '../SelectorHeadline';
 import { ExplorationModeInfo } from './InfoBlocks';
-import { CollectionAnalysisFilter } from './filters/CollectionAnalysisFilter';
+import { CovSpectrumCollectionAnalysisFilter } from './filters/CovSpectrumCollectionAnalysisFilter';
 import { ManualAnalysisFilter } from './filters/ManualAnalysisFilter';
 import { ResistanceMutationsFilter } from './filters/ResistanceMutationsFilter';
 import { UntrackedFilter } from './filters/UntrackedFilter';
@@ -58,8 +58,8 @@ export function WasapPageStateSelector({
         setResistanceFilter,
         untrackedFilter,
         setUntrackedFilter,
-        collectionFilter,
-        setCollectionFilter,
+        covSpectrumCollectionFilter,
+        setCovSpectrumCollectionFilter,
     } = useAnalysisFilterStates(initialAnalysisFilterState, config);
 
     const [selectedAnalysisMode, setSelectedAnalysisMode] = useState(initialAnalysisFilterState.mode);
@@ -77,8 +77,8 @@ export function WasapPageStateSelector({
                 return { base: baseFilterState, analysis: resistanceFilter! };
             case 'untracked':
                 return { base: baseFilterState, analysis: untrackedFilter! };
-            case 'collection':
-                return { base: baseFilterState, analysis: collectionFilter! };
+            case 'covSpectrumCollection':
+                return { base: baseFilterState, analysis: covSpectrumCollectionFilter! };
         }
         /* eslint-enable  @typescript-eslint/no-non-null-assertion */
     }
@@ -232,14 +232,17 @@ export function WasapPageStateSelector({
                                     cladeLineageQueryResult={cladeLineageQueryResult}
                                 />
                             );
-                        case 'collection':
-                            if (!config.collectionAnalysisModeEnabled || collectionFilter === undefined) {
-                                throw Error("'collection' mode selected, but it isn't enabled.");
+                        case 'covSpectrumCollection':
+                            if (
+                                !config.covSpectrumCollectionAnalysisModeEnabled ||
+                                covSpectrumCollectionFilter === undefined
+                            ) {
+                                throw Error("'covSpectrumCollection' mode selected, but it isn't enabled.");
                             }
                             return (
-                                <CollectionAnalysisFilter
-                                    pageState={collectionFilter}
-                                    setPageState={setCollectionFilter}
+                                <CovSpectrumCollectionAnalysisFilter
+                                    pageState={covSpectrumCollectionFilter}
+                                    setPageState={setCovSpectrumCollectionFilter}
                                     collectionsApiBaseUrl={config.collectionsApiBaseUrl}
                                     collectionTitleFilter={config.collectionTitleFilter}
                                 />
@@ -266,8 +269,8 @@ function modeLabel(mode: WasapAnalysisMode): string {
             return 'Variant Explorer';
         case 'untracked':
             return 'Untracked Mutations';
-        case 'collection':
-            return 'Collection';
+        case 'covSpectrumCollection':
+            return 'CovSpectrum Collection';
     }
 }
 
@@ -305,11 +308,11 @@ function useAnalysisFilterStates(initialFilter: WasapAnalysisFilter, config: Was
               ? config.filterDefaults.untracked
               : undefined,
     );
-    const [collectionFilter, setCollectionFilter] = useState(
-        initialFilter.mode === 'collection'
+    const [covSpectrumCollectionFilter, setCovSpectrumCollectionFilter] = useState(
+        initialFilter.mode === 'covSpectrumCollection'
             ? initialFilter
-            : config.collectionAnalysisModeEnabled
-              ? config.filterDefaults.collection
+            : config.covSpectrumCollectionAnalysisModeEnabled
+              ? config.filterDefaults.covSpectrumCollection
               : undefined,
     );
 
@@ -322,7 +325,7 @@ function useAnalysisFilterStates(initialFilter: WasapAnalysisFilter, config: Was
         setResistanceFilter,
         untrackedFilter,
         setUntrackedFilter,
-        collectionFilter,
-        setCollectionFilter,
+        covSpectrumCollectionFilter,
+        setCovSpectrumCollectionFilter,
     };
 }

--- a/website/src/components/pageStateSelectors/wasap/filters/CovSpectrumCollectionAnalysisFilter.browser.spec.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/CovSpectrumCollectionAnalysisFilter.browser.spec.tsx
@@ -2,10 +2,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
-import { CollectionAnalysisFilter } from './CollectionAnalysisFilter';
+import { CovSpectrumCollectionAnalysisFilter } from './CovSpectrumCollectionAnalysisFilter';
 import { it } from '../../../../../test-extend';
 import type { CollectionRaw } from '../../../../covspectrum/types';
-import type { WasapCollectionFilter } from '../../../views/wasap/wasapPageConfig';
+import type { WasapCovSpectrumCollectionFilter } from '../../../views/wasap/wasapPageConfig';
 
 const DUMMY_COV_SPECTRUM_URL = 'https://cov-spectrum-dummy.com/api';
 
@@ -30,9 +30,9 @@ const mockCollections: CollectionRaw[] = [
 
 const queryClient = new QueryClient();
 
-describe('CollectionAnalysisFilter', () => {
-    const defaultPageState: WasapCollectionFilter = {
-        mode: 'collection',
+describe('CovSpectrumCollectionAnalysisFilter', () => {
+    const defaultPageState: WasapCovSpectrumCollectionFilter = {
+        mode: 'covSpectrumCollection',
         collectionId: 42,
     };
 
@@ -43,7 +43,7 @@ describe('CollectionAnalysisFilter', () => {
 
         const { getByRole } = render(
             <QueryClientProvider client={queryClient}>
-                <CollectionAnalysisFilter
+                <CovSpectrumCollectionAnalysisFilter
                     pageState={defaultPageState}
                     setPageState={mockSetPageState}
                     collectionsApiBaseUrl={DUMMY_COV_SPECTRUM_URL}
@@ -63,7 +63,7 @@ describe('CollectionAnalysisFilter', () => {
 
         const { getByRole } = render(
             <QueryClientProvider client={queryClient}>
-                <CollectionAnalysisFilter
+                <CovSpectrumCollectionAnalysisFilter
                     pageState={defaultPageState}
                     setPageState={mockSetPageState}
                     collectionsApiBaseUrl={DUMMY_COV_SPECTRUM_URL}

--- a/website/src/components/pageStateSelectors/wasap/filters/CovSpectrumCollectionAnalysisFilter.tsx
+++ b/website/src/components/pageStateSelectors/wasap/filters/CovSpectrumCollectionAnalysisFilter.tsx
@@ -1,18 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getCollections } from '../../../../covspectrum/getCollections';
-import type { WasapCollectionFilter } from '../../../views/wasap/wasapPageConfig';
+import type { WasapCovSpectrumCollectionFilter } from '../../../views/wasap/wasapPageConfig';
 import { CollectionInfo } from '../InfoBlocks';
 import { LabeledField } from '../utils/LabeledField';
 
-export function CollectionAnalysisFilter({
+export function CovSpectrumCollectionAnalysisFilter({
     pageState,
     setPageState,
     collectionsApiBaseUrl,
     collectionTitleFilter,
 }: {
-    pageState: WasapCollectionFilter;
-    setPageState: (newState: WasapCollectionFilter) => void;
+    pageState: WasapCovSpectrumCollectionFilter;
+    setPageState: (newState: WasapCovSpectrumCollectionFilter) => void;
     collectionsApiBaseUrl: string;
     collectionTitleFilter: string;
 }) {

--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import type {
     VariantTimeFrame,
     WasapAnalysisFilter,
-    WasapCollectionFilter,
+    WasapCovSpectrumCollectionFilter,
     WasapManualFilter,
     WasapPageConfig,
     WasapResistanceFilter,
@@ -51,8 +51,8 @@ async function fetchWasapPageData(
             return fetchResistanceModeData(resistanceMutationsBySet, analysis);
         case 'untracked':
             return fetchUntrackedModeData(config, analysis);
-        case 'collection':
-            return fetchCollectionModeData(config, analysis);
+        case 'covSpectrumCollection':
+            return fetchCovSpectrumCollectionModeData(config, analysis);
     }
 }
 
@@ -229,12 +229,12 @@ async function fetchUntrackedModeData(
     };
 }
 
-async function fetchCollectionModeData(
+async function fetchCovSpectrumCollectionModeData(
     config: WasapPageConfig,
-    analysis: WasapCollectionFilter,
+    analysis: WasapCovSpectrumCollectionFilter,
 ): Promise<WasapCollectionData> {
-    if (!config.collectionAnalysisModeEnabled) {
-        throw Error("Cannot fetch data, 'collection' mode is not enabled.");
+    if (!config.covSpectrumCollectionAnalysisModeEnabled) {
+        throw Error("Cannot fetch data, 'covSpectrumCollection' mode is not enabled.");
     }
     if (!analysis.collectionId) {
         throw Error('No collection selected');

--- a/website/src/components/views/wasap/wasapPageConfig.ts
+++ b/website/src/components/views/wasap/wasapPageConfig.ts
@@ -56,7 +56,7 @@ type AnalysisModeConfigs = ManualAnalysisModeConfig &
     VariantAnalysisModeConfig &
     ResistanceAnalysisModeConfig &
     UntrackedAnalyisModeConfig &
-    CollectionAnalysisModeConfig;
+    CovSpectrumCollectionAnalysisModeConfig;
 
 type ManualAnalysisModeConfig =
     | {
@@ -119,16 +119,16 @@ type UntrackedAnalyisModeConfig =
           };
       };
 
-type CollectionAnalysisModeConfig =
+type CovSpectrumCollectionAnalysisModeConfig =
     | {
-          collectionAnalysisModeEnabled?: never;
+          covSpectrumCollectionAnalysisModeEnabled?: never;
       }
     | {
-          collectionAnalysisModeEnabled: true;
+          covSpectrumCollectionAnalysisModeEnabled: true;
           collectionsApiBaseUrl: string;
           collectionTitleFilter: string;
           filterDefaults: {
-              collection: WasapCollectionFilter;
+              covSpectrumCollection: WasapCovSpectrumCollectionFilter;
           };
       };
 
@@ -149,8 +149,8 @@ export function enabledAnalysisModes(config: WasapPageConfig): WasapAnalysisMode
     if (config.untrackedAnalysisModeEnabled) {
         result.push('untracked');
     }
-    if (config.collectionAnalysisModeEnabled) {
-        result.push('collection');
+    if (config.covSpectrumCollectionAnalysisModeEnabled) {
+        result.push('covSpectrumCollection');
     }
     return result;
 }
@@ -164,7 +164,7 @@ export type LinkTemplate = {
     aminoAcidMutation: string;
 };
 
-export type WasapAnalysisMode = 'manual' | 'variant' | 'resistance' | 'untracked' | 'collection';
+export type WasapAnalysisMode = 'manual' | 'variant' | 'resistance' | 'untracked' | 'covSpectrumCollection';
 
 /**
  * Contains mode-independent settings, like the filter for location and date range.
@@ -242,8 +242,8 @@ export type WasapUntrackedFilter = {
     excludeVariants?: string[];
 };
 
-export type WasapCollectionFilter = {
-    mode: 'collection';
+export type WasapCovSpectrumCollectionFilter = {
+    mode: 'covSpectrumCollection';
     collectionId?: number;
 };
 
@@ -252,7 +252,7 @@ export type WasapAnalysisFilter =
     | WasapVariantFilter
     | WasapResistanceFilter
     | WasapUntrackedFilter
-    | WasapCollectionFilter;
+    | WasapCovSpectrumCollectionFilter;
 
 export type WasapFilter = {
     base: WasapBaseFilter;

--- a/website/src/types/wastewaterConfig.ts
+++ b/website/src/types/wastewaterConfig.ts
@@ -42,7 +42,7 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
             variantAnalysisModeEnabled: true,
             resistanceAnalysisModeEnabled: true,
             untrackedAnalysisModeEnabled: true,
-            collectionAnalysisModeEnabled: true,
+            covSpectrumCollectionAnalysisModeEnabled: true,
             defaultAnalysisMode: 'resistance',
             resistanceMutationCollections: [
                 {
@@ -114,8 +114,8 @@ function buildWastewaterOrganismConfigs(env: DbIdSpace): Record<WastewaterOrgani
                     sequenceType: 'nucleotide',
                     excludeSet: 'predefined',
                 },
-                collection: {
-                    mode: 'collection',
+                covSpectrumCollection: {
+                    mode: 'covSpectrumCollection',
                     collectionId: 1,
                 },
             },

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { WasapPageStateHandler } from './WasapPageStateHandler';
 import {
     VARIANT_TIME_FRAME,
-    type WasapCollectionFilter,
+    type WasapCovSpectrumCollectionFilter,
     type WasapManualFilter,
     type WasapPageConfig,
     type WasapResistanceFilter,
@@ -90,13 +90,13 @@ const config: WasapPageConfig = {
 
 const configWithCollection: WasapPageConfig = {
     ...config,
-    collectionAnalysisModeEnabled: true,
+    covSpectrumCollectionAnalysisModeEnabled: true,
     collectionsApiBaseUrl: 'https://collections.example.org',
     collectionTitleFilter: 'test',
     filterDefaults: {
         ...config.filterDefaults,
-        collection: {
-            mode: 'collection',
+        covSpectrumCollection: {
+            mode: 'covSpectrumCollection',
             collectionId: undefined,
         },
     },
@@ -453,9 +453,9 @@ describe('WasapPageStateHandler', () => {
         const handlerWithCollection = new WasapPageStateHandler(configWithCollection);
 
         it('throws error when feature is disabled', () => {
-            const url = '/wastewater/covid?analysisMode=collection&collectionId=123&';
+            const url = '/wastewater/covid?analysisMode=covSpectrumCollection&collectionId=123&';
             expect(() => handler.parsePageStateFromUrl(new URL(`http://example.com${url}`))).toThrow(
-                "The 'collection' analysis mode is not enabled.",
+                "The 'covSpectrumCollection' analysis mode is not enabled.",
             );
         });
 
@@ -464,12 +464,12 @@ describe('WasapPageStateHandler', () => {
                 '/wastewater/covid?' +
                 'locationName=Z%C3%BCrich+%28ZH%29&' +
                 'granularity=day&' +
-                'analysisMode=collection&' +
+                'analysisMode=covSpectrumCollection&' +
                 'collectionId=123&';
             const filter = handlerWithCollection.parsePageStateFromUrl(new URL(`http://example.com${url}`));
 
-            expect(filter.analysis.mode).toBe('collection');
-            const analysis = filter.analysis as WasapCollectionFilter;
+            expect(filter.analysis.mode).toBe('covSpectrumCollection');
+            const analysis = filter.analysis as WasapCovSpectrumCollectionFilter;
             expect(analysis.collectionId).toBe(123);
 
             const newUrl = handlerWithCollection.toUrl(filter);
@@ -477,16 +477,16 @@ describe('WasapPageStateHandler', () => {
         });
 
         it('parses collection filter without collectionId', () => {
-            const url = '/wastewater/covid?analysisMode=collection&';
+            const url = '/wastewater/covid?analysisMode=covSpectrumCollection&';
             const filter = handlerWithCollection.parsePageStateFromUrl(new URL(`http://example.com${url}`));
 
-            expect(filter.analysis.mode).toBe('collection');
-            const analysis = filter.analysis as WasapCollectionFilter;
+            expect(filter.analysis.mode).toBe('covSpectrumCollection');
+            const analysis = filter.analysis as WasapCovSpectrumCollectionFilter;
             expect(analysis.collectionId).toBeUndefined();
         });
 
         it('encodes collection filter omits undefined collectionId', () => {
-            const url = '/wastewater/covid?analysisMode=collection&';
+            const url = '/wastewater/covid?analysisMode=covSpectrumCollection&';
             const filter = handlerWithCollection.parsePageStateFromUrl(new URL(`http://example.com${url}`));
 
             const encodedUrl = handlerWithCollection.toUrl(filter);
@@ -494,22 +494,22 @@ describe('WasapPageStateHandler', () => {
         });
 
         it('converts collectionId string to number', () => {
-            const url = '/wastewater/covid?analysisMode=collection&collectionId=456&';
+            const url = '/wastewater/covid?analysisMode=covSpectrumCollection&collectionId=456&';
             const filter = handlerWithCollection.parsePageStateFromUrl(new URL(`http://example.com${url}`));
 
-            const analysis = filter.analysis as WasapCollectionFilter;
+            const analysis = filter.analysis as WasapCovSpectrumCollectionFilter;
             expect(typeof analysis.collectionId).toBe('number');
             expect(analysis.collectionId).toBe(456);
         });
 
         it('collection mode round-trip preserves collectionId', () => {
-            const url = '/wastewater/covid?analysisMode=collection&collectionId=789&';
+            const url = '/wastewater/covid?analysisMode=covSpectrumCollection&collectionId=789&';
             const filter1 = handlerWithCollection.parsePageStateFromUrl(new URL(`http://example.com${url}`));
             const url2 = handlerWithCollection.toUrl(filter1);
             const filter2 = handlerWithCollection.parsePageStateFromUrl(new URL(`http://example.com${url2}`));
 
-            const analysis1 = filter1.analysis as WasapCollectionFilter;
-            const analysis2 = filter2.analysis as WasapCollectionFilter;
+            const analysis1 = filter1.analysis as WasapCovSpectrumCollectionFilter;
+            const analysis2 = filter2.analysis as WasapCovSpectrumCollectionFilter;
             expect(analysis2.collectionId).toBe(analysis1.collectionId);
         });
     });

--- a/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
+++ b/website/src/views/pageStateHandlers/WasapPageStateHandler.ts
@@ -104,9 +104,9 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                     excludeVariants: texts.excludeVariants?.split('|'),
                 };
                 break;
-            case 'collection':
-                if (!this.config.collectionAnalysisModeEnabled) {
-                    throw Error("The 'collection' analysis mode is not enabled.");
+            case 'covSpectrumCollection':
+                if (!this.config.covSpectrumCollectionAnalysisModeEnabled) {
+                    throw Error("The 'covSpectrumCollection' analysis mode is not enabled.");
                 }
                 analysis = {
                     mode,
@@ -181,7 +181,7 @@ export class WasapPageStateHandler implements PageStateHandler<WasapFilter> {
                     setSearchFromString(search, 'excludeVariants', analysis.excludeVariants?.join('|'));
                 }
                 break;
-            case 'collection':
+            case 'covSpectrumCollection':
                 setSearchFromString(
                     search,
                     'collectionId',


### PR DESCRIPTION
This is in anticipation of adding a 'collection' mode which will use the GenSpectrum collections: https://github.com/GenSpectrum/dashboards/issues/1324

## Summary

- Renames the W-ASAP analysis mode string `'collection'` → `'covSpectrumCollection'`
- Renames `CollectionAnalysisFilter` component and files → `CovSpectrumCollectionAnalysisFilter`
- Renames `WasapCollectionFilter` type → `WasapCovSpectrumCollectionFilter`
- Renames `collectionAnalysisModeEnabled` config key → `covSpectrumCollectionAnalysisModeEnabled`
- Updates `filterDefaults.collection` → `filterDefaults.covSpectrumCollection` throughout

Makes it explicit that this mode is specific to CovSpectrum collections (as opposed to our own internal collections system).