### PR TITLE
fix(dashboards): rename lineage field to outbreakLineage and update values

### DIFF
--- a/website/src/views/mpox.ts
+++ b/website/src/views/mpox.ts
@@ -37,7 +37,7 @@ import { ALL_TIMES_LABEL, defaultDateRangeOption } from '../util/defaultDateRang
 
 const earliestDate = '1960-01-01';
 
-const LINEAGE_FIELD_NAME = 'lineage';
+const LINEAGE_FIELD_NAME = 'outbreakLineage';
 const CLADE_FIELD_NAME = 'clade';
 
 class MpoxConstants implements OrganismConstants {
@@ -48,7 +48,7 @@ class MpoxConstants implements OrganismConstants {
     public readonly lineageFilters: LineageFilterConfig[] = [
         {
             lapisField: LINEAGE_FIELD_NAME,
-            placeholderText: 'Lineage',
+            placeholderText: 'Outbreak & Lineage',
             filterType: 'lineage' as const,
         },
         {
@@ -88,10 +88,10 @@ class MpoxConstants implements OrganismConstants {
     public readonly accessionDownloadFields = PATHOPLEXUS_ACCESSION_DOWNLOAD_FIELDS;
     public readonly predefinedVariants = [
         {
-            lineages: { [LINEAGE_FIELD_NAME]: 'F.1' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'sh2017/F.1' },
         },
         {
-            lineages: { [LINEAGE_FIELD_NAME]: 'F.2' },
+            lineages: { [LINEAGE_FIELD_NAME]: 'sh2017/F.2' },
         },
         {
             lineages: { [CLADE_FIELD_NAME]: 'Ia' },
@@ -102,7 +102,7 @@ class MpoxConstants implements OrganismConstants {
     public get aggregatedVisualizations() {
         return getPathoplexusSequencingEffortsAggregatedVisualizations(this, {
             sublineages: {
-                label: 'Sub-Lineages',
+                label: 'Outbreak & Lineage',
                 fields: [LINEAGE_FIELD_NAME, CLADE_FIELD_NAME],
             },
         });
@@ -142,12 +142,12 @@ export class MpoxCompareSideBySideView extends BaseView<
         const defaultPageState = makeCompareSideBySideData(defaultDatasetFilter, [
             {
                 lineages: {
-                    [LINEAGE_FIELD_NAME]: 'F.1',
+                    [LINEAGE_FIELD_NAME]: 'sh2017/F.1',
                 },
             },
             {
                 lineages: {
-                    [LINEAGE_FIELD_NAME]: 'F.2',
+                    [LINEAGE_FIELD_NAME]: 'sh2017/F.2',
                 },
             },
         ]);

--- a/website/tests/helpers/organisms.ts
+++ b/website/tests/helpers/organisms.ts
@@ -17,7 +17,7 @@ export const organismOptions = {
     [Organisms.westNile]: { lineage: '1A', lineageFieldPlaceholder: 'Lineage', gene: 'NS1' },
     [Organisms.rsvA]: { lineage: 'A.D.5.2', lineageFieldPlaceholder: 'Lineage', gene: 'NS1' },
     [Organisms.rsvB]: { lineage: 'B.D.E.1', lineageFieldPlaceholder: 'Lineage', gene: 'NS1' },
-    [Organisms.mpox]: { lineage: 'F.1', lineageFieldPlaceholder: 'Lineage', gene: 'OPG001' },
+    [Organisms.mpox]: { lineage: 'sh2017/F.1', lineageFieldPlaceholder: 'Outbreak & Lineage', gene: 'OPG001' },
     [Organisms.ebolaSudan]: { mutation: 'G5902T', gene: 'NP' },
     [Organisms.ebolaZaire]: { mutation: 'T18365C', gene: 'NP' },
     [Organisms.cchf]: { mutation: 'M:G3565A', gene: 'RdRp' },


### PR DESCRIPTION
Pathoplexus restructured mpox lineages: the LAPIS field is now `outbreakLineage` (old `lineage` field no longer has a lineage index, causing the lineage definition fetch to fail). Lineage values are now prefixed with the outbreak identifier (e.g. `sh2017/F.1`).

- Labels updated to "Outbreak & Lineage" throughout
- Predefined variants and compare-side-by-side defaults updated to use `sh2017/F.*` values
- E2E test helper updated with new field placeholder and lineage value