### PR TITLE
fix(wasap): deduplicate display labels in CovSpectrum collection mode

### DIFF
--- a/website/src/components/views/wasap/deduplicateDisplayLabels.spec.ts
+++ b/website/src/components/views/wasap/deduplicateDisplayLabels.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { deduplicateDisplayLabels } from './useWasapPageData';
+
+describe('deduplicateDisplayLabels', () => {
+    it('leaves unique labels unchanged', () => {
+        const input = [{ displayLabel: 'Alpha' }, { displayLabel: 'Beta' }];
+        expect(deduplicateDisplayLabels(input)).toEqual(input);
+    });
+
+    it('appends a counter suffix to duplicate labels', () => {
+        const input = [{ displayLabel: 'Resistance' }, { displayLabel: 'Resistance' }, { displayLabel: 'Resistance' }];
+        expect(deduplicateDisplayLabels(input)).toEqual([
+            { displayLabel: 'Resistance' },
+            { displayLabel: 'Resistance (2)' },
+            { displayLabel: 'Resistance (3)' },
+        ]);
+    });
+
+    it('handles interleaved duplicates independently', () => {
+        const input = [
+            { displayLabel: 'A' },
+            { displayLabel: 'B' },
+            { displayLabel: 'A' },
+            { displayLabel: 'B' },
+            { displayLabel: 'A' },
+        ];
+        expect(deduplicateDisplayLabels(input)).toEqual([
+            { displayLabel: 'A' },
+            { displayLabel: 'B' },
+            { displayLabel: 'A (2)' },
+            { displayLabel: 'B (2)' },
+            { displayLabel: 'A (3)' },
+        ]);
+    });
+
+    it('preserves other properties on items', () => {
+        const input = [
+            { displayLabel: 'X', countQuery: 'q1', coverageQuery: 'c1' },
+            { displayLabel: 'X', countQuery: 'q2', coverageQuery: 'c2' },
+        ];
+        expect(deduplicateDisplayLabels(input)).toEqual([
+            { displayLabel: 'X', countQuery: 'q1', coverageQuery: 'c1' },
+            { displayLabel: 'X (2)', countQuery: 'q2', coverageQuery: 'c2' },
+        ]);
+    });
+});

--- a/website/src/components/views/wasap/useWasapPageData.ts
+++ b/website/src/components/views/wasap/useWasapPageData.ts
@@ -327,10 +327,18 @@ async function fetchCollectionModeData(
         collection: {
             id: collection.id,
             title: collection.title,
-            queries,
+            queries: deduplicateDisplayLabels(queries),
         },
         ...(invalidVariants.length > 0 && { invalidVariants }),
     };
+}
+
+export function deduplicateDisplayLabels<T extends { displayLabel: string }>(items: T[]): T[] {
+    const seen: Record<string, number> = {};
+    return items.map((item) => {
+        const count = (seen[item.displayLabel] = (seen[item.displayLabel] ?? 0) + 1);
+        return count === 1 ? item : { ...item, displayLabel: `${item.displayLabel} (${count})` };
+    });
 }
 
 export function getLapisFilterForTimeFrame(timeFrame: VariantTimeFrame, dateFieldName: string): LapisFilter {


### PR DESCRIPTION
Closes #1328

## Summary

- Extracts a `deduplicateDisplayLabels` helper from `useWasapPageData.ts` and applies it to the `queries` array in `fetchCovSpectrumCollectionModeData`
- Appends a counter suffix to subsequent duplicate labels (e.g. "Resistance" → "Resistance (2)")
- Adds unit tests covering unique labels, consecutive duplicates, interleaved duplicates, and property preservation

## Test plan

- [ ] Unit tests pass (`npm run test` in `website/`)
- [ ] Manually verify a CovSpectrum collection with duplicate variant names no longer throws "Display labels must be unique"

🤖 Generated with [Claude Code](https://claude.com/claude-code)