### PR TITLE
feat(collection-seeder): add descriptions to covid pango lineage variant types

### DIFF
--- a/collection-seeding/sources/covid_pango_lineages.py
+++ b/collection-seeding/sources/covid_pango_lineages.py
@@ -47,21 +47,25 @@ class CovidPangoLineagesSource(Source):
             {
                 "type": "filterObject",
                 "name": "Nucleotide substitutions",
+                "description": "All nucleotide substitutions that define this lineage.",
                 "filterObject": {"nucleotideMutations": nuc_subs},
             },
             {
                 "type": "filterObject",
                 "name": "Amino acid substitutions",
+                "description": "All amino acid substitutions that define this lineage.",
                 "filterObject": {"aminoAcidMutations": aa_subs},
             },
             {
                 "type": "filterObject",
                 "name": "New nucleotide substitutions",
+                "description": f"Nucleotide substitutions not present in the parent lineage ({parent}).",
                 "filterObject": {"nucleotideMutations": nuc_subs_new},
             },
             {
                 "type": "filterObject",
                 "name": "New amino acid substitutions",
+                "description": f"Amino acid substitutions not present in the parent lineage ({parent}).",
                 "filterObject": {"aminoAcidMutations": aa_subs_new},
             },
         ]

--- a/collection-seeding/tests/test_influenza_resistance_mutations.py
+++ b/collection-seeding/tests/test_influenza_resistance_mutations.py
@@ -306,7 +306,6 @@ def test_mutations_prefixed_with_na():
                 assert aa.startswith("NA:"), f"Expected NA: prefix, got {aa!r}"
 
 
-
 # --- PA inhibitor (Baloxavir) collections ----------------------------------
 
 


### PR DESCRIPTION
resolves #1357 

### Summary

Explains what 'Nucleotide substitutions' vs 'New nucleotide substitutions' means for each lineage collection. The parent lineage name is included in the description of the 'New' variants. These descriptions surface in the collection detail page and as tooltips in the queries-over-time table.

### Screenshot

<img width="1270" height="670" alt="image" src="https://github.com/user-attachments/assets/c8cdff0d-8683-4f34-b72f-5274b05a9980" />


<img width="1538" height="513" alt="image" src="https://github.com/user-attachments/assets/30a3b7dc-08c4-4dd5-bd90-699d6002038d" />


## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
