### PR TITLE
test(website): make lineage-filter selection resilient to menu re-renders

### DIFF
--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
         trace: 'retain-on-failure',
         screenshot: 'only-on-failure',
     },
+    expect: {
+        timeout: 15_000,
+    },
 
     projects: [
         // API integration tests (browser-independent)

--- a/website/tests/ViewPage.ts
+++ b/website/tests/ViewPage.ts
@@ -30,8 +30,20 @@ export abstract class ViewPage {
 
     public async fillLineageField(locator: Locator, lineage: string) {
         await locator.fill(lineage);
-        const selectedLineage = this.page.getByRole('listbox').getByRole('option', { name: lineage, exact: false });
-        await selectedLineage.first().click();
+
+        const option = this.page.getByRole('listbox').getByRole('option', { name: lineage, exact: false }).first();
+
+        // Filling the field opens the autocomplete menu, but each filter field fetches its options
+        // from LAPIS independently and a re-render triggered by another field settling can close the
+        // menu again. When that happens the option never appears and a plain click would wait out the
+        // whole test timeout. Retry "ensure the menu is open, then click the option" together so a
+        // transient close cannot wedge the test.
+        await expect(async () => {
+            if (!(await option.isVisible())) {
+                await locator.click(); // re-open the menu
+            }
+            await option.click({ timeout: 2_000 });
+        }).toPass();
     }
 
     public async fillMutationField(locator: Locator, mutation: string) {


### PR DESCRIPTION
resolves #1255 

### Summary

The variant-selection e2e tests (compareSideBySide, singleVariant) were flaky on Firefox/WebKit. The worst failure mode: fillLineageField typed into the lineage autocomplete then clicked the matching dropdown option, but the Downshift menu can be closed again by a concurrent re-render (each filter field fetches its options from LAPIS independently). The option then never appears and the click waits out the full 60s test timeout -- a larger timeout cannot help a closed menu. Re-open the menu and retry the option click together so a transient close cannot wedge the test.

Also keep two mitigations for the slower "still loading" failure mode: bump @playwright/test 1.60->1.61 and set a global 15s expect timeout.