### PR TITLE
refactor(auth): use useMutation for social sign-in in LoginButton

### DIFF
--- a/website/src/components/auth/LoginButton.tsx
+++ b/website/src/components/auth/LoginButton.tsx
@@ -1,5 +1,7 @@
+import { useMutation } from '@tanstack/react-query';
 import { createAuthClient } from 'better-auth/client';
 
+import { withQueryProvider } from '../../backendApi/withQueryProvider.tsx';
 import { getClientLogger } from '../../clientLogger.ts';
 import { getErrorLogMessage } from '../../util/getErrorLogMessage.ts';
 import { useErrorToast } from '../ErrorReportInstruction.tsx';
@@ -7,29 +9,34 @@ import { useErrorToast } from '../ErrorReportInstruction.tsx';
 const logger = getClientLogger('LoginButton');
 const authClient = createAuthClient();
 
-export function LoginButton() {
+export const LoginButton = withQueryProvider(LoginButtonInner);
+
+function LoginButtonInner() {
     const { showErrorToast } = useErrorToast(logger);
 
-    const login = () => {
-        const callbackUrlThatDoesNotImmediatelyLogoutAgain = new URL(window.location.href).pathname.endsWith('/logout')
-            ? new URL('/', window.location.href).toString()
-            : undefined;
-        authClient.signIn
-            .social({
+    const loginMutation = useMutation({
+        mutationFn: () => {
+            const callbackUrlThatDoesNotImmediatelyLogoutAgain = new URL(window.location.href).pathname.endsWith(
+                '/logout',
+            )
+                ? new URL('/', window.location.href).toString()
+                : undefined;
+            return authClient.signIn.social({
                 provider: 'github',
                 callbackURL: callbackUrlThatDoesNotImmediatelyLogoutAgain,
-            })
-            .catch((error: unknown) => {
-                showErrorToast({
-                    error: error instanceof Error ? error : new Error(String(error)),
-                    logMessage: `Login failed: ${getErrorLogMessage(error)}`,
-                    errorToastMessages: ['Login failed. Please try again.'],
-                });
             });
-    };
+        },
+        onError: (error) => {
+            showErrorToast({
+                error: error instanceof Error ? error : new Error(String(error)),
+                logMessage: `Login failed: ${getErrorLogMessage(error)}`,
+                errorToastMessages: ['Login failed. Please try again.'],
+            });
+        },
+    });
 
     return (
-        <button className='cursor-pointer' onClick={login}>
+        <button className='cursor-pointer' onClick={() => loginMutation.mutate()}>
             Login
         </button>
     );


### PR DESCRIPTION
## Summary

- Wraps `authClient.signIn.social()` in a `useMutation` hook, replacing the raw `.catch()` pattern
- Moves error handling to the `onError` callback, consistent with how other async operations are handled in the codebase
- Wraps the component with `withQueryProvider` so it has access to the query client

Closes #1209

🤖 Generated with [Claude Code](https://claude.ai/claude-code)